### PR TITLE
fix: unattended loop — park human-gate + detached runner

### DIFF
--- a/.claude/commands/claire-loop.md
+++ b/.claude/commands/claire-loop.md
@@ -27,7 +27,7 @@ autonomously, until the bound in `$ARGUMENTS` is hit. Full spec: `docs/AUTONOMOU
      --jq 'map(.pri = (([.labels[].name]|map(select(test("^p[0-9]$")))|first) // "p9")) | sort_by(.milestone.title, .pri) | .[] | "#\(.number) [\(.milestone.title|split(" ")[0])] \(.pri) \(.title)"'
    ```
    Choose the **lowest milestone (M0 first), then lowest priority number (p0 first)**.
-   Skip any issue labeled `blocked`, or whose body says `Depends on:` an issue that is still open. (Hint: M0 issues **#7 web build, #8 MOCK_BRIDGE, #9 testIDs, #10 Playwright, #11 CI** are prerequisites for most e2e work — finish them first, roughly in that order.)
+   Skip any issue labeled `blocked` or `needs-review` (already built, PR parked), or whose body says `Depends on:` an issue that is still open. (Hint: M0 issues **#7 web build, #8 MOCK_BRIDGE, #9 testIDs, #10 Playwright, #11 CI** are prerequisites for most e2e work — finish them first, roughly in that order.)
 3. **Claim:** comment `🔁 loop: starting` on the issue. Create an isolated branch:
    `git worktree add ../wt-<num> -b feat/<area>-<slug> origin/main` (or a normal branch if not parallelizing).
 4. **Implement** strictly to the issue's Acceptance Criteria. Reuse existing code (see `docs/AUTONOMOUS_LOOP.md` "reuse map"). Add/extend mock Playwright e2e + unit tests.
@@ -44,7 +44,7 @@ autonomously, until the bound in `$ARGUMENTS` is hit. Full spec: `docs/AUTONOMOU
    ```
 7. **Merge decision:**
    - Issue labeled `risk/auto-merge` → `gh pr merge --squash --auto` (merges when CI is green).
-   - Issue labeled `risk/human-gate` → leave PR open, add `needs-review` to the issue, post one line to the user. **Never auto-merge human-gate.**
+   - Issue labeled `risk/human-gate` → leave PR open; **remove `ready` and add `needs-review`** on the issue (so the loop won't re-pick it), post one line to the user. **Never auto-merge human-gate.** A human merges it after review, which clears it from the queue.
 8. **Record:** check the milestone box in the "Road to v1 — tracking" issue if the milestone is complete; append a line to `.context/loop-state.md`:
    `<iso-time> | #<num> <title> | PR #<pr> | <merged|needs-review|blocked>`.
    (Get the timestamp with `date -u +%FT%TZ`.)

--- a/docs/AUTONOMOUS_LOOP.md
+++ b/docs/AUTONOMOUS_LOOP.md
@@ -36,7 +36,7 @@ All work is tracked as **GitHub Issues** on `l2succes/claire`.
 gh issue list --state open --label ready --json number,title,labels,milestone \
   --jq 'map(.pri = (([.labels[].name]|map(select(test("^p[0-9]$")))|first) // "p9")) | sort_by(.milestone.title, .pri) | .[] | "#\(.number) [\(.milestone.title|split(" ")[0])] \(.pri) \(.title)"'
 ```
-Skip anything labeled `blocked` or whose body lists `Depends on:` an issue that is still open.
+Skip anything labeled `blocked` or `needs-review` (already built, PR parked), or whose body lists `Depends on:` an issue that is still open.
 
 The backlog is created (idempotently) by `scripts/loop-init.sh` via `/claire-loop-init`.
 
@@ -57,7 +57,7 @@ The backlog is created (idempotently) by `scripts/loop-init.sh` via `/claire-loo
 6. **PR** — `gh pr create --base main` with `Closes #<num>`, the risk tier, and how it was verified.
 7. **Merge decision:**
    - `risk/auto-merge` → `gh pr merge --squash --auto` (lands when CI is green).
-   - `risk/human-gate` → leave open, add `needs-review` to the issue, ping the user. **Never auto-merge human-gate.**
+   - `risk/human-gate` → leave open; **remove `ready`, add `needs-review`** (so the loop won't re-pick it); ping the user. **Never auto-merge human-gate.** A human merges after review, clearing it from the queue.
 8. **Record** — tick the milestone in the tracking issue when complete; append to `.context/loop-state.md`:
    `<iso-time> | #<num> <title> | PR #<pr> | <merged|needs-review|blocked>`.
 9. **Clean up** worktree; repeat.
@@ -119,6 +119,8 @@ CI must be green either way: lint + typecheck + jest + web build + **mock Playwr
 3. `cd server && bun install && cd ../client && bun install`
 4. Copy env files: `server/.env`, `client/.env`. The mock-bridge loop needs **no** Docker and **no** real WhatsApp/Matrix — Docker is only for the real-stack nightly run.
 5. **First time only:** `/claire-loop-init` to populate the backlog. Skip if another machine already created it (issues are shared server-side).
-6. Run the loop: `/claire-loop until-green`.
+6. Run the loop, either way:
+   - **Interactive (in a Claude Code session):** `/claire-loop until-green`.
+   - **Unattended/detached (dedicated machine):** `nohup zsh -ic 'scripts/loop-runner.sh 40' >/tmp/claire-loop.out 2>&1 &` — runs one ticket per fresh `claude -p` session until the pickable backlog drains; logs to `.context/loop-runner.log`. Monitor with `tail -f .context/loop-runner.log`; review parked PRs with `gh pr list --label needs-review`.
 
 Because GitHub Issues + `.context/loop-state.md` are the shared truth, you can stop/restart, or move to another machine, and the loop resumes where it left off.

--- a/scripts/loop-runner.sh
+++ b/scripts/loop-runner.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# loop-runner.sh — unattended wrapper around /claire-loop.
+#
+# Runs ONE ticket per fresh `claude -p` session (keeps context small) and repeats
+# until no pickable ticket remains (ready, not blocked, not needs-review) or the
+# iteration cap is hit. Auto-merges low-risk PRs on green CI; parks human-gate PRs
+# as needs-review for human review (see docs/AUTONOMOUS_LOOP.md).
+#
+# Prereqs (verified by the runbook): claude authenticated, gh authenticated,
+# bun deps installed, repo on latest main. gh + claude must be on PATH.
+#
+# Usage:
+#   scripts/loop-runner.sh [MAX_ITER]      # default 40
+#   LOOP_PROMPT='/claire-loop 1' scripts/loop-runner.sh 25
+#
+# Launch detached on a dedicated machine:
+#   nohup zsh -ic 'scripts/loop-runner.sh 40' >/tmp/claire-loop.out 2>&1 &
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1            # repo root
+mkdir -p .context
+LOG=".context/loop-runner.log"
+MAX_ITER="${1:-40}"
+PROMPT="${LOOP_PROMPT:-/claire-loop 1}"
+
+log() { echo "$@" | tee -a "$LOG"; }
+
+command -v claude >/dev/null 2>&1 || { log "FATAL: claude not on PATH"; exit 1; }
+command -v gh     >/dev/null 2>&1 || { log "FATAL: gh not on PATH"; exit 1; }
+gh auth status >/dev/null 2>&1     || { log "FATAL: gh not authenticated (run: gh auth login)"; exit 1; }
+
+log "=== loop-runner start $(date -u +%FT%TZ) max=$MAX_ITER prompt='$PROMPT' ==="
+
+pickable_count() {
+  gh issue list --state open --label ready --json number,labels --jq \
+    '[ .[] | select((.labels|map(.name)) as $l | ($l|index("blocked")|not) and ($l|index("needs-review")|not)) ] | length' \
+    2>/dev/null || echo 0
+}
+
+for i in $(seq 1 "$MAX_ITER"); do
+  git fetch origin --quiet 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+  n="$(pickable_count)"
+  log "--- iter $i/$MAX_ITER $(date -u +%FT%TZ) pickable=$n ---"
+  if [ "$n" = "0" ]; then
+    log "no pickable tickets remain (all merged / parked needs-review / blocked); stopping"
+    break
+  fi
+  # one ticket, fresh context, unattended
+  claude -p "$PROMPT" --dangerously-skip-permissions >>"$LOG" 2>&1 \
+    || log "claude exited non-zero on iter $i (continuing)"
+done
+
+log "=== loop-runner done $(date -u +%FT%TZ) ==="
+log "Open PRs awaiting review:"; gh pr list --state open --label needs-review 2>/dev/null | tee -a "$LOG" || true


### PR DESCRIPTION
Makes the loop safe to run unattended:
- Park human-gate tickets (remove `ready`, add `needs-review`); pick step skips `needs-review`/`blocked` so it won't re-pick #7 forever.
- `scripts/loop-runner.sh`: one ticket per fresh `claude -p` session until the pickable backlog drains.

Docs/commands/script only — risk: auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)