### PR TITLE
feat: register Expo push token -> server (#25)

### DIFF
--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -6,7 +6,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import * as Sentry from '@sentry/react-native';
 import { useAuthStore } from '../stores/authStore';
-import { setupNotifications } from '../services/notifications';
+import { setupNotifications, registerPushToken } from '../services/notifications';
 import '../global.css';
 
 const SENTRY_DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
@@ -35,7 +35,10 @@ export default function RootLayout() {
     async function init() {
       try {
         await initialize();
-        await setupNotifications();
+        const pushToken = await setupNotifications();
+        if (pushToken) {
+          await registerPushToken(pushToken);
+        }
       } catch (e) {
         console.error('Init error:', e);
       } finally {

--- a/client/services/notifications.ts
+++ b/client/services/notifications.ts
@@ -1,6 +1,10 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
+import Constants from 'expo-constants';
 import { platformCapabilities } from '../utils/platformCapabilities';
+import { supabase } from './supabase';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 
 if (platformCapabilities.supportsNativeNotifications) {
   Notifications.setNotificationHandler({
@@ -43,8 +47,17 @@ export async function setupNotifications() {
   }
 
   try {
+    const projectId =
+      Constants.easConfig?.projectId ??
+      Constants.expoConfig?.extra?.eas?.projectId;
+
+    if (!projectId) {
+      console.error('Cannot get Expo push token: EAS project ID is not configured');
+      return null;
+    }
+
     const token = await Notifications.getExpoPushTokenAsync({
-      projectId: 'your-project-id',
+      projectId,
     });
 
     console.log('Push token:', token.data);
@@ -52,6 +65,37 @@ export async function setupNotifications() {
   } catch (error) {
     console.error('Error getting push token:', error);
     return null;
+  }
+}
+
+/**
+ * Register an Expo push token with the server.
+ * No-op on web (graceful).
+ */
+export async function registerPushToken(token: string): Promise<void> {
+  if (!platformCapabilities.supportsNativeNotifications) {
+    logWebNoop('registerPushToken');
+    return;
+  }
+
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) return;
+
+    const response = await fetch(`${API_BASE_URL}/push-tokens`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Push token registration failed with status ${response.status}`);
+    }
+  } catch (error) {
+    console.error('Failed to register push token:', error);
   }
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import preferencesRoutes from './routes/preferences';
 import { aiRateLimit, authRateLimit } from './middleware/rate-limit';
 import seedRoutes from './routes/seed';
 import promiseRoutes from './routes/promises';
+import pushTokenRoutes from './routes/push-tokens';
 import { platformManager } from './adapters';
 import { aiProcessor } from './services/ai-processor';
 import { whatsappAdapter } from './adapters/whatsapp';
@@ -68,6 +69,7 @@ app.use('/preferences', preferencesRoutes);
 // Seed/reset route — only functional when MOCK_BRIDGE=true (guarded inside route)
 app.use('/seed', seedRoutes);
 app.use('/promises', promiseRoutes);
+app.use('/push-tokens', pushTokenRoutes);
 
 // Handle Supabase email confirmation redirects
 app.get('/', (_req, res) => {

--- a/server/src/routes/push-tokens.ts
+++ b/server/src/routes/push-tokens.ts
@@ -1,0 +1,53 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../middleware/auth';
+import { validateRequest } from '../middleware/validation';
+import { supabase } from '../services/supabase';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+const registerTokenSchema = z.object({
+  body: z.object({
+    token: z.string().min(1),
+    platform: z.string().optional(),
+    device_id: z.string().optional(),
+  }),
+});
+
+/**
+ * POST /push-tokens — register an Expo push token for the current user
+ */
+router.post(
+  '/',
+  requireAuth,
+  validateRequest(registerTokenSchema),
+  async (req: Request, res: Response) => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+    const { token, platform = 'expo', device_id } = req.body;
+
+    const { error } = await supabase
+      .from('push_tokens')
+      .upsert(
+        {
+          user_id: userId,
+          token,
+          platform,
+          device_id: device_id ?? null,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,token' }
+      );
+
+    if (error) {
+      logger.error('Error registering push token:', error);
+      return res.status(500).json({ error: 'Failed to register push token' });
+    }
+
+    return res.json({ success: true });
+  }
+);
+
+export default router;

--- a/server/tests/routes/app-factory.ts
+++ b/server/tests/routes/app-factory.ts
@@ -169,6 +169,18 @@ export function createApp() {
   });
 
   // ------------------------------------------------------------------
+  // /push-tokens
+  // ------------------------------------------------------------------
+  app.post('/push-tokens', requireAuth, (req, res): void => {
+    const { token } = req.body ?? {};
+    if (!token) {
+      res.status(400).json({ error: 'Missing required fields' });
+      return;
+    }
+    res.json({ success: true });
+  });
+
+  // ------------------------------------------------------------------
   // 404 catch-all
   // ------------------------------------------------------------------
   app.use((_req, res) => {

--- a/server/tests/routes/routes.test.ts
+++ b/server/tests/routes/routes.test.ts
@@ -351,6 +351,37 @@ describe('/preferences', () => {
 });
 
 // ---------------------------------------------------------------------------
+// /push-tokens
+// ---------------------------------------------------------------------------
+describe('/push-tokens', () => {
+  it('POST / — 401 without token', async () => {
+    const res = await request
+      .post('/push-tokens')
+      .send({ token: 'ExponentPushToken[abc123]' });
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('POST / — 400 missing token field', async () => {
+    const res = await request
+      .post('/push-tokens')
+      .set('Authorization', 'Bearer valid-token')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('POST / — 200 persists valid token', async () => {
+    const res = await request
+      .post('/push-tokens')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ token: 'ExponentPushToken[abc123]' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 404 catch-all
 // ---------------------------------------------------------------------------
 describe('404 handler', () => {

--- a/supabase/migrations/20260630000001_add_push_tokens.sql
+++ b/supabase/migrations/20260630000001_add_push_tokens.sql
@@ -1,0 +1,17 @@
+-- Push tokens: store Expo push notification tokens per user/device
+CREATE TABLE push_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL,
+  platform TEXT NOT NULL DEFAULT 'expo',
+  device_id TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(user_id, token)
+);
+
+ALTER TABLE push_tokens ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own push_tokens" ON push_tokens FOR ALL USING (auth.uid() = user_id);
+
+-- Reload PostgREST schema cache
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes #25

## Summary
- Adds \`push_tokens\` table migration (upsert on \`user_id,token\`; RLS enabled)
- Adds \`POST /push-tokens\` server route (auth-gated, validates token field)
- Wires \`registerPushToken()\` into client \`notifications.ts\` with graceful web no-op
- Calls \`registerPushToken()\` from \`_layout.tsx\` after \`setupNotifications()\` on startup

## Risk
\`risk/human-gate\` — involves DB schema migration + new server route

## Verified
- 35 route smoke tests pass (including 3 new push-token tests: 401/400/200)
- Client TypeScript typecheck: exit 0
- Web build does not crash (no-op guard in \`registerPushToken\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)