### PR TITLE
test: promise unit + e2e tests for detector, API, and screen (#20)

### DIFF
--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -450,6 +450,61 @@ test.describe('Core loop — mock backend', () => {
     await expect(page.getByTestId('promises-screen')).toBeVisible({ timeout: 10_000 });
   });
 
+  // 6b. Promises screen — seeded promise item appears in the list
+  test('Promises screen shows seeded promise item', async ({ page }) => {
+    await signIn(page);
+
+    await page.click('text=Promises');
+    await expect(page.getByTestId('promises-screen')).toBeVisible({ timeout: 10_000 });
+
+    // The promises list should be visible
+    await expect(page.getByTestId('promises-list')).toBeVisible({ timeout: 8_000 });
+
+    // The seeded promise item should appear
+    await expect(
+      page.locator('[data-testid^="promise-item-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 6c. Promises screen — tab switching works
+  test('Promises screen tab switching renders correct tab', async ({ page }) => {
+    await signIn(page);
+
+    await page.click('text=Promises');
+    await expect(page.getByTestId('promises-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Switch to Done tab
+    await page.getByTestId('promises-tab-done').click();
+    // Done tab is now active — either empty state or items show
+    await expect(page.getByTestId('promises-list')).toBeVisible({ timeout: 5_000 });
+
+    // Switch to Overdue tab
+    await page.getByTestId('promises-tab-overdue').click();
+    await expect(page.getByTestId('promises-list')).toBeVisible({ timeout: 5_000 });
+
+    // Switch back to Open
+    await page.getByTestId('promises-tab-open').click();
+    await expect(page.getByTestId('promises-list')).toBeVisible({ timeout: 5_000 });
+  });
+
+  // 6d. Promises screen — mark complete interaction
+  test('Promises screen mark complete button is present on open promise', async ({ page }) => {
+    await signIn(page);
+
+    await page.click('text=Promises');
+    await expect(page.getByTestId('promises-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the promise item to appear
+    await expect(
+      page.locator('[data-testid^="promise-item-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+
+    // The "Done" button should be visible on open promises
+    await expect(
+      page.locator('[data-testid^="promise-complete-"]').first()
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
   // 7. Platform connection screen — all required selectors present
   test('platform connection screen shows platform selectors', async ({ page }) => {
     await page.goto('/login');

--- a/server/tests/routes/app-factory.ts
+++ b/server/tests/routes/app-factory.ts
@@ -98,6 +98,43 @@ export function createApp() {
   });
 
   // ------------------------------------------------------------------
+  // /promises
+  // ------------------------------------------------------------------
+  const MOCK_PROMISE = {
+    id: 'promise-1',
+    user_id: 'test-user',
+    message_id: 'msg-1',
+    chat_id: 'chat-1',
+    content: "I'll send the report by Friday",
+    type: 'commitment',
+    priority: 'medium',
+    status: 'pending',
+    from_me: true,
+    created_at: new Date().toISOString(),
+  };
+
+  app.get('/promises', requireAuth, (_req, res) => {
+    res.json({ promises: [MOCK_PROMISE], total: 1 });
+  });
+  app.get('/promises/:id', requireAuth, (req, res): void => {
+    if (req.params.id !== MOCK_PROMISE.id) {
+      res.status(404).json({ error: 'Promise not found' });
+      return;
+    }
+    res.json({ promise: MOCK_PROMISE });
+  });
+  app.patch('/promises/:id', requireAuth, (req, res) => {
+    res.json({ promise: { ...MOCK_PROMISE, ...req.body, id: req.params.id } });
+  });
+  app.post('/promises/:id/snooze', requireAuth, (req, res) => {
+    const snoozedUntil = req.body?.until ?? new Date(Date.now() + 86_400_000).toISOString();
+    res.json({ promise: { ...MOCK_PROMISE, id: req.params.id, deadline: snoozedUntil } });
+  });
+  app.delete('/promises/:id', requireAuth, (_req, res) => {
+    res.json({ success: true });
+  });
+
+  // ------------------------------------------------------------------
   // 404 catch-all
   // ------------------------------------------------------------------
   app.use((_req, res) => {

--- a/server/tests/routes/routes.test.ts
+++ b/server/tests/routes/routes.test.ts
@@ -160,6 +160,83 @@ describe('/platforms', () => {
 });
 
 // ---------------------------------------------------------------------------
+// /promises
+// ---------------------------------------------------------------------------
+describe('/promises', () => {
+  it('GET / — 401 without token', async () => {
+    const res = await request.get('/promises');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('GET / — 200 with valid token, returns array', async () => {
+    const res = await request
+      .get('/promises')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.promises)).toBe(true);
+    expect(typeof res.body.total).toBe('number');
+  });
+
+  it('GET /:id — 200 for existing promise', async () => {
+    const res = await request
+      .get('/promises/promise-1')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(res.body.promise).toHaveProperty('id', 'promise-1');
+    expect(res.body.promise).toHaveProperty('status');
+    expect(res.body.promise).toHaveProperty('content');
+  });
+
+  it('GET /:id — 404 for unknown promise', async () => {
+    const res = await request
+      .get('/promises/no-such-promise')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('PATCH /:id — 401 without token', async () => {
+    const res = await request
+      .patch('/promises/promise-1')
+      .send({ status: 'completed' });
+    expect(res.status).toBe(401);
+  });
+
+  it('PATCH /:id — 200 marks promise completed', async () => {
+    const res = await request
+      .patch('/promises/promise-1')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'completed' });
+    expect(res.status).toBe(200);
+    expect(res.body.promise).toHaveProperty('status', 'completed');
+  });
+
+  it('POST /:id/snooze — 200 returns updated deadline', async () => {
+    const until = new Date(Date.now() + 2 * 86_400_000).toISOString();
+    const res = await request
+      .post('/promises/promise-1/snooze')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ until });
+    expect(res.status).toBe(200);
+    expect(res.body.promise).toHaveProperty('deadline', until);
+  });
+
+  it('DELETE /:id — 401 without token', async () => {
+    const res = await request.delete('/promises/promise-1');
+    expect(res.status).toBe(401);
+  });
+
+  it('DELETE /:id — 200 with valid token', async () => {
+    const res = await request
+      .delete('/promises/promise-1')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 404 catch-all
 // ---------------------------------------------------------------------------
 describe('404 handler', () => {


### PR DESCRIPTION
Closes #20

## Changes

- **`server/tests/routes/app-factory.ts`**: Added `/promises` route group (list, get by ID, patch, snooze, delete) to the lightweight smoke-test app factory.
- **`server/tests/routes/routes.test.ts`**: Added 9 supertest cases for `/promises` covering 401 auth guards, 404 for unknown IDs, 200 with expected response shapes, and CRUD/snooze operations.
- **`client/e2e/core-flows.spec.mjs`**: Extended with 3 new Promises screen flow tests: seeded item appears in list, tab switching (Open/Done/Overdue) works, mark-complete button is present on open promises.

## Test Results

- Server: 27 route tests pass (up from 18), 22 promise-detector unit tests pass
- Client: 10 unit tests pass, lint clean (0 errors)
- Pre-existing typecheck/lint issues (75 TS errors, ai-processor jest.mock incompatibility) unchanged

Risk: auto-merge
Verified: bun test (server route tests 27/27), bunx jest (client 10/10), promise-detector unit tests 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)