### PR TITLE
test: Playwright e2e core flows vs mock backend

### DIFF
--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from '../../stores/authStore';
 import { usePlatformStore } from '../../stores/platformStore';
 import { PlatformBadge } from '../../components/PlatformIcon';
 import { ChatSmartCardTray } from '../../components/ChatSmartCardTray';
+import { ResponseSuggestion } from '../../components/ResponseSuggestion';
 import { useConversationSettingsStore } from '../../stores/conversationSettingsStore';
 import { Platform } from '../../types/platform';
 
@@ -375,6 +376,15 @@ export default function ChatScreen() {
                 <Text style={{ color: '#9ca3af', fontSize: 15 }}>No messages yet</Text>
               </View>
             }
+          />
+        )}
+
+        {/* AI Response Suggestions */}
+        {messages.filter(m => !m.from_me).length > 0 && (
+          <ResponseSuggestion
+            chatId={chatId!}
+            messageId={[...messages].reverse().find(m => !m.from_me)?.id ?? ''}
+            onSelectSuggestion={(text) => setInputText(text)}
           />
         )}
 

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -1,0 +1,453 @@
+/**
+ * Core-loop e2e tests — run with MOCK_BRIDGE=true against the Expo web dev server.
+ *
+ * All Supabase and server API calls are intercepted via page.route() so these
+ * tests run with zero real backend dependencies.
+ *
+ * Flows covered (from the issue #10 acceptance criteria):
+ *   1. Auth → sign in renders and accepts credentials
+ *   2. Inbox → seeded messages appear after sign-in
+ *   3. Chat → open a chat and messages render
+ *   4. Send → type and send a message
+ *   5. AI suggestion → suggestion strip appears in chat
+ *   6. Promises tab → promises screen renders
+ *   7. Platform connection screen renders
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Fixture data (mirrors MOCK_BRIDGE server fixtures from docs/MOCK_BRIDGE.md)
+// ---------------------------------------------------------------------------
+
+const MOCK_USER_ID = '00000000-0000-0000-0000-000000000001';
+const MOCK_SESSION_ID = 'mock-session-1';
+const MOCK_ACCESS_TOKEN = 'mock-access-token-e2e';
+
+const MOCK_USER = {
+  id: MOCK_USER_ID,
+  email: 'test@claire.local',
+  role: 'authenticated',
+  app_metadata: {},
+  user_metadata: { name: 'Test User' },
+  aud: 'authenticated',
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+const MOCK_SESSION_RESP = {
+  access_token: MOCK_ACCESS_TOKEN,
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: 'mock-refresh-token',
+  user: MOCK_USER,
+};
+
+// Messages with the nested join shape that messages.tsx's Supabase query returns:
+//   chats(name, platform_chat_id) + ai_suggestions(id, confidence)
+const MOCK_INBOX_MESSAGES = [
+  {
+    id: 'msg-wa-1',
+    chat_id: 'mock-chat-wa-alice',
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content: "I'll send you the report by Friday",
+    timestamp: new Date(Date.now() - 3600_000).toISOString(),
+    from_me: false,
+    is_group: false,
+    platform: 'whatsapp',
+    platform_message_id: 'wa-msg-1',
+    status: 'delivered',
+    chats: { name: null, platform_chat_id: 'mock-chat-wa-alice' },
+    ai_suggestions: [{ id: 'sug-1', confidence: 0.9 }],
+  },
+  {
+    id: 'msg-tg-1',
+    chat_id: 'mock-chat-tg-bob',
+    contact_name: 'Bob (TG)',
+    contact_phone: null,
+    content: 'Hey, when can we meet?',
+    timestamp: new Date(Date.now() - 7200_000).toISOString(),
+    from_me: false,
+    is_group: false,
+    platform: 'telegram',
+    platform_message_id: 'tg-msg-1',
+    status: 'delivered',
+    chats: { name: null, platform_chat_id: 'mock-chat-tg-bob' },
+    ai_suggestions: [],
+  },
+  {
+    id: 'msg-ig-1',
+    chat_id: 'mock-chat-ig-carol',
+    contact_name: 'Carol (IG)',
+    contact_phone: null,
+    content: "Let's catch up soon!",
+    timestamp: new Date(Date.now() - 14400_000).toISOString(),
+    from_me: false,
+    is_group: false,
+    platform: 'instagram',
+    platform_message_id: 'ig-msg-1',
+    status: 'delivered',
+    chats: { name: null, platform_chat_id: 'mock-chat-ig-carol' },
+    ai_suggestions: [],
+  },
+];
+
+const MOCK_CHAT_MESSAGES = [
+  {
+    id: 'chatmsg-1',
+    content: "Hi! I'll send you the report by Friday",
+    timestamp: new Date(Date.now() - 3700_000).toISOString(),
+    from_me: false,
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content_type: 'text',
+  },
+  {
+    id: 'chatmsg-2',
+    content: 'Thanks for letting me know',
+    timestamp: new Date(Date.now() - 3600_000).toISOString(),
+    from_me: true,
+    contact_name: null,
+    content_type: 'text',
+  },
+];
+
+const MOCK_AI_SUGGESTIONS = [
+  {
+    id: 'sug-1',
+    message_id: 'chatmsg-1',
+    response_text: 'Sounds great, looking forward to it!',
+    confidence: 0.92,
+    is_selected: false,
+    feedback: null,
+  },
+  {
+    id: 'sug-2',
+    message_id: 'chatmsg-1',
+    response_text: 'Perfect, thank you for the update.',
+    confidence: 0.81,
+    is_selected: false,
+    feedback: null,
+  },
+];
+
+const MOCK_PROMISES = [
+  {
+    id: 'promise-1',
+    user_id: MOCK_USER_ID,
+    message_id: 'chatmsg-1',
+    chat_id: 'mock-chat-wa-alice',
+    promise_text: "I'll send you the report by Friday",
+    due_date: new Date(Date.now() + 86400_000 * 3).toISOString(),
+    status: 'open',
+    platform: 'whatsapp',
+    contact_name: 'Alice (WA)',
+    created_at: new Date(Date.now() - 3700_000).toISOString(),
+  },
+];
+
+const MOCK_PLATFORM_SESSIONS = [
+  {
+    id: MOCK_SESSION_ID,
+    user_id: MOCK_USER_ID,
+    platform: 'whatsapp',
+    status: 'connected',
+    platform_user_id: '+15161234567',
+    created_at: '2025-01-01T00:00:00Z',
+  },
+];
+
+// Chats table rows — needed by chat screen's fetchChatInfo() to resolve
+// platform_chat_id (used as the send target).
+const MOCK_CHATS = [
+  {
+    id: 'mock-chat-wa-alice',
+    user_id: MOCK_USER_ID,
+    platform: 'whatsapp',
+    platform_chat_id: 'mock-chat-wa-alice',
+    name: null,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Route mocking helper — intercept all Supabase + server API calls.
+//
+// IMPORTANT: Playwright glob patterns do not match query strings reliably.
+// We use a single `**/rest/v1/**` catch-all and branch on url.includes()
+// inside the handler to ensure correct matching.
+// ---------------------------------------------------------------------------
+
+async function mockBackend(page) {
+  // Supabase auth: sign-in via password (POST /auth/v1/token)
+  await page.route('**/auth/v1/token**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_SESSION_RESP),
+    });
+  });
+
+  // Supabase auth: user validation
+  await page.route('**/auth/v1/user**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_USER),
+    });
+  });
+
+  // Supabase REST: all /rest/v1/* endpoints — branch on URL path
+  await page.route('**/rest/v1/**', async (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    if (url.includes('/messages')) {
+      // Inbox list or chat detail (chat_id=eq. in query params)
+      if (url.includes('chat_id=eq.')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_CHAT_MESSAGES),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_INBOX_MESSAGES),
+        });
+      }
+    } else if (url.includes('/ai_suggestions')) {
+      if (method === 'PATCH') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_AI_SUGGESTIONS),
+        });
+      }
+    } else if (url.includes('/promises')) {
+      if (method === 'PATCH' || method === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{ ...MOCK_PROMISES[0], status: 'completed' }]),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_PROMISES),
+        });
+      }
+    } else if (url.includes('/chats')) {
+      // chat screen's fetchChatInfo uses .single() which sends
+      // Accept: application/vnd.pgrst.object+json → PostgREST returns
+      // a bare object, not an array. Return the first chat object.
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CHATS[0]),
+      });
+    } else if (url.includes('/platform_sessions')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_PLATFORM_SESSIONS),
+      });
+    } else if (url.includes('/users')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{
+          id: MOCK_USER_ID,
+          email: 'test@claire.local',
+          name: 'Test User',
+        }]),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      });
+    }
+  });
+
+  // Bun server API: platform status endpoints.
+  // getAllSessions() calls /platforms/<platform>/status for each platform.
+  await page.route('**/platforms/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sessions: MOCK_PLATFORM_SESSIONS }),
+    });
+  });
+
+  // Bun server API: send message
+  await page.route('**/messages/send**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, messageId: `sent-${Date.now()}` }),
+    });
+  });
+
+  // Supabase realtime — stub WebSocket preflight requests
+  await page.route('**/realtime/**', async (route) => {
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: sign in through the UI
+//
+// Uses the actual sign-in form so the Supabase auth state is set in the
+// Zustand store. Direct page.goto() to authenticated routes fails because
+// the auth guard redirects before the async getSession() resolves.
+// ---------------------------------------------------------------------------
+
+async function signIn(page) {
+  await page.goto('/signin');
+  await page.waitForLoadState('domcontentloaded');
+
+  await page.getByTestId('signin-email-input').fill('test@claire.local');
+  await page.getByTestId('signin-password-input').fill('password123');
+  await page.getByTestId('signin-submit').click();
+
+  // Mock auth succeeds + platform sessions check returns connected → goes to dashboard
+  await page.waitForURL('**/dashboard', { timeout: 15_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Core loop — mock backend', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBackend(page);
+  });
+
+  // 1. Auth — sign-in screen renders required fields
+  test('sign-in screen renders required fields', async ({ page }) => {
+    await page.goto('/signin');
+
+    await expect(page.getByTestId('signin-screen')).toBeVisible();
+    await expect(page.getByTestId('signin-email-input')).toBeVisible();
+    await expect(page.getByTestId('signin-password-input')).toBeVisible();
+    await expect(page.getByTestId('signin-submit')).toBeVisible();
+  });
+
+  // 2. Inbox — messages screen shows seeded messages after sign-in
+  test('inbox shows seeded messages after sign-in', async ({ page }) => {
+    await signIn(page);
+
+    // Click Messages tab (client-side navigation preserves auth state)
+    await page.click('text=Messages');
+    await expect(page.getByTestId('messages-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('messages-list')).toBeVisible();
+
+    // At least one seeded message card should render
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 3. Chat — opening a conversation shows the chat message list
+  test('opening a chat shows message list', async ({ page }) => {
+    await signIn(page);
+
+    await page.click('text=Messages');
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 4. Send — typing and submitting a message clears the chat input
+  test('sending a message clears the chat input', async ({ page }) => {
+    await signIn(page);
+
+    // Start listening for the platform sessions response BEFORE triggering
+    // the navigation that causes the fetch, so we don't miss it.
+    const sessionsResponsePromise = page.waitForResponse('**/platforms/**', { timeout: 10_000 }).catch(() => null);
+
+    await page.click('text=Messages');
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+
+    // Wait for sessions to be loaded (ensures send button won't be disabled)
+    await sessionsResponsePromise;
+
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-input')).toBeVisible({ timeout: 8_000 });
+
+    await page.getByTestId('chat-input').fill('Hello from e2e test');
+    await page.getByTestId('chat-send-button').click();
+
+    // Input should clear after sending (optimistic update clears immediately)
+    await expect(page.getByTestId('chat-input')).toHaveValue('', { timeout: 5_000 });
+  });
+
+  // 5. AI suggestions — suggestion text appears in the chat screen
+  test('AI suggestion text appears in chat', async ({ page }) => {
+    await signIn(page);
+
+    await page.click('text=Messages');
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+
+    // ResponseSuggestion renders suggestion text fetched from ai_suggestions table
+    await expect(
+      page.getByText('Sounds great, looking forward to it!')
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  // 6. Promises tab — renders the promises screen
+  test('Promises tab renders the promises screen', async ({ page }) => {
+    await signIn(page);
+
+    // Click Promises tab
+    await page.click('text=Promises');
+
+    // Confirm the route loaded — the promises screen container is present
+    await expect(page.getByTestId('promises-screen')).toBeVisible({ timeout: 10_000 });
+  });
+
+  // 7. Platform connection screen — all required selectors present
+  test('platform connection screen shows platform selectors', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByTestId('platform-login-screen')).toBeVisible();
+    await expect(page.getByTestId('platform-selector-whatsapp')).toBeVisible();
+    await expect(page.getByTestId('platform-selector-instagram')).toBeVisible();
+  });
+});
+
+test.describe('Web shell smoke', () => {
+  test('sign-in page is accessible', async ({ page }) => {
+    await page.goto('/signin');
+    await expect(page.getByTestId('signin-screen')).toBeVisible();
+  });
+
+  test('platform login page is accessible', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('platform-login-screen')).toBeVisible();
+  });
+});

--- a/client/playwright.config.mjs
+++ b/client/playwright.config.mjs
@@ -3,16 +3,26 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8081',
     trace: 'on-first-retry',
+    // Silence browser console noise in CI
+    bypassCSP: true,
   },
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: 'bunx expo start --web --non-interactive',
+        command: 'MOCK_BRIDGE=true bunx expo start --web --non-interactive',
         port: 8081,
         reuseExistingServer: true,
         timeout: 120_000,
+        env: {
+          MOCK_BRIDGE: 'true',
+          EXPO_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+          EXPO_PUBLIC_SUPABASE_ANON_KEY: 'mock-anon-key',
+          EXPO_PUBLIC_API_URL: 'http://localhost:3001',
+        },
       },
 });


### PR DESCRIPTION
## Summary

- Adds `client/e2e/core-flows.spec.mjs` with 9 tests covering the 7 acceptance-criteria flows from issue #10 (auth, inbox, chat, send, AI suggestion, promises, platform connection screen)
- Wires `ResponseSuggestion` component into the chat screen so the AI suggestion test has something to assert
- Updates `playwright.config.mjs` with CI reporter, retries, and `MOCK_BRIDGE=true` env for the webServer

Closes #10
Risk: `risk/auto-merge`

## Test plan

- [x] `MOCK_BRIDGE=true bunx playwright test` — 11 passed (10.9s)
- [x] `bunx tsc --noEmit` — no errors
- [x] `bunx jest` — 10 passed
- [x] ESLint — 0 errors (16 pre-existing warnings)
- [x] Server typecheck — pre-existing errors only (identical to main)

## Key implementation notes

| Challenge | Solution |
|---|---|
| Auth-guard race on `page.goto()` | Use actual UI sign-in form + `waitForURL('**/dashboard')`, then tab clicks for client-side nav |
| Supabase REST glob vs query strings | Single `**/rest/v1/**` catch-all with `url.includes()` branching |
| `sendMessage` blocked by null `platformChatId` | Mock `/chats` returning a bare object (`.single()` semantics) |
| `connectedSessions` race | `waitForResponse('**/platforms/**')` before navigating to chat |

🤖 Generated with [Claude Code](https://claude.com/claude-code)