### PR TITLE
feat: wire promise detection into live Matrix ingestion path (#15)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,6 +20,7 @@ import { aiRateLimit, authRateLimit } from './middleware/rate-limit';
 import seedRoutes from './routes/seed';
 import { platformManager } from './adapters';
 import { aiProcessor } from './services/ai-processor';
+import { promiseDetector } from './services/promise-detector';
 import { whatsappAdapter } from './adapters/whatsapp';
 import { telegramAdapter } from './adapters/telegram';
 import { imessageAdapter } from './adapters/imessage';
@@ -295,6 +296,12 @@ async function initializePlatforms() {
           const chatType = message.chatType === 'group' ? 'group' : 'individual';
           aiProcessor.generateAndStore(savedMsg.id, message.content, message.userId, chatType)
             .catch((err) => logger.debug('AI suggestion skipped:', (err as Error).message));
+        }
+
+        // Detect and persist promises (fire-and-forget, both inbound and outbound)
+        if (savedMsg?.id && message.content?.trim()) {
+          promiseDetector.detectPromises(savedMsg.id, message.content, message.userId, message.isFromMe)
+            .catch((err) => logger.debug('Promise detection skipped:', (err as Error).message));
         }
       }
 


### PR DESCRIPTION
Closes #15

## Summary
- Import `promiseDetector` in `server/src/index.ts`
- Call `detectPromises` (fire-and-forget) after every message is saved to the DB, for both inbound and outbound messages
- Any message containing a promise/commitment/deadline/task automatically creates a row in the `promises` table, scoped to the user

## Risk
`risk/human-gate` — touches the core message ingestion path in `server/src/index.ts`

## Verified
- `bun run typecheck` — no new errors introduced (pre-existing errors in unrelated files are unchanged)
- `bun test` — 23 pass, 3 pre-existing failures (ai-processor mock, test utilities), promise-detector at 95% function / 100% line coverage
- Logic: fire-and-forget with `.catch()` so a promise-detection failure never blocks message delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)