### PR TITLE
feat: contact clarification card — 'Who is X?' persists to profile (#30)

### DIFF
--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -15,6 +15,7 @@ import { usePlatformStore } from '../../stores/platformStore';
 import { PlatformBadge } from '../../components/PlatformIcon';
 import { ChatSmartCardTray } from '../../components/ChatSmartCardTray';
 import { ResponseSuggestion } from '../../components/ResponseSuggestion';
+import { ContactClarificationCard } from '../../components/ContactClarificationCard';
 import { useConversationSettingsStore } from '../../stores/conversationSettingsStore';
 import { Platform } from '../../types/platform';
 
@@ -41,9 +42,20 @@ export default function ChatScreen() {
 
   const user = useAuthStore((state) => state.user);
   const connectedSessions = usePlatformStore((state) => state.connectedSessions);
-  const { settings: convSettings, fetchSettings: fetchConvSettings, dismissCard, markCardActed } = useConversationSettingsStore();
+  const {
+    settings: convSettings,
+    fetchSettings: fetchConvSettings,
+    dismissCard,
+    markCardActed,
+    updateProfile,
+    dismissClarificationCard,
+  } = useConversationSettingsStore();
   const insets = useSafeAreaInsets();
   const smartCards = convSettings[chatId!]?.smartCards ?? [];
+  const contactProfile = convSettings[chatId!]?.profile ?? null;
+  const clarificationDismissed = convSettings[chatId!]?.clarificationDismissed ?? false;
+  // Show clarification card for 1-on-1 chats that don't yet have a relationship set
+  const showClarificationCard = is_group !== '1' && !clarificationDismissed && !contactProfile?.relationship_context;
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -385,6 +397,19 @@ export default function ChatScreen() {
             chatId={chatId!}
             messageId={[...messages].reverse().find(m => !m.from_me)?.id ?? ''}
             onSelectSuggestion={(text) => setInputText(text)}
+          />
+        )}
+
+        {/* Contact Clarification Card */}
+        {showClarificationCard && (
+          <ContactClarificationCard
+            contactName={displayName}
+            onSelect={(relationship) => {
+              if (chatId && user?.id) {
+                updateProfile(chatId, user.id, { relationship_context: relationship });
+              }
+            }}
+            onDismiss={() => chatId && dismissClarificationCard(chatId)}
           />
         )}
 

--- a/client/components/ContactClarificationCard.tsx
+++ b/client/components/ContactClarificationCard.tsx
@@ -1,0 +1,94 @@
+import { View, Text, TouchableOpacity } from 'react-native';
+import { User, Briefcase, Users, Heart, X } from 'lucide-react-native';
+
+export type RelationshipType = 'colleague' | 'friend' | 'family' | 'romantic' | 'other';
+
+interface RelationshipOption {
+  label: string;
+  value: RelationshipType;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Icon: (props: { size: number; color: string }) => any;
+  color: string;
+}
+
+const OPTIONS: RelationshipOption[] = [
+  { label: 'Colleague', value: 'colleague', Icon: Briefcase, color: '#8b5cf6' },
+  { label: 'Friend', value: 'friend', Icon: Users, color: '#3b82f6' },
+  { label: 'Family', value: 'family', Icon: Heart, color: '#ec4899' },
+  { label: 'Other', value: 'other', Icon: User, color: '#6b7280' },
+];
+
+interface ContactClarificationCardProps {
+  contactName: string;
+  onSelect: (relationship: RelationshipType) => void;
+  onDismiss: () => void;
+}
+
+export function ContactClarificationCard({
+  contactName,
+  onSelect,
+  onDismiss,
+}: ContactClarificationCardProps) {
+  return (
+    <View
+      testID="contact-clarification-card"
+      style={{
+        marginHorizontal: 12,
+        marginBottom: 8,
+        borderRadius: 16,
+        backgroundColor: '#f9fafb',
+        borderWidth: 1,
+        borderColor: '#e5e7eb',
+        padding: 14,
+      }}
+    >
+      {/* Header */}
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 12 }}>
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{ fontSize: 14, fontWeight: '600', color: '#111827' }}
+            numberOfLines={1}
+            testID="contact-clarification-prompt"
+          >
+            Who is {contactName}?
+          </Text>
+          <Text style={{ fontSize: 12, color: '#6b7280', marginTop: 2 }}>
+            Help Claire personalise replies
+          </Text>
+        </View>
+        <TouchableOpacity
+          onPress={onDismiss}
+          testID="contact-clarification-dismiss"
+          style={{ padding: 4 }}
+        >
+          <X size={16} color="#9ca3af" />
+        </TouchableOpacity>
+      </View>
+
+      {/* Options */}
+      <View style={{ flexDirection: 'row', gap: 8, flexWrap: 'wrap' }}>
+        {OPTIONS.map(({ label, value, Icon, color }) => (
+          <TouchableOpacity
+            key={value}
+            testID={`contact-clarification-option-${value}`}
+            onPress={() => onSelect(value)}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 6,
+              paddingHorizontal: 12,
+              paddingVertical: 8,
+              borderRadius: 20,
+              backgroundColor: '#ffffff',
+              borderWidth: 1,
+              borderColor: '#e5e7eb',
+            }}
+          >
+            <Icon size={13} color={color} />
+            <Text style={{ fontSize: 13, color: '#374151', fontWeight: '500' }}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -299,13 +299,41 @@ async function mockBackend(page) {
           body: JSON.stringify(MOCK_SMART_CARDS),
         });
       }
-    } else if (url.includes('/chat_categories') || url.includes('/contact_profiles')) {
-      // Settings tables — return empty (no category/profile set)
+    } else if (url.includes('/chat_categories')) {
+      // Settings table — return empty (no category set)
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(null),
       });
+    } else if (url.includes('/contact_profiles')) {
+      if (method === 'POST') {
+        // upsert (insert via POST with Prefer: resolution=merge-duplicates)
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            id: 'profile-1',
+            user_id: MOCK_USER_ID,
+            chat_id: 'mock-chat-wa-alice',
+            relationship_context: JSON.parse(route.request().postData() || '{}').relationship_context ?? null,
+            display_name: null,
+            email: null,
+            phone_number: null,
+            location: null,
+            key_facts: [],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          }]),
+        });
+      } else {
+        // GET — return null (no profile set yet, so clarification card appears)
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(null),
+        });
+      }
     } else if (url.includes('/users')) {
       await route.fulfill({
         status: 200,
@@ -678,6 +706,62 @@ test.describe('Core loop — mock backend', () => {
     await expect(
       page.getByTestId('message-card-promise-badge-msg-tg-1')
     ).not.toBeVisible();
+  });
+
+  // 11. Contact clarification card — appears in chat and answer persists to profile
+  test('contact clarification card appears and answer persists to profile', async ({ page }) => {
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Clarification card should appear (no profile set in mock)
+    await expect(page.getByTestId('contact-clarification-card')).toBeVisible({ timeout: 8_000 });
+
+    // The prompt should mention the contact name
+    await expect(page.getByTestId('contact-clarification-prompt')).toBeVisible();
+
+    // Intercept the upsert request to verify relationship_context is sent
+    const profileUpsertPromise = page.waitForRequest(
+      (req) => req.url().includes('/contact_profiles') && req.method() === 'POST',
+      { timeout: 5_000 }
+    );
+
+    // Tap "Colleague" option
+    await page.getByTestId('contact-clarification-option-colleague').click();
+
+    // Verify the upsert was fired with the right payload
+    const profileReq = await profileUpsertPromise;
+    const body = JSON.parse(profileReq.postData() || '{}');
+    expect(body.relationship_context).toBe('colleague');
+
+    // Card should disappear after selection (optimistic dismiss)
+    await expect(page.getByTestId('contact-clarification-card')).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  // 11b. Contact clarification card — dismiss hides the card
+  test('contact clarification card can be dismissed', async ({ page }) => {
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Clarification card should appear
+    await expect(page.getByTestId('contact-clarification-card')).toBeVisible({ timeout: 8_000 });
+
+    // Dismiss it
+    await page.getByTestId('contact-clarification-dismiss').click();
+
+    // Card should be gone
+    await expect(page.getByTestId('contact-clarification-card')).not.toBeVisible({ timeout: 5_000 });
   });
 
   // 9b. Smart card tray — dismissing a card removes it

--- a/client/stores/conversationSettingsStore.ts
+++ b/client/stores/conversationSettingsStore.ts
@@ -8,6 +8,8 @@ interface ChatSettings {
   profile: ContactProfile | null;
   smartCards: SmartCard[];
   isLoading: boolean;
+  /** Set to true once user dismisses or answers the clarification card */
+  clarificationDismissed: boolean;
 }
 
 interface ConversationSettingsState {
@@ -15,7 +17,9 @@ interface ConversationSettingsState {
 
   fetchSettings: (chatId: string) => Promise<void>;
   setCategory: (chatId: string, userId: string, category: ChatCategory) => Promise<void>;
-  updateProfile: (chatId: string, userId: string, updates: Partial<Pick<ContactProfile, 'display_name' | 'email' | 'phone_number' | 'location'>>) => Promise<void>;
+  updateProfile: (chatId: string, userId: string, updates: Partial<Pick<ContactProfile, 'display_name' | 'email' | 'phone_number' | 'location' | 'relationship_context'>>) => Promise<void>;
+  dismissClarificationCard: (chatId: string) => void;
+  showClarificationCard: (chatId: string) => void;
   dismissCard: (chatId: string, cardId: string) => Promise<void>;
   markCardActed: (chatId: string, cardId: string) => Promise<void>;
   generateSmartCards: (chatId: string) => Promise<void>;
@@ -27,6 +31,7 @@ const defaultSettings: ChatSettings = {
   profile: null,
   smartCards: [],
   isLoading: false,
+  clarificationDismissed: false,
 };
 
 export const useConversationSettingsStore = create<ConversationSettingsState>((set, get) => ({
@@ -68,6 +73,9 @@ export const useConversationSettingsStore = create<ConversationSettingsState>((s
             profile: profileRes.data ?? null,
             smartCards: cardsRes.data ?? [],
             isLoading: false,
+            // Preserve dismissal state: if profile now has relationship_context, keep dismissed
+            clarificationDismissed: (profileRes.data?.relationship_context != null)
+              || (state.settings[chatId]?.clarificationDismissed ?? false),
           },
         },
       }));
@@ -105,7 +113,7 @@ export const useConversationSettingsStore = create<ConversationSettingsState>((s
     }
   },
 
-  updateProfile: async (chatId: string, userId: string, updates: Partial<Pick<ContactProfile, 'display_name' | 'email' | 'phone_number' | 'location'>>) => {
+  updateProfile: async (chatId: string, userId: string, updates: Partial<Pick<ContactProfile, 'display_name' | 'email' | 'phone_number' | 'location' | 'relationship_context'>>) => {
     // Optimistic update
     set((state) => {
       const current = state.settings[chatId] || defaultSettings;
@@ -117,6 +125,8 @@ export const useConversationSettingsStore = create<ConversationSettingsState>((s
             profile: current.profile
               ? { ...current.profile, ...updates }
               : { id: '', user_id: userId, contact_id: null, chat_id: chatId, display_name: null, email: null, phone_number: null, location: null, key_facts: [], relationship_context: null, created_at: '', updated_at: '', ...updates } as ContactProfile,
+            // Once the relationship is saved, dismiss the card
+            clarificationDismissed: updates.relationship_context !== undefined ? true : current.clarificationDismissed,
           },
         },
       };
@@ -133,6 +143,30 @@ export const useConversationSettingsStore = create<ConversationSettingsState>((s
       console.error('Failed to update profile:', error);
       get().fetchSettings(chatId);
     }
+  },
+
+  dismissClarificationCard: (chatId: string) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        [chatId]: {
+          ...(state.settings[chatId] || defaultSettings),
+          clarificationDismissed: true,
+        },
+      },
+    }));
+  },
+
+  showClarificationCard: (chatId: string) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        [chatId]: {
+          ...(state.settings[chatId] || defaultSettings),
+          clarificationDismissed: false,
+        },
+      },
+    }));
   },
 
   dismissCard: async (chatId: string, cardId: string) => {


### PR DESCRIPTION
Closes #30

## Summary
- Adds `ContactClarificationCard` component: shows "Who is [name]?" with Colleague/Friend/Family/Other options in any 1-on-1 chat with no `relationship_context` set
- Extends `conversationSettingsStore` with `clarificationDismissed` flag and `relationship_context` support in `updateProfile` (upserts to `contact_profiles` via Supabase)
- Wires card into `chat/[chatId].tsx` below the AI suggestion strip
- 2 new Playwright e2e tests: answer persists to profile (verifies POST payload) + dismiss hides card

Risk: auto-merge
Verified: 23/23 Playwright mock-backend e2e tests pass (`MOCK_BRIDGE=true bunx playwright test`)