### PR TITLE
test: testID coverage pass + selector map doc (#9)

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  globals: {
+    __DEV__: 'readonly',
+  },
+  ignorePatterns: ['node_modules/', '.expo/', 'dist/', 'coverage/', 'babel.config.js', 'metro.config.js', 'tailwind.config.js'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    'no-console': 'off',
+  },
+};

--- a/client/app/(tabs)/contacts.tsx
+++ b/client/app/(tabs)/contacts.tsx
@@ -85,7 +85,7 @@ export default function ContactsScreen() {
   );
 
   return (
-    <View className="flex-1 bg-gray-50 dark:bg-gray-900">
+    <View className="flex-1 bg-gray-50 dark:bg-gray-900" testID="contacts-screen">
       {/* Search Bar */}
       <View className="bg-white dark:bg-gray-800 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <View className="flex-row items-center bg-gray-100 dark:bg-gray-700 rounded-lg px-3 py-2">
@@ -96,6 +96,7 @@ export default function ContactsScreen() {
             placeholderTextColor="#6b7280"
             value={searchQuery}
             onChangeText={setSearchQuery}
+            testID="contacts-search-input"
           />
         </View>
       </View>
@@ -106,8 +107,9 @@ export default function ContactsScreen() {
         renderItem={renderContact}
         keyExtractor={(item) => item.id}
         contentContainerStyle={{ paddingVertical: 8 }}
+        testID="contacts-list"
         ListEmptyComponent={
-          <View className="flex-1 items-center justify-center py-20">
+          <View className="flex-1 items-center justify-center py-20" testID="contacts-empty">
             <User size={48} color="#9ca3af" />
             <Text className="text-gray-500 dark:text-gray-400 mt-4">
               {searchQuery ? 'No contacts found' : 'No contacts yet'}

--- a/client/app/(tabs)/dashboard.tsx
+++ b/client/app/(tabs)/dashboard.tsx
@@ -202,6 +202,7 @@ export default function HomeScreen() {
       className="flex-1 bg-gray-50 dark:bg-gray-900"
       contentContainerStyle={{ paddingTop: 12, paddingBottom: 32 }}
       showsVerticalScrollIndicator={false}
+      testID="dashboard-screen"
     >
       {/* Morning Brief */}
       <MorningBrief text={DUMMY_MORNING_BRIEF} />

--- a/client/app/(tabs)/promises.tsx
+++ b/client/app/(tabs)/promises.tsx
@@ -2,10 +2,12 @@ import { View, Text, ScrollView } from 'react-native';
 
 export default function PromisesScreen() {
   return (
-    <ScrollView className="flex-1 bg-gray-50">
+    <ScrollView className="flex-1 bg-gray-50" testID="promises-screen">
       <View className="p-4">
         <Text className="text-2xl font-bold text-gray-900 mb-4">Promises</Text>
-        <Text className="text-gray-600">Your commitments and promises will be tracked here</Text>
+        <View testID="promises-empty">
+          <Text className="text-gray-600">Your commitments and promises will be tracked here</Text>
+        </View>
       </View>
     </ScrollView>
   );

--- a/client/app/(tabs)/settings.tsx
+++ b/client/app/(tabs)/settings.tsx
@@ -124,18 +124,21 @@ export default function SettingsScreen() {
     description,
     onPress,
     danger = false,
+    testID,
   }: {
     icon: typeof User;
     title: string;
     description: string;
     onPress?: () => void;
     danger?: boolean;
+    testID?: string;
   }) => (
     <TouchableOpacity
       onPress={onPress}
       disabled={!onPress}
       className="bg-white dark:bg-gray-800 rounded-lg px-4 py-3 mb-3 flex-row items-center"
       activeOpacity={onPress ? 0.7 : 1}
+      testID={testID}
     >
       <View
         className={`w-10 h-10 rounded-full items-center justify-center mr-3 ${
@@ -261,18 +264,21 @@ export default function SettingsScreen() {
           icon={User}
           title="Account"
           description="Manage your account settings"
+          testID="settings-account"
         />
 
         <SettingsSection
           icon={Bell}
           title="Notifications"
           description="Configure notification preferences"
+          testID="settings-notifications"
         />
 
         <SettingsSection
           icon={Sparkles}
           title="AI Settings"
           description="Customize AI response behavior"
+          testID="settings-ai"
         />
 
         {/* Logout */}
@@ -283,6 +289,7 @@ export default function SettingsScreen() {
             description="Sign out of your account"
             onPress={handleLogout}
             danger
+            testID="settings-logout"
           />
         </View>
 

--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -439,7 +439,7 @@ export default function ChatScreen() {
           />
           <TouchableOpacity
             onPress={handleSend}
-            disabled={!inputText.trim() || sending || (platform && !connectedSessions.some(s => s.platform === platform && s.status === 'connected'))}
+            disabled={!inputText.trim() || sending || (!!platform && !connectedSessions.some(s => s.platform === platform && s.status === 'connected'))}
             testID="chat-send-button"
             style={{
               width: 40,

--- a/docs/E2E_SELECTORS.md
+++ b/docs/E2E_SELECTORS.md
@@ -1,0 +1,154 @@
+# Claire — E2E Test Selector Map
+
+All stable `testID` values (rendered as `data-testid` on web via React Native Web) used by Playwright e2e tests.
+
+> **Convention:** `testID` props are used on React Native components. On web they surface as `data-testid` attributes. Playwright uses `page.getByTestId(id)` which maps to `[data-testid="id"]`.
+
+---
+
+## Auth screens
+
+### Sign-in (`/(auth)/signin`)
+
+| Selector | Element |
+|---|---|
+| `signin-screen` | Root `KeyboardAvoidingView` |
+| `signin-email-input` | Email `TextInput` |
+| `signin-password-input` | Password `TextInput` |
+| `signin-submit` | Sign-in submit `TouchableOpacity` |
+| `google-sign-in-signin` | Google sign-in button |
+
+### Sign-up (`/(auth)/signup`)
+
+| Selector | Element |
+|---|---|
+| `signup-screen` | Root view |
+| `signup-name-input` | Name `TextInput` |
+| `signup-email-input` | Email `TextInput` |
+| `signup-password-input` | Password `TextInput` |
+| `signup-submit` | Submit `TouchableOpacity` |
+
+### Platform connect (`/(auth)/login`)
+
+| Selector | Element |
+|---|---|
+| `platform-login-screen` | Root `View` |
+| `platform-selector-whatsapp` | WhatsApp selector tile |
+| `platform-selector-telegram` | Telegram selector tile |
+| `platform-selector-instagram` | Instagram selector tile |
+| `platform-login-continue` | "Continue to Inbox" `Button` (shown when ≥1 platform connected) |
+| `platform-login-skip-dev` | "Skip (dev mode)" link (only in `__DEV__`) |
+
+---
+
+## Tab screens
+
+### Dashboard / Home (`/(tabs)/dashboard`)
+
+| Selector | Element |
+|---|---|
+| `dashboard-screen` | Root `ScrollView` |
+
+### Messages / Inbox (`/(tabs)/messages`)
+
+| Selector | Element |
+|---|---|
+| `messages-screen` | Root `View` |
+| `messages-loading` | Loading spinner `View` |
+| `messages-search-input` | Search `TextInput` |
+| `messages-list` | Conversation `FlatList` |
+| `messages-empty` | Empty state `View` |
+| `message-card-<id>` | Individual `MessageCard` row (dynamic, `id` = message UUID) |
+
+### Contacts (`/(tabs)/contacts`)
+
+| Selector | Element |
+|---|---|
+| `contacts-screen` | Root `View` |
+| `contacts-search-input` | Search `TextInput` |
+| `contacts-list` | Contacts `FlatList` |
+| `contacts-empty` | Empty state `View` |
+
+### Promises (`/(tabs)/promises`)
+
+| Selector | Element |
+|---|---|
+| `promises-screen` | Root `ScrollView` |
+| `promises-empty` | Empty state `View` (shown when no promises exist) |
+| `promises-list` | Promises list (added by #18) |
+| `promise-item-<id>` | Individual promise row (added by #18) |
+| `promise-complete-<id>` | Mark-complete button (added by #18) |
+
+### Settings (`/(tabs)/settings`)
+
+| Selector | Element |
+|---|---|
+| `settings-screen` | Root `ScrollView` |
+| `settings-refresh-platforms` | Refresh platforms `TouchableOpacity` |
+| `settings-add-platform` | Add platform `TouchableOpacity` |
+| `settings-no-platforms` | Empty platforms `View` |
+| `settings-connect-platform` | "Connect Platform" button in empty state |
+| `settings-account` | Account row `TouchableOpacity` |
+| `settings-notifications` | Notifications row `TouchableOpacity` |
+| `settings-ai` | AI Settings row `TouchableOpacity` |
+| `settings-logout` | Logout row `TouchableOpacity` |
+| `connected-platforms-list` | Connected platforms `View` |
+| `connected-platforms-empty` | Empty connected platforms `View` |
+| `connected-platform-<platform>` | Platform row (e.g. `connected-platform-whatsapp`) |
+| `reconnect-platform-<platform>` | Reconnect button per platform |
+| `disconnect-platform-<platform>` | Disconnect button per platform |
+
+---
+
+## Chat screen (`/chat/[chatId]`)
+
+| Selector | Element |
+|---|---|
+| `chat-screen` | Root `SafeAreaView` |
+| `chat-loading` | Loading spinner `View` |
+| `chat-message-list` | Messages `FlatList` |
+| `chat-empty` | Empty state `View` |
+| `chat-input` | Message composer `TextInput` |
+| `chat-send-button` | Send `TouchableOpacity` |
+
+---
+
+## Platform auth modal
+
+| Selector | Element |
+|---|---|
+| `platform-auth-modal` | Modal root `View` |
+| `platform-auth-scroll` | Scrollable content area |
+| `platform-auth-success` | Success state `View` |
+| `platform-auth-error` | Error state `View` |
+
+### Instagram auth (web)
+
+| Selector | Element |
+|---|---|
+| `instagram-web-login` | Instagram login root `View` |
+| `instagram-username-input` | Username `TextInput` |
+| `instagram-password-input` | Password `TextInput` |
+| `instagram-toggle-password` | Show/hide password `TouchableOpacity` |
+| `instagram-sign-in-button` | Sign-in `TouchableOpacity` |
+| `instagram-2fa-input` | 2FA code `TextInput` |
+| `instagram-2fa-submit` | 2FA submit `TouchableOpacity` |
+| `instagram-try-again` | Retry `TouchableOpacity` |
+| `instagram-web-login-close` | Close/cancel `TouchableOpacity` |
+
+### Instagram auth (native)
+
+| Selector | Element |
+|---|---|
+| `instagram-native-webview` | Native WebView |
+| `instagram-native-login-loading` | Loading `View` |
+| `instagram-native-login-close` | Close `TouchableOpacity` |
+
+---
+
+## Notes
+
+- Selectors prefixed with a platform name (e.g. `platform-selector-whatsapp`) use the platform's lowercase `Platform` enum value.
+- Dynamic selectors using `<id>` use the DB UUID of the entity.
+- Selectors marked "(added by #N)" are placeholders for upcoming issues and will be wired in those tickets.
+- The web build is required for Playwright (`bunx expo start --web`); see `client/playwright.config.mjs`.


### PR DESCRIPTION
Closes #9

## Changes

- **`client/app/(tabs)/dashboard.tsx`**: add `testID="dashboard-screen"` on root `ScrollView`
- **`client/app/(tabs)/contacts.tsx`**: add `contacts-screen`, `contacts-search-input`, `contacts-list`, `contacts-empty`
- **`client/app/(tabs)/promises.tsx`**: add `promises-screen`, `promises-empty` on stub screen
- **`client/app/(tabs)/settings.tsx`**: add optional `testID` prop to `SettingsSection`; add `settings-account`, `settings-notifications`, `settings-ai`, `settings-logout`
- **`client/app/chat/[chatId].tsx`**: fix pre-existing TS2322 error (`boolean | "" -> !!platform`)
- **`client/.eslintrc.js`**: add missing eslint config (client lint was completely broken)
- **`docs/E2E_SELECTORS.md`**: complete selector map for all screens

Risk: auto-merge
Verified: `bunx tsc --noEmit` passes; `bunx jest` 10/10 passing; all added testIDs are stable unique string literals matching the selector map