### PR TITLE
feat: wire ResponseSuggestion testIDs + accept-fills-composer e2e (#21)

### DIFF
--- a/client/components/ResponseSuggestion.tsx
+++ b/client/components/ResponseSuggestion.tsx
@@ -143,7 +143,7 @@ export function ResponseSuggestion({
   }
 
   return (
-    <View className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 mx-4 mb-2">
+    <View className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 mx-4 mb-2" testID="ai-suggestion-strip">
       {/* Header */}
       <View className="flex-row items-center justify-between mb-2">
         <View className="flex-row items-center">
@@ -166,11 +166,12 @@ export function ResponseSuggestion({
       </View>
 
       {/* Suggestions */}
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} testID="ai-suggestion-scroll">
         {suggestions.map((suggestion, index) => (
           <View key={suggestion.id} className="mr-2">
             <TouchableOpacity
               onPress={() => handleSelectSuggestion(suggestion, index)}
+              testID={`ai-suggestion-chip-${index}`}
               className={`bg-white dark:bg-gray-800 rounded-lg p-2.5 min-w-[200] max-w-[280] ${
                 selectedIndex === index ? 'border-2 border-blue-500' : 'border border-gray-200 dark:border-gray-700'
               }`}
@@ -217,6 +218,7 @@ export function ResponseSuggestion({
                 </View>
                 <TouchableOpacity
                   onPress={() => handleSelectSuggestion(suggestion, index)}
+                  testID={`ai-suggestion-use-${index}`}
                   className="flex-row items-center bg-blue-500 rounded px-2 py-1"
                 >
                   <Send size={12} color="#ffffff" />

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -415,6 +415,30 @@ test.describe('Core loop — mock backend', () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
+  // 5b. AI suggestion accept — tapping "Use" fills the composer
+  test('accepting AI suggestion fills the composer', async ({ page }) => {
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the suggestion strip to appear
+    await expect(page.getByTestId('ai-suggestion-strip')).toBeVisible({ timeout: 10_000 });
+
+    // Tap the first "Use" button
+    await page.getByTestId('ai-suggestion-use-0').click();
+
+    // Composer should now contain the first suggestion text
+    await expect(page.getByTestId('chat-input')).toHaveValue(
+      'Sounds great, looking forward to it!',
+      { timeout: 5_000 }
+    );
+  });
+
   // 6. Promises tab — renders the promises screen
   test('Promises tab renders the promises screen', async ({ page }) => {
     await signIn(page);

--- a/docs/E2E_SELECTORS.md
+++ b/docs/E2E_SELECTORS.md
@@ -111,6 +111,15 @@ All stable `testID` values (rendered as `data-testid` on web via React Native We
 | `chat-input` | Message composer `TextInput` |
 | `chat-send-button` | Send `TouchableOpacity` |
 
+### AI Suggestion strip (`ResponseSuggestion`)
+
+| Selector | Element |
+|---|---|
+| `ai-suggestion-strip` | Root `View` (only visible when suggestions exist) |
+| `ai-suggestion-scroll` | Horizontal `ScrollView` containing chips |
+| `ai-suggestion-chip-<index>` | Individual suggestion card `TouchableOpacity` (0-based) |
+| `ai-suggestion-use-<index>` | "Use" button inside chip (0-based); tapping fills the composer |
+
 ---
 
 ## Platform auth modal


### PR DESCRIPTION
Closes #21

## What

Wire `client/components/ResponseSuggestion.tsx` into the e2e test suite with stable `testID` selectors, and add the "accept fills composer" acceptance-criteria test.

**Changes:**
- `ResponseSuggestion`: add `testID="ai-suggestion-strip"` on root, `ai-suggestion-chip-<index>` on each chip, `ai-suggestion-use-<index>` on each "Use" button
- `core-flows.spec.mjs`: new test "accepting AI suggestion fills the composer" — taps `ai-suggestion-use-0`, asserts `chat-input` value matches suggestion text
- `docs/E2E_SELECTORS.md`: document new selectors under Chat screen section

The component was already integrated in `chat/[chatId].tsx` (lines 383–389); this issue completes it by adding the testID coverage and the accept→composer e2e verification.

Risk: auto-merge
Verified: 10/10 Playwright e2e pass locally (`MOCK_BRIDGE=true bunx playwright test`)