### PR TITLE
feat: loop observability — live dashboard + verbose agent trace

### DIFF
--- a/docs/AUTONOMOUS_LOOP.md
+++ b/docs/AUTONOMOUS_LOOP.md
@@ -123,4 +123,14 @@ CI must be green either way: lint + typecheck + jest + web build + **mock Playwr
    - **Interactive (in a Claude Code session):** `/claire-loop until-green`.
    - **Unattended/detached (dedicated machine):** `nohup zsh -ic 'scripts/loop-runner.sh 40' >/tmp/claire-loop.out 2>&1 &` — runs one ticket per fresh `claude -p` session until the pickable backlog drains; logs to `.context/loop-runner.log`. Monitor with `tail -f .context/loop-runner.log`; review parked PRs with `gh pr list --label needs-review`.
 
+### Watching a run
+
+`claude -p` runs headless — there is no live TUI. Visibility comes from three places:
+
+- **Live dashboard** (second terminal, no restart): `scripts/loop-watch.sh` — shows the active ticket (git worktree), runner heartbeat, open PRs, latest CI, queue counts, and the ledger, refreshing every few seconds.
+- **Live agent trace** (its actual tool calls/messages): the runner defaults to `LOOP_VERBOSE=1`, streaming `--output-format stream-json` formatted by `scripts/loop-fmt.jq` into `.context/loop-runner.log` (raw JSONL saved to `.context/loop-trace.jsonl`). Tail it directly with: `tail -f .context/loop-trace.jsonl | jq -Rrf scripts/loop-fmt.jq`. Set `LOOP_VERBOSE=0` for terse final-result-only logs.
+- **Durable trail:** the agent claims each issue with a `🔁 loop: starting` comment, opens branches/PRs, and appends to `.context/loop-state.md`. `gh pr list`, `gh issue list`, and `gh run watch` show progress and parked (`needs-review`) PRs.
+
+> A run already in flight was launched with the old runner (text-only output); to get the live trace, stop it and relaunch with the updated `scripts/loop-runner.sh`.
+
 Because GitHub Issues + `.context/loop-state.md` are the shared truth, you can stop/restart, or move to another machine, and the loop resumes where it left off.

--- a/scripts/loop-fmt.jq
+++ b/scripts/loop-fmt.jq
@@ -1,0 +1,25 @@
+# loop-fmt.jq — turn `claude -p --output-format stream-json` JSONL into readable lines.
+# Usage: tail -f .context/loop-trace.jsonl | jq -Rrf scripts/loop-fmt.jq
+# (-R: each input line is a raw string; fromjson parses it; -r: raw output.)
+fromjson? // empty
+| if .type == "system" then
+    "⚙️  " + ((.subtype // "init") | tostring)
+  elif .type == "assistant" then
+    ( .message.content[]? |
+      if .type == "text" then
+        ( (.text // "") | gsub("\\s+"; " ") | if length > 0 then "💬 " + .[0:240] else empty end )
+      elif .type == "tool_use" then
+        "🔧 " + (.name // "tool") + "  " + ((.input // {}) | tojson | .[0:180])
+      else empty end )
+  elif .type == "user" then
+    ( .message.content[]? |
+      if .type == "tool_result" then
+        "↳  " + ( ( .content
+                    | if type == "array" then ( map(.text // (. | tojson)) | join(" ") )
+                      else (. // "" | tostring) end )
+                  | gsub("\\s+"; " ") | .[0:180] )
+      else empty end )
+  elif .type == "result" then
+    "✅ " + ((.subtype // "done") | tostring) + ": "
+       + ((.result // "") | tostring | gsub("\\s+"; " ") | .[0:240])
+  else empty end

--- a/scripts/loop-runner.sh
+++ b/scripts/loop-runner.sh
@@ -13,17 +13,39 @@
 #   scripts/loop-runner.sh [MAX_ITER]      # default 40
 #   LOOP_PROMPT='/claire-loop 1' scripts/loop-runner.sh 25
 #
+# Observability:
+#   LOOP_VERBOSE=1 (default) streams the agent's tool calls/messages live via
+#   `--output-format stream-json`, formatted by scripts/loop-fmt.jq into the log
+#   and saved raw to .context/loop-trace.jsonl. Set LOOP_VERBOSE=0 for terse
+#   final-result-only output. Watch a run with: scripts/loop-watch.sh
+#
 # Launch detached on a dedicated machine:
 #   nohup zsh -ic 'scripts/loop-runner.sh 40' >/tmp/claire-loop.out 2>&1 &
 set -uo pipefail
 
-cd "$(dirname "$0")/.." || exit 1            # repo root
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE/.." || exit 1                       # repo root
 mkdir -p .context
 LOG=".context/loop-runner.log"
+TRACE=".context/loop-trace.jsonl"
 MAX_ITER="${1:-40}"
 PROMPT="${LOOP_PROMPT:-/claire-loop 1}"
+VERBOSE="${LOOP_VERBOSE:-1}"
 
 log() { echo "$@" | tee -a "$LOG"; }
+
+# Run one claude session. Verbose mode streams a readable tool-by-tool trace into
+# the log (and raw JSONL to $TRACE) so `tail -f` shows live activity, not silence.
+run_claude() {
+  if [ "$VERBOSE" = "1" ] && command -v jq >/dev/null 2>&1; then
+    claude -p "$PROMPT" --dangerously-skip-permissions --verbose --output-format stream-json 2>>"$LOG" \
+      | tee -a "$TRACE" \
+      | jq -Rrf "$HERE/loop-fmt.jq" 2>/dev/null \
+      | tee -a "$LOG"
+  else
+    claude -p "$PROMPT" --dangerously-skip-permissions >>"$LOG" 2>&1
+  fi
+}
 
 command -v claude >/dev/null 2>&1 || { log "FATAL: claude not on PATH"; exit 1; }
 command -v gh     >/dev/null 2>&1 || { log "FATAL: gh not on PATH"; exit 1; }
@@ -47,8 +69,7 @@ for i in $(seq 1 "$MAX_ITER"); do
     break
   fi
   # one ticket, fresh context, unattended
-  claude -p "$PROMPT" --dangerously-skip-permissions >>"$LOG" 2>&1 \
-    || log "claude exited non-zero on iter $i (continuing)"
+  run_claude || log "claude pipe exited non-zero on iter $i (continuing)"
 done
 
 log "=== loop-runner done $(date -u +%FT%TZ) ==="

--- a/scripts/loop-watch.sh
+++ b/scripts/loop-watch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# loop-watch.sh — live dashboard for the autonomous loop. Run in a SECOND terminal
+# on the loop machine (where gh is authenticated). Works against any in-progress
+# run; no restart needed. Ctrl-C to exit.
+#
+#   scripts/loop-watch.sh            # refresh every 8s
+#   scripts/loop-watch.sh 4          # refresh every 4s
+set -uo pipefail
+cd "$(cd "$(dirname "$0")" && pwd)/.." || exit 1
+INTERVAL="${1:-8}"
+
+while true; do
+  clear
+  printf '==== Claire autonomous loop — %s ====\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+
+  printf '\n-- active ticket (git worktrees) --\n'
+  if git worktree list 2>/dev/null | grep -v '\[main\]' | grep -q .; then
+    git worktree list 2>/dev/null | grep -v '\[main\]'
+  else
+    echo '(none — between tickets / idle)'
+  fi
+
+  printf '\n-- runner heartbeat (.context/loop-runner.log) --\n'
+  tail -n 14 .context/loop-runner.log 2>/dev/null || echo '(no runner log yet)'
+
+  printf '\n-- open PRs --\n'
+  gh pr list --state open -L 10 2>/dev/null || echo '(gh unavailable here)'
+
+  printf '\n-- latest CI runs --\n'
+  gh run list -L 3 2>/dev/null || true
+
+  printf '\n-- queue --\n'
+  printf 'ready+pickable: '
+  gh issue list --state open --label ready --json labels --jq \
+    '[ .[] | select((.labels|map(.name)) as $l | ($l|index("blocked")|not) and ($l|index("needs-review")|not)) ] | length' 2>/dev/null || echo '?'
+  printf 'needs-review:   '; gh issue list --state open --label needs-review --json number --jq 'length' 2>/dev/null || echo '?'
+  printf 'blocked:        '; gh issue list --state open --label blocked --json number --jq 'length' 2>/dev/null || echo '?'
+
+  printf '\n-- ledger (.context/loop-state.md) --\n'
+  tail -n 5 .context/loop-state.md 2>/dev/null || echo '(none yet)'
+
+  printf '\n(Ctrl-C to exit · refresh %ss · live agent trace: tail -f .context/loop-trace.jsonl | jq -Rrf scripts/loop-fmt.jq)\n' "$INTERVAL"
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Adds visibility into the headless `claude -p` loop:
- `scripts/loop-watch.sh` — live dashboard (active ticket, PRs, CI, queue), no restart needed.
- `scripts/loop-fmt.jq` + `LOOP_VERBOSE=1` in the runner — streams the agent's tool calls/messages into the log and `.context/loop-trace.jsonl`.
- Runbook "Watching a run" section.

Tooling/docs only — risk: auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)