### PR TITLE
test: per-platform self-ghost / group-detection regression tests (#37)

### DIFF
--- a/server/src/adapters/matrix/event-converter.test.ts
+++ b/server/src/adapters/matrix/event-converter.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Regression tests for isGroupRoom / extractChatId per platform (issue #37).
+ *
+ * We exercise the MatrixEventConverter's DM-vs-group detection logic using
+ * lightweight fakes (no real matrix-js-sdk instantiation needed).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { MatrixEventConverter } from './event-converter';
+import { MatrixUserMapper } from './user-mapper';
+import { Platform } from '../types';
+
+const SERVER = 'claire.local';
+const userMapper = new MatrixUserMapper(SERVER);
+const converter = new MatrixEventConverter(userMapper);
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function makeMember(userId: string) {
+  return { userId } as { userId: string };
+}
+
+function makeRoom(
+  roomId: string,
+  roomName: string,
+  members: Array<{ userId: string }>
+) {
+  return {
+    roomId,
+    name: roomName,
+    getMember: (_uid: string) => null,
+    getJoinedMembers: () => members,
+  } as unknown as import('matrix-js-sdk').Room;
+}
+
+function makeEvent(senderId: string, body: string, msgtype = 'm.text') {
+  return {
+    getContent: () => ({ msgtype, body }),
+    getSender: () => senderId,
+    getId: () => 'evt-001',
+    getDate: () => new Date('2025-01-01T00:00:00Z'),
+  } as unknown as import('matrix-js-sdk').MatrixEvent;
+}
+
+// ---------------------------------------------------------------------------
+// WhatsApp — DM
+// ---------------------------------------------------------------------------
+
+describe('WhatsApp DM (1:1)', () => {
+  const selfGhost = '@whatsapp_15166100494:claire.local';
+  const otherGhost = '@whatsapp_19998887776:claire.local';
+  const room = makeRoom('!wa-dm:claire.local', 'Jane Doe', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(selfGhost),
+    makeMember(otherGhost),
+  ]);
+
+  it('chatType is individual', async () => {
+    const event = makeEvent(otherGhost, 'hello');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.chatType).toBe('individual');
+  });
+
+  it('chatId is the other contact phone number', async () => {
+    const event = makeEvent(otherGhost, 'hello');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.chatId).toBe('19998887776');
+  });
+
+  it('isFromMe is false for messages from the other side', async () => {
+    const event = makeEvent(otherGhost, 'hello');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.isFromMe).toBe(false);
+  });
+
+  it('isFromMe is true for messages from own ghost', async () => {
+    const event = makeEvent(selfGhost, 'hi back');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.isFromMe).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WhatsApp — Group
+// ---------------------------------------------------------------------------
+
+describe('WhatsApp Group', () => {
+  const selfGhost = '@whatsapp_15166100494:claire.local';
+  const member1 = '@whatsapp_19998887776:claire.local';
+  const member2 = '@whatsapp_18887776665:claire.local';
+  const room = makeRoom('!wa-grp:claire.local', 'Family Group', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(selfGhost),
+    makeMember(member1),
+    makeMember(member2),
+  ]);
+
+  it('chatType is group', async () => {
+    const event = makeEvent(member1, 'hey group');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.chatType).toBe('group');
+  });
+
+  it('chatId is the room ID for groups', async () => {
+    const event = makeEvent(member1, 'hey group');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.chatId).toBe('!wa-grp:claire.local');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WhatsApp — LID duplicates (mautrix v2 accounts)
+// A room that has both phone and LID ghosts for the same contacts must still
+// be counted as a DM (only one unique phone-based contact, ignoring LID).
+// ---------------------------------------------------------------------------
+
+describe('WhatsApp LID de-duplication', () => {
+  const selfGhost = '@whatsapp_15166100494:claire.local';
+  // Same contact, once as phone ghost, once as LID ghost
+  const phoneGhost = '@whatsapp_19998887776:claire.local';
+  const lidGhost = '@whatsapp_lid-1234567890123456789:claire.local';
+  const room = makeRoom('!wa-lid-dm:claire.local', 'John (WA)', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(selfGhost),
+    makeMember(phoneGhost),
+    makeMember(lidGhost),
+  ]);
+
+  it('chatType is individual (phone count takes precedence over LID count)', async () => {
+    const event = makeEvent(phoneGhost, 'yo');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.WHATSAPP,
+      selfGhost
+    );
+    expect(msg.chatType).toBe('individual');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telegram — DM
+// ---------------------------------------------------------------------------
+
+describe('Telegram DM', () => {
+  const otherGhost = '@_telegram_999888777:claire.local';
+  const room = makeRoom('!tg-dm:claire.local', 'Tg User', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(otherGhost),
+  ]);
+
+  it('chatType is individual', async () => {
+    const event = makeEvent(otherGhost, 'hi tg');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.TELEGRAM,
+      undefined
+    );
+    expect(msg.chatType).toBe('individual');
+  });
+
+  it('chatId is the telegram user id', async () => {
+    const event = makeEvent(otherGhost, 'hi tg');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.TELEGRAM,
+      undefined
+    );
+    expect(msg.chatId).toBe('999888777');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telegram — Group
+// ---------------------------------------------------------------------------
+
+describe('Telegram Group', () => {
+  const tg1 = '@_telegram_111:claire.local';
+  const tg2 = '@_telegram_222:claire.local';
+  const room = makeRoom('!tg-grp:claire.local', 'TG Group', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(tg1),
+    makeMember(tg2),
+  ]);
+
+  it('chatType is group', async () => {
+    const event = makeEvent(tg1, 'group msg');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.TELEGRAM,
+      undefined
+    );
+    expect(msg.chatType).toBe('group');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Instagram / Meta — DM
+// ---------------------------------------------------------------------------
+
+describe('Instagram DM', () => {
+  const igGhost = '@meta_111222333:claire.local';
+  const room = makeRoom('!ig-dm:claire.local', 'IG User', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(igGhost),
+  ]);
+
+  it('chatType is individual', async () => {
+    const event = makeEvent(igGhost, 'dm on ig');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.INSTAGRAM,
+      undefined
+    );
+    expect(msg.chatType).toBe('individual');
+  });
+
+  it('chatId is the meta user id', async () => {
+    const event = makeEvent(igGhost, 'dm on ig');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.INSTAGRAM,
+      undefined
+    );
+    expect(msg.chatId).toBe('111222333');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Instagram / Meta — Group
+// ---------------------------------------------------------------------------
+
+describe('Instagram Group', () => {
+  const ig1 = '@meta_111:claire.local';
+  const ig2 = '@meta_222:claire.local';
+  const room = makeRoom('!ig-grp:claire.local', 'IG Group', [
+    makeMember('@claire_bot:claire.local'),
+    makeMember(ig1),
+    makeMember(ig2),
+  ]);
+
+  it('chatType is group', async () => {
+    const event = makeEvent(ig1, 'group ig');
+    const msg = await converter.toUnifiedMessage(
+      event,
+      room,
+      'sess1',
+      'user1',
+      Platform.INSTAGRAM,
+      undefined
+    );
+    expect(msg.chatType).toBe('group');
+  });
+});

--- a/server/src/adapters/matrix/room-mapper.test.ts
+++ b/server/src/adapters/matrix/room-mapper.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for DM-vs-group detection per platform (issue #37).
+ *
+ * We create lightweight fakes for matrix-js-sdk Room/RoomMember to avoid
+ * loading the full SDK in a unit test context.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { MatrixRoomMapper } from './room-mapper';
+import { MatrixUserMapper } from './user-mapper';
+import { Platform } from '../types';
+
+const SERVER = 'claire.local';
+const userMapper = new MatrixUserMapper(SERVER);
+const roomMapper = new MatrixRoomMapper(userMapper);
+
+// ---------------------------------------------------------------------------
+// Minimal fakes for matrix-js-sdk Room / RoomMember
+// ---------------------------------------------------------------------------
+
+function makeMember(userId: string) {
+  return { userId } as { userId: string };
+}
+
+function makeRoom(roomId: string, members: Array<{ userId: string }>) {
+  return {
+    roomId,
+    name: 'Test Room',
+    getJoinedMembers: () => members,
+  } as unknown as import('matrix-js-sdk').Room;
+}
+
+// ---------------------------------------------------------------------------
+// detectRoomPlatform
+// ---------------------------------------------------------------------------
+
+describe('MatrixRoomMapper.detectRoomPlatform', () => {
+  it('WA: detects WhatsApp from a ghost member', () => {
+    const room = makeRoom('!wa-dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsapp_15551234567:claire.local'),
+    ]);
+    expect(roomMapper.detectRoomPlatform(room)).toBe(Platform.WHATSAPP);
+  });
+
+  it('TG: detects Telegram from a ghost member', () => {
+    const room = makeRoom('!tg-dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@_telegram_999888777:claire.local'),
+    ]);
+    expect(roomMapper.detectRoomPlatform(room)).toBe(Platform.TELEGRAM);
+  });
+
+  it('IG: detects Instagram from a ghost member', () => {
+    const room = makeRoom('!ig-dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@meta_111222333:claire.local'),
+    ]);
+    expect(roomMapper.detectRoomPlatform(room)).toBe(Platform.INSTAGRAM);
+  });
+
+  it('returns null for a room with only bridge bots', () => {
+    const room = makeRoom('!ctrl:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsappbot:claire.local'),
+    ]);
+    expect(roomMapper.detectRoomPlatform(room)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isControlRoom
+// ---------------------------------------------------------------------------
+
+describe('MatrixRoomMapper.isControlRoom', () => {
+  it('2-member room with bridge bot → control room', () => {
+    const room = makeRoom('!ctrl:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsappbot:claire.local'),
+    ]);
+    expect(roomMapper.isControlRoom(room)).toBe(true);
+  });
+
+  it('2-member room without bridge bot → not a control room', () => {
+    const room = makeRoom('!dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsapp_123:claire.local'),
+    ]);
+    expect(roomMapper.isControlRoom(room)).toBe(false);
+  });
+
+  it('3-member room → not a control room', () => {
+    const room = makeRoom('!grp:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsappbot:claire.local'),
+      makeMember('@whatsapp_456:claire.local'),
+    ]);
+    expect(roomMapper.isControlRoom(room)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrimaryChatParticipant
+// ---------------------------------------------------------------------------
+
+describe('MatrixRoomMapper.getPrimaryChatParticipant', () => {
+  it('WA 1:1: returns the other contact ID, skipping self ghost', () => {
+    const room = makeRoom('!dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsapp_15166100494:claire.local'),   // self ghost
+      makeMember('@whatsapp_19998887776:claire.local'),   // contact
+    ]);
+    const result = roomMapper.getPrimaryChatParticipant(
+      room,
+      '@whatsapp_15166100494:claire.local'
+    );
+    expect(result).toBe('19998887776');
+  });
+
+  it('TG 1:1: returns the contact ID', () => {
+    const room = makeRoom('!tg-dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@_telegram_111:claire.local'),
+    ]);
+    const result = roomMapper.getPrimaryChatParticipant(room, undefined);
+    expect(result).toBe('111');
+  });
+
+  it('IG 1:1: returns the contact ID', () => {
+    const room = makeRoom('!ig-dm:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@meta_222:claire.local'),
+    ]);
+    expect(roomMapper.getPrimaryChatParticipant(room, undefined)).toBe('222');
+  });
+
+  it('returns null when room has no ghost members', () => {
+    const room = makeRoom('!empty:claire.local', [
+      makeMember('@claire_bot:claire.local'),
+      makeMember('@whatsappbot:claire.local'),
+    ]);
+    expect(roomMapper.getPrimaryChatParticipant(room, undefined)).toBeNull();
+  });
+});

--- a/server/src/adapters/matrix/user-mapper.test.ts
+++ b/server/src/adapters/matrix/user-mapper.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression tests for per-platform self-ghost user ID patterns and DM/group detection.
+ *
+ * Acceptance: Regression tests pass for WA/TG/IG (issue #37).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { MatrixUserMapper } from './user-mapper';
+import { Platform } from '../types';
+import { GHOST_USER_PREFIXES } from './types';
+
+const SERVER = 'claire.local';
+const mapper = new MatrixUserMapper(SERVER);
+
+// ---------------------------------------------------------------------------
+// Ghost user prefix constants
+// ---------------------------------------------------------------------------
+
+describe('GHOST_USER_PREFIXES', () => {
+  it('WhatsApp prefix is whatsapp_', () => {
+    expect(GHOST_USER_PREFIXES[Platform.WHATSAPP]).toBe('whatsapp_');
+  });
+
+  it('Telegram prefix is _telegram_', () => {
+    expect(GHOST_USER_PREFIXES[Platform.TELEGRAM]).toBe('_telegram_');
+  });
+
+  it('Instagram/Meta prefix is meta_', () => {
+    expect(GHOST_USER_PREFIXES[Platform.INSTAGRAM]).toBe('meta_');
+  });
+
+  it('iMessage prefix is _imessage_', () => {
+    expect(GHOST_USER_PREFIXES[Platform.IMESSAGE]).toBe('_imessage_');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// platformContactToGhostUser — self-ghost ID construction
+// ---------------------------------------------------------------------------
+
+describe('MatrixUserMapper.platformContactToGhostUser', () => {
+  it('WA: constructs self-ghost ID for a phone number', () => {
+    expect(mapper.platformContactToGhostUser('15166100494', Platform.WHATSAPP)).toBe(
+      '@whatsapp_15166100494:claire.local'
+    );
+  });
+
+  it('TG: constructs self-ghost ID for a telegram user id', () => {
+    expect(mapper.platformContactToGhostUser('123456789', Platform.TELEGRAM)).toBe(
+      '@_telegram_123456789:claire.local'
+    );
+  });
+
+  it('IG: constructs self-ghost ID for a meta user id', () => {
+    expect(mapper.platformContactToGhostUser('987654321', Platform.INSTAGRAM)).toBe(
+      '@meta_987654321:claire.local'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ghostUserToPlatformContact — self-ghost ID parsing
+// ---------------------------------------------------------------------------
+
+describe('MatrixUserMapper.ghostUserToPlatformContact', () => {
+  const fixtures: Array<{
+    userId: string;
+    platform: Platform;
+    contactId: string;
+  }> = [
+    // WhatsApp — phone number
+    {
+      userId: '@whatsapp_15166100494:claire.local',
+      platform: Platform.WHATSAPP,
+      contactId: '15166100494',
+    },
+    // WhatsApp — LID (v2 accounts)
+    {
+      userId: '@whatsapp_lid-1234567890123456789:claire.local',
+      platform: Platform.WHATSAPP,
+      contactId: 'lid-1234567890123456789',
+    },
+    // Telegram
+    {
+      userId: '@_telegram_123456789:claire.local',
+      platform: Platform.TELEGRAM,
+      contactId: '123456789',
+    },
+    // Instagram / Meta
+    {
+      userId: '@meta_987654321:claire.local',
+      platform: Platform.INSTAGRAM,
+      contactId: '987654321',
+    },
+    // iMessage — email address
+    {
+      userId: '@_imessage_user@example.com:claire.local',
+      platform: Platform.IMESSAGE,
+      contactId: 'user@example.com',
+    },
+    // iMessage — phone number
+    {
+      userId: '@_imessage_+15556667777:claire.local',
+      platform: Platform.IMESSAGE,
+      contactId: '+15556667777',
+    },
+  ];
+
+  for (const { userId, platform, contactId } of fixtures) {
+    it(`parses ${userId}`, () => {
+      const result = mapper.ghostUserToPlatformContact(userId);
+      expect(result).not.toBeNull();
+      expect(result!.platform).toBe(platform);
+      expect(result!.platformContactId).toBe(contactId);
+    });
+  }
+
+  it('returns null for a real user (non-ghost)', () => {
+    expect(mapper.ghostUserToPlatformContact('@claire_bot:claire.local')).toBeNull();
+  });
+
+  it('returns null for a bridge bot', () => {
+    expect(mapper.ghostUserToPlatformContact('@whatsappbot:claire.local')).toBeNull();
+  });
+
+  it('returns null for a user on a different server', () => {
+    expect(mapper.ghostUserToPlatformContact('@whatsapp_123:other.server')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGhostUser
+// ---------------------------------------------------------------------------
+
+describe('MatrixUserMapper.isGhostUser', () => {
+  it('WA ghost → true', () => {
+    expect(mapper.isGhostUser('@whatsapp_15166100494:claire.local')).toBe(true);
+  });
+
+  it('TG ghost → true', () => {
+    expect(mapper.isGhostUser('@_telegram_123:claire.local')).toBe(true);
+  });
+
+  it('IG ghost → true', () => {
+    expect(mapper.isGhostUser('@meta_456:claire.local')).toBe(true);
+  });
+
+  it('bridge bot → false', () => {
+    expect(mapper.isGhostUser('@whatsappbot:claire.local')).toBe(false);
+  });
+
+  it('admin bot → false', () => {
+    expect(mapper.isGhostUser('@claire_bot:claire.local')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectPlatformFromUser
+// ---------------------------------------------------------------------------
+
+describe('MatrixUserMapper.detectPlatformFromUser', () => {
+  it('detects WhatsApp from ghost user', () => {
+    expect(mapper.detectPlatformFromUser('@whatsapp_15166100494:claire.local')).toBe(
+      Platform.WHATSAPP
+    );
+  });
+
+  it('detects Telegram from ghost user', () => {
+    expect(mapper.detectPlatformFromUser('@_telegram_123:claire.local')).toBe(
+      Platform.TELEGRAM
+    );
+  });
+
+  it('detects Instagram from ghost user', () => {
+    expect(mapper.detectPlatformFromUser('@meta_456:claire.local')).toBe(Platform.INSTAGRAM);
+  });
+
+  it('returns null for non-ghost user', () => {
+    expect(mapper.detectPlatformFromUser('@claire_bot:claire.local')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBridgeBot
+// ---------------------------------------------------------------------------
+
+describe('MatrixUserMapper.isBridgeBot', () => {
+  it('whatsappbot → true', () => {
+    expect(mapper.isBridgeBot('@whatsappbot:claire.local')).toBe(true);
+  });
+
+  it('telegrambot → true', () => {
+    expect(mapper.isBridgeBot('@telegrambot:claire.local')).toBe(true);
+  });
+
+  it('metabot → true', () => {
+    expect(mapper.isBridgeBot('@metabot:claire.local')).toBe(true);
+  });
+
+  it('imessagebot → true', () => {
+    expect(mapper.isBridgeBot('@imessagebot:claire.local')).toBe(true);
+  });
+
+  it('ghost user → false', () => {
+    expect(mapper.isBridgeBot('@whatsapp_123:claire.local')).toBe(false);
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -23,5 +23,5 @@
     "emitDecoratorMetadata": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #37

Adds 54 unit regression tests for:
- Ghost user ID construction and parsing per platform (WA/TG/IG/iMessage)
- DM-vs-group detection in `MatrixEventConverter` with platform-specific fixtures
- `MatrixRoomMapper` control-room detection and primary participant extraction
- `MatrixUserMapper` ghost detection, bot detection, and platform inference

Also excludes `*.test.ts` files from `tsc --noEmit` to prevent false `bun:test` module errors in the typecheck gate.

Risk: auto-merge
Verified: `bun test ./src/adapters/matrix/*.test.ts` → 54 pass, 0 fail