### PR TITLE
chore: remove duplicate inbox tab — consolidate dashboard + messages (#14)

### DIFF
--- a/client/app/(tabs)/_layout.tsx
+++ b/client/app/(tabs)/_layout.tsx
@@ -1,6 +1,5 @@
 import { Tabs, Redirect } from 'expo-router';
 import {
-  Sparkles,
   MessageCircle,
   CheckSquare,
   Settings,
@@ -49,19 +48,16 @@ export default function TabLayout() {
       <Tabs.Screen
         name="dashboard"
         options={{
-          title: 'Home',
+          title: 'Messages',
           tabBarIcon: ({ color, size }) => (
-            <Sparkles size={size} color={color} />
+            <MessageCircle size={size} color={color} />
           ),
         }}
       />
       <Tabs.Screen
         name="messages"
         options={{
-          title: 'Messages',
-          tabBarIcon: ({ color, size }) => (
-            <MessageCircle size={size} color={color} />
-          ),
+          href: null,
         }}
       />
       <Tabs.Screen

--- a/client/app/(tabs)/dashboard.tsx
+++ b/client/app/(tabs)/dashboard.tsx
@@ -1,187 +1,267 @@
-import { View, ScrollView, Text, TouchableOpacity } from 'react-native';
-import { useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+} from 'react-native';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Search, MessageCircle } from 'lucide-react-native';
 import { router } from 'expo-router';
-import { UrgentCard, UrgentOverflowItem } from '../../components/UrgentCard';
-import type { UrgentMessage } from '../../components/UrgentCard';
-import { HomeSection } from '../../components/HomeSection';
-import { MorningBrief } from '../../components/MorningBrief';
-import { NudgeCard } from '../../components/NudgeCard';
+import Animated, { FadeInDown, LinearTransition } from 'react-native-reanimated';
+import { MessageCard } from '../../components/MessageCard';
 import { PlatformBadge } from '../../components/PlatformIcon';
-import { Platform } from '../../types/platform';
-import type { ChatCategory } from '../../types/conversationSettings';
-import { formatWaitTime } from '../../utils/urgency';
+import { supabase } from '../../services/supabase';
+import { useAuthStore } from '../../stores/authStore';
+import { usePlatformStore, useHasAnyConnection } from '../../stores/platformStore';
+import { Platform, PLATFORM_DISPLAY } from '../../types/platform';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface CatchUpGroup {
+interface Message {
   id: string;
+  conversation_key: string;
+  contact_name?: string;
+  contact_avatar?: string;
+  chat_name?: string;
+  content: string;
+  timestamp: string;
+  from_me: boolean;
+  is_group: boolean;
+  status?: 'sent' | 'delivered' | 'read' | 'pending';
+  unread_count?: number;
+  has_ai_response?: boolean;
   chat_id: string;
-  chat_name: string;
-  unread_count: number;
+  contact_phone?: string;
   platform?: Platform;
-  last_active: string;
-  summary: string;
 }
 
-interface Nudge {
-  id: string;
-  chat_id: string;
-  contact_name: string;
-  category: ChatCategory;
-  message: string;
+type FilterType = 'all' | 'unread' | 'groups' | 'ai';
+type PlatformFilterType = Platform | 'all';
+const MESSAGE_ROW_LAYOUT = LinearTransition.springify().damping(18).stiffness(220);
+const MESSAGE_ROW_ENTERING = FadeInDown.duration(180);
+
+function getConversationKey(chatId: string, platform?: Platform) {
+  return `${platform || Platform.WHATSAPP}:${chatId}`;
 }
 
-// ---------------------------------------------------------------------------
-// Dummy data (Phase 1 — replace with real data in Phase 2)
-// ---------------------------------------------------------------------------
-
-const DUMMY_MORNING_BRIEF =
-  '3 conversations are waiting for your reply. Sarah has been waiting 2.5 hours about the proposal. Mom texted last night. The Vegas trip group is planning April dates.';
-
-const DUMMY_URGENT: UrgentMessage[] = [
-  {
-    id: 'u1',
-    chat_id: 'chat-sarah',
-    contact_name: 'Sarah Chen',
-    content: 'Can we reschedule our call to tomorrow? Also need your input on the proposal ASAP',
-    timestamp: new Date(Date.now() - 2.5 * 3_600_000).toISOString(),
-    from_me: false,
-    is_group: false,
-    platform: Platform.WHATSAPP,
-    urgency_score: 78,
-    quick_replies: [
-      { text: 'Sure, what time works for you?', tone: 'warm' },
-      { text: "I'll review the proposal tonight", tone: 'professional' },
-      { text: 'Can we do 2pm tomorrow?', tone: 'casual' },
-    ],
-  },
-  {
-    id: 'u2',
-    chat_id: 'chat-mom',
-    contact_name: 'Mom',
-    content: 'Just checking in! How are you doing?',
-    timestamp: new Date(Date.now() - 18 * 3_600_000).toISOString(),
-    from_me: false,
-    is_group: false,
-    platform: Platform.WHATSAPP,
-    urgency_score: 48,
-    quick_replies: [
-      { text: 'Hey! Doing well, talk soon', tone: 'warm' },
-      { text: "All good! I'll call you this weekend", tone: 'casual' },
-    ],
-  },
-  {
-    id: 'u3',
-    chat_id: 'chat-vegas',
-    chat_name: 'Vegas Trip',
-    content: 'Jordan: Everyone still good for April 18-21?',
-    timestamp: new Date(Date.now() - 45 * 60_000).toISOString(),
-    from_me: false,
-    is_group: true,
-    platform: Platform.WHATSAPP,
-    urgency_score: 55,
-    quick_replies: [
-      { text: "I'm in!", tone: 'casual' },
-      { text: 'Can confirm those dates work', tone: 'brief' },
-    ],
-  },
-];
-
-const DUMMY_CATCHUP: CatchUpGroup[] = [
-  {
-    id: 'g1',
-    chat_id: 'chat-design',
-    chat_name: 'Design Team',
-    unread_count: 24,
-    platform: Platform.TELEGRAM,
-    last_active: new Date(Date.now() - 20 * 60_000).toISOString(),
-    summary: 'Discussing the new onboarding flow. Lena shared mockups and feedback was requested.',
-  },
-  {
-    id: 'g2',
-    chat_id: 'chat-nyc',
-    chat_name: 'NYC Friends',
-    unread_count: 11,
-    platform: Platform.WHATSAPP,
-    last_active: new Date(Date.now() - 3 * 3_600_000).toISOString(),
-    summary: 'Planning dinner for Friday. Still deciding on a spot.',
-  },
-];
-
-const DUMMY_NUDGES: Nudge[] = [
-  {
-    id: 'n1',
-    chat_id: 'chat-emma',
-    contact_name: 'Emma',
-    category: 'romantic',
-    message: "Haven't texted in 3 days — say good morning?",
-  },
-  {
-    id: 'n2',
-    chat_id: 'chat-alex',
-    contact_name: 'Alex Rivera',
-    category: 'business',
-    message: 'You offered to send a proposal 4 days ago. Follow up?',
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function CatchUpCard({ group, onPress }: { group: CatchUpGroup; onPress: () => void }) {
-  const minsAgo = Math.floor((Date.now() - new Date(group.last_active).getTime()) / 60_000);
-  const timeLabel = minsAgo < 60 ? `${minsAgo}m ago` : `${Math.floor(minsAgo / 60)}h ago`;
-
+function FilterPill({
+  type,
+  label,
+  activeFilter,
+  onPress,
+}: {
+  type: FilterType;
+  label: string;
+  activeFilter: FilterType;
+  onPress: () => void;
+}) {
+  const isActive = activeFilter === type;
   return (
     <TouchableOpacity
       onPress={onPress}
-      activeOpacity={0.75}
-      className="mx-4 mb-2 bg-white dark:bg-gray-800 rounded-2xl p-4 border border-gray-100 dark:border-gray-700"
+      className={`px-3 py-1.5 rounded-full mr-2 ${isActive ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'}`}
     >
-      <View className="flex-row items-start justify-between mb-2">
-        <View className="flex-row items-center flex-1 mr-3">
-          <View className="w-9 h-9 rounded-full bg-gray-100 dark:bg-gray-700 items-center justify-center mr-2.5">
-            <Text className="text-sm font-bold text-gray-600 dark:text-gray-300">
-              {group.chat_name[0].toUpperCase()}
-            </Text>
-          </View>
-          <View className="flex-1">
-            <Text className="font-semibold text-gray-900 dark:text-white text-sm" numberOfLines={1}>
-              {group.chat_name}
-            </Text>
-            <View className="flex-row items-center gap-1.5 mt-0.5">
-              {group.platform && <PlatformBadge platform={group.platform} size={11} />}
-              <Text className="text-xs text-gray-400 dark:text-gray-500">{timeLabel}</Text>
-            </View>
-          </View>
-        </View>
-        <View className="bg-indigo-100 dark:bg-indigo-900 rounded-full px-2 py-0.5">
-          <Text className="text-xs font-semibold text-indigo-600 dark:text-indigo-400">
-            {group.unread_count} new
-          </Text>
-        </View>
-      </View>
-      <Text className="text-sm text-gray-500 dark:text-gray-400 leading-4" numberOfLines={2}>
-        {group.summary}
+      <Text className={`text-sm font-medium ${isActive ? 'text-white' : 'text-gray-700 dark:text-gray-300'}`}>
+        {label}
       </Text>
     </TouchableOpacity>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Main screen
-// ---------------------------------------------------------------------------
+function PlatformFilterPill({
+  platform,
+  label,
+  platformFilter,
+  onPress,
+}: {
+  platform: PlatformFilterType;
+  label: string;
+  platformFilter: PlatformFilterType;
+  onPress: () => void;
+}) {
+  const isActive = platformFilter === platform;
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className={`flex-row items-center px-3 py-1.5 rounded-full mr-2 ${isActive ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'}`}
+    >
+      {platform !== 'all' && (
+        <PlatformBadge platform={platform as Platform} size={14} className="mr-1" />
+      )}
+      <Text className={`text-sm font-medium ${isActive ? 'text-white' : 'text-gray-700 dark:text-gray-300'}`}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
 
-export default function HomeScreen() {
-  const [dismissedNudges, setDismissedNudges] = useState<Set<string>>(new Set());
+export default function DashboardScreen() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  const [platformFilter, setPlatformFilter] = useState<PlatformFilterType>('all');
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
 
-  const navigateToChat = (
-    msg: { chat_id: string; contact_name?: string; chat_name?: string; platform?: Platform; is_group: boolean },
-    prefillText?: string
-  ) => {
+  const user = useAuthStore((state) => state.user);
+  const { initialize, isInitialized } = usePlatformStore();
+  const hasConnection = useHasAnyConnection();
+
+  useEffect(() => {
+    if (!isInitialized) initialize();
+  }, [initialize, isInitialized]);
+
+  const fetchMessages = useCallback(async (pageNum = 0, append = false) => {
+    if (!user?.id) return;
+    const pageSize = 20;
+    const from = pageNum * pageSize;
+    const to = from + pageSize - 1;
+    try {
+      const { data, error, count } = await supabase
+        .from('messages')
+        .select(
+          `id, content, timestamp, from_me, is_group, status, platform,
+           chat_id, platform_message_id, contact_phone, contact_name,
+           chats (name, platform_chat_id),
+           ai_suggestions (id, confidence)`,
+          { count: 'exact' }
+        )
+        .eq('user_id', user.id)
+        .order('timestamp', { ascending: false })
+        .range(from, to);
+
+      if (error) throw error;
+
+      const chatMap = new Map<string, Message>();
+      (data || []).forEach((msg: any) => {
+        const chatId = msg.chat_id || msg.id;
+        const platform = msg.platform || Platform.WHATSAPP;
+        const conversationKey = getConversationKey(chatId, platform);
+        if (!chatMap.has(conversationKey) || new Date(msg.timestamp) > new Date(chatMap.get(conversationKey)!.timestamp)) {
+          chatMap.set(conversationKey, {
+            id: msg.id,
+            conversation_key: conversationKey,
+            contact_name: msg.contact_name,
+            chat_name: msg.chats?.name || (!msg.from_me ? msg.contact_name : null),
+            content: msg.content,
+            timestamp: msg.timestamp,
+            from_me: msg.from_me,
+            is_group: msg.is_group,
+            status: msg.status,
+            chat_id: chatId,
+            contact_phone: msg.contact_phone,
+            has_ai_response: msg.ai_suggestions?.length > 0,
+            unread_count: 0,
+            platform,
+          });
+        }
+      });
+
+      const sorted = Array.from(chatMap.values()).sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      );
+
+      const seen = new Set<string>();
+      const latest = sorted.filter((msg) => {
+        const key = `${msg.platform}:${msg.chat_name || msg.contact_phone || msg.chat_id}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      if (append) {
+        setMessages((prev) => {
+          const combined = [...prev, ...latest];
+          const seenConversationKeys = new Set<string>();
+          return combined.filter((m) => {
+            if (seenConversationKeys.has(m.conversation_key)) return false;
+            seenConversationKeys.add(m.conversation_key);
+            return true;
+          });
+        });
+      } else {
+        setMessages(latest);
+      }
+
+      setHasMore(count ? to < count - 1 : false);
+      setPage(pageNum);
+    } catch (e) {
+      console.error('Error fetching messages:', e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+      setLoadingMore(false);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    fetchMessages();
+    const sub = supabase
+      .channel(`messages-tab-${user.id}`)
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages', filter: `user_id=eq.${user.id}` }, (payload) => {
+        const row = payload.new as any;
+        const platform = row.platform || Platform.WHATSAPP;
+        const conversationKey = getConversationKey(row.chat_id, platform);
+        setMessages((prev) => {
+          const idx = prev.findIndex((m) => m.conversation_key === conversationKey);
+          if (idx >= 0) {
+            const updated: Message = {
+              ...prev[idx],
+              id: row.id,
+              conversation_key: conversationKey,
+              content: row.content,
+              timestamp: row.timestamp,
+              from_me: row.from_me,
+              is_group: row.is_group ?? prev[idx].is_group,
+              contact_name: row.contact_name || prev[idx].contact_name,
+              contact_phone: row.contact_phone || prev[idx].contact_phone,
+              platform,
+            };
+            return [updated, ...prev.filter((_, i) => i !== idx)];
+          }
+          fetchMessages();
+          return prev;
+        });
+      })
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'messages', filter: `user_id=eq.${user.id}` }, () => fetchMessages())
+      .subscribe();
+    return () => { sub.unsubscribe(); };
+  }, [user?.id, fetchMessages]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    const interval = setInterval(() => fetchMessages(), 15_000);
+    return () => clearInterval(interval);
+  }, [user?.id, fetchMessages]);
+
+  const filteredMessages = useMemo(() => {
+    let filtered = messages;
+    if (platformFilter !== 'all') filtered = filtered.filter((m) => m.platform === platformFilter);
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (m) =>
+          m.contact_name?.toLowerCase().includes(q) ||
+          m.chat_name?.toLowerCase().includes(q) ||
+          m.content.toLowerCase().includes(q) ||
+          m.contact_phone?.includes(q)
+      );
+    }
+    switch (activeFilter) {
+      case 'unread': filtered = filtered.filter((m) => m.unread_count && m.unread_count > 0); break;
+      case 'groups': filtered = filtered.filter((m) => m.is_group); break;
+      case 'ai':     filtered = filtered.filter((m) => m.has_ai_response); break;
+    }
+    return filtered;
+  }, [messages, searchQuery, activeFilter, platformFilter]);
+
+  const navigateToChat = (msg: Message) => {
     router.push({
       pathname: '/chat/[chatId]',
       params: {
@@ -190,94 +270,100 @@ export default function HomeScreen() {
         chat_name: msg.chat_name || '',
         platform: msg.platform || '',
         is_group: msg.is_group ? '1' : '0',
-        ...(prefillText ? { prefill: prefillText } : {}),
       },
     });
   };
 
-  const visibleNudges = DUMMY_NUDGES.filter((n) => !dismissedNudges.has(n.id));
+  if (loading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-gray-50 dark:bg-gray-900" testID="messages-loading">
+        <ActivityIndicator size="large" color="#6366f1" />
+        <Text className="mt-2 text-gray-500 dark:text-gray-400">Loading messages...</Text>
+      </View>
+    );
+  }
 
   return (
-    <ScrollView
-      className="flex-1 bg-gray-50 dark:bg-gray-900"
-      contentContainerStyle={{ paddingTop: 12, paddingBottom: 32 }}
-      showsVerticalScrollIndicator={false}
-      testID="dashboard-screen"
-    >
-      {/* Morning Brief */}
-      <MorningBrief text={DUMMY_MORNING_BRIEF} />
-
-      {/* Needs Your Reply */}
-      <HomeSection
-        title="Needs Your Reply"
-        subtitle={`${DUMMY_URGENT.length} conversations waiting`}
-      >
-        <UrgentCard
-          message={DUMMY_URGENT[0]}
-          onPress={() => navigateToChat(DUMMY_URGENT[0])}
-          onQuickReply={(text, chatId) => {
-            const msg = DUMMY_URGENT.find((u) => u.chat_id === chatId);
-            if (msg) navigateToChat(msg, text);
-          }}
-        />
-        {DUMMY_URGENT.length > 1 && (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingHorizontal: 16, gap: 12, paddingTop: 12 }}
-          >
-            {DUMMY_URGENT.slice(1).map((msg) => (
-              <UrgentOverflowItem
-                key={msg.id}
-                message={msg}
-                onPress={() => navigateToChat(msg)}
-              />
-            ))}
-          </ScrollView>
-        )}
-      </HomeSection>
-
-      {/* Catch Up */}
-      <HomeSection title="Catch Up" subtitle="Groups with new activity">
-        {DUMMY_CATCHUP.map((group) => (
-          <CatchUpCard
-            key={group.id}
-            group={group}
-            onPress={() =>
-              router.push({
-                pathname: '/chat/[chatId]',
-                params: {
-                  chatId: group.chat_id,
-                  chat_name: group.chat_name,
-                  platform: group.platform || '',
-                  is_group: '1',
-                },
-              })
-            }
+    <View className="flex-1 bg-gray-50 dark:bg-gray-900" testID="messages-screen">
+      {/* Sticky filter bar — lives outside FlatList to avoid key conflicts */}
+      <View className="bg-white dark:bg-gray-800 px-4 pt-3 pb-2 border-b border-gray-100 dark:border-gray-700">
+        <View className="flex-row items-center bg-gray-100 dark:bg-gray-700 rounded-xl px-3 py-2 mb-3">
+          <Search size={18} color="#6b7280" />
+          <TextInput
+            className="flex-1 ml-2 text-gray-900 dark:text-white"
+            placeholder="Search messages..."
+            placeholderTextColor="#6b7280"
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            returnKeyType="search"
+            testID="messages-search-input"
           />
-        ))}
-      </HomeSection>
-
-      {/* Follow-up Nudges */}
-      {visibleNudges.length > 0 && (
-        <HomeSection title="Follow-up Nudges">
-          {visibleNudges.map((nudge) => (
-            <NudgeCard
-              key={nudge.id}
-              contactName={nudge.contact_name}
-              message={nudge.message}
-              category={nudge.category}
-              onPress={() =>
-                router.push({
-                  pathname: '/chat/[chatId]',
-                  params: { chatId: nudge.chat_id, contact_name: nudge.contact_name },
-                })
-              }
-              onDismiss={() => setDismissedNudges((prev) => new Set([...prev, nudge.id]))}
+        </View>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-2" contentContainerStyle={{ gap: 6 }}>
+          <PlatformFilterPill platform="all" label="All" platformFilter={platformFilter} onPress={() => setPlatformFilter('all')} />
+          <PlatformFilterPill platform={Platform.WHATSAPP} label="WhatsApp" platformFilter={platformFilter} onPress={() => setPlatformFilter(Platform.WHATSAPP)} />
+          <PlatformFilterPill platform={Platform.TELEGRAM} label="Telegram" platformFilter={platformFilter} onPress={() => setPlatformFilter(Platform.TELEGRAM)} />
+          <PlatformFilterPill platform={Platform.INSTAGRAM} label="Instagram" platformFilter={platformFilter} onPress={() => setPlatformFilter(Platform.INSTAGRAM)} />
+        </ScrollView>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 6 }}>
+          <FilterPill type="all" label="All" activeFilter={activeFilter} onPress={() => setActiveFilter('all')} />
+          <FilterPill type="unread" label="Unread" activeFilter={activeFilter} onPress={() => setActiveFilter('unread')} />
+          <FilterPill type="groups" label="Groups" activeFilter={activeFilter} onPress={() => setActiveFilter('groups')} />
+          <FilterPill type="ai" label="AI Suggestions" activeFilter={activeFilter} onPress={() => setActiveFilter('ai')} />
+        </ScrollView>
+      </View>
+      <FlatList
+        data={filteredMessages}
+        renderItem={({ item }) => (
+          <Animated.View entering={MESSAGE_ROW_ENTERING} layout={MESSAGE_ROW_LAYOUT}>
+            <MessageCard
+              message={item}
+              onPress={() => navigateToChat(item)}
+              onLongPress={() => console.log('options:', item.id)}
             />
-          ))}
-        </HomeSection>
-      )}
-    </ScrollView>
+          </Animated.View>
+        )}
+        keyExtractor={(item) => item.conversation_key}
+        testID="messages-list"
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => { setRefreshing(true); setPage(0); fetchMessages(0, false); }}
+            tintColor="#6366f1"
+          />
+        }
+        onEndReached={() => { if (hasMore && !loadingMore) { setLoadingMore(true); fetchMessages(page + 1, true); } }}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={
+          loadingMore ? (
+            <View className="py-4">
+              <ActivityIndicator size="small" color="#6366f1" />
+            </View>
+          ) : null
+        }
+        ListEmptyComponent={
+          <View className="items-center py-16 px-8" testID="messages-empty">
+            <MessageCircle size={40} color="#9ca3af" />
+            <Text className="text-gray-500 dark:text-gray-400 mt-3 text-center text-sm">
+              {searchQuery
+                ? 'No messages matching your search'
+                : platformFilter !== 'all'
+                  ? `No ${PLATFORM_DISPLAY[platformFilter as Platform].name} messages`
+                  : activeFilter !== 'all'
+                    ? `No ${activeFilter} messages`
+                    : 'No messages yet'}
+            </Text>
+            {!searchQuery && activeFilter === 'all' && platformFilter === 'all' && !hasConnection && (
+              <TouchableOpacity
+                onPress={() => router.push('/(auth)/login')}
+                className="mt-4 bg-indigo-600 px-6 py-2 rounded-full"
+              >
+                <Text className="text-white font-semibold text-sm">Connect Platform</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        }
+      />
+    </View>
   );
 }

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -347,8 +347,7 @@ test.describe('Core loop — mock backend', () => {
   test('inbox shows seeded messages after sign-in', async ({ page }) => {
     await signIn(page);
 
-    // Click Messages tab (client-side navigation preserves auth state)
-    await page.click('text=Messages');
+    // Dashboard is now the canonical inbox — no tab navigation needed
     await expect(page.getByTestId('messages-screen')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('messages-list')).toBeVisible();
 
@@ -362,7 +361,6 @@ test.describe('Core loop — mock backend', () => {
   test('opening a chat shows message list', async ({ page }) => {
     await signIn(page);
 
-    await page.click('text=Messages');
     await expect(
       page.locator('[data-testid^="message-card-"]').first()
     ).toBeVisible({ timeout: 8_000 });
@@ -381,7 +379,6 @@ test.describe('Core loop — mock backend', () => {
     // the navigation that causes the fetch, so we don't miss it.
     const sessionsResponsePromise = page.waitForResponse('**/platforms/**', { timeout: 10_000 }).catch(() => null);
 
-    await page.click('text=Messages');
     await expect(
       page.locator('[data-testid^="message-card-"]').first()
     ).toBeVisible({ timeout: 8_000 });
@@ -405,7 +402,6 @@ test.describe('Core loop — mock backend', () => {
   test('AI suggestion text appears in chat', async ({ page }) => {
     await signIn(page);
 
-    await page.click('text=Messages');
     await expect(
       page.locator('[data-testid^="message-card-"]').first()
     ).toBeVisible({ timeout: 8_000 });


### PR DESCRIPTION
Closes #14

Reconciles `dashboard.tsx` and `messages.tsx` into a single canonical inbox screen.

**Changes:**
- `dashboard.tsx` now contains the full inbox (previously in `messages.tsx`): real-time message list, search, platform & type filters, pagination
- `_layout.tsx`: removed the separate "Messages" tab; `dashboard` tab renamed to "Messages" with MessageCircle icon; `messages` route hidden via `href: null`
- `e2e/core-flows.spec.mjs`: removed `page.click('text=Messages')` navigation steps — the inbox is now directly visible after sign-in on the dashboard route

**Verified:** All 11 Playwright e2e tests pass with `MOCK_BRIDGE=true` · client lint clean (0 errors) · `tsc --noEmit` passes

Risk: auto-merge