### PR TITLE
feat: media in/out — testIDs + e2e fixtures for image/audio/video/doc (#35)

### DIFF
--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -221,11 +221,12 @@ export default function ChatScreen() {
         ? `${API_BASE_URL}${item.media_url}`
         : item.media_url;
       return (
-        <View>
+        <View testID={`media-image-${item.id}`}>
           <Image
             source={{ uri: imageUri }}
             style={{ width: 220, height: 160, borderRadius: 10, marginBottom: 4 }}
             resizeMode="cover"
+            testID={`media-image-img-${item.id}`}
           />
           {item.content ? (
             <Text style={{ fontSize: 14, color: textColor, marginTop: 2 }}>{item.content}</Text>
@@ -236,7 +237,7 @@ export default function ChatScreen() {
 
     if (type === 'image') {
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+        <View testID={`media-image-${item.id}`} style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
           <ImageIcon size={16} color={iconColor} />
           <Text style={{ fontSize: 14, color: textColor }}>Photo</Text>
         </View>
@@ -245,7 +246,7 @@ export default function ChatScreen() {
 
     if (type === 'audio') {
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <View testID={`media-audio-${item.id}`} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
           <Volume2 size={16} color={iconColor} />
           <Text style={{ fontSize: 14, color: textColor }}>
             {item.content || 'Voice message'}
@@ -256,7 +257,7 @@ export default function ChatScreen() {
 
     if (type === 'video') {
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <View testID={`media-video-${item.id}`} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
           <Video size={16} color={iconColor} />
           <Text style={{ fontSize: 14, color: textColor }}>
             {item.content || 'Video'}
@@ -267,7 +268,7 @@ export default function ChatScreen() {
 
     if (type === 'document') {
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <View testID={`media-document-${item.id}`} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
           <FileText size={16} color={iconColor} />
           <Text style={{ fontSize: 14, color: textColor }}>
             {item.content || 'File'}

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -111,6 +111,50 @@ const MOCK_CHAT_MESSAGES = [
     contact_name: null,
     content_type: 'text',
   },
+  {
+    id: 'chatmsg-img',
+    content: 'Check out this photo',
+    timestamp: new Date(Date.now() - 3500_000).toISOString(),
+    from_me: false,
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content_type: 'image',
+    media_url: '/media/claire.local/abc123img',
+    media_mime_type: 'image/jpeg',
+  },
+  {
+    id: 'chatmsg-audio',
+    content: '',
+    timestamp: new Date(Date.now() - 3400_000).toISOString(),
+    from_me: false,
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content_type: 'audio',
+    media_url: '/media/claire.local/abc123audio',
+    media_mime_type: 'audio/ogg',
+  },
+  {
+    id: 'chatmsg-video',
+    content: 'Short clip',
+    timestamp: new Date(Date.now() - 3300_000).toISOString(),
+    from_me: false,
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content_type: 'video',
+    media_url: '/media/claire.local/abc123video',
+    media_mime_type: 'video/mp4',
+  },
+  {
+    id: 'chatmsg-doc',
+    content: 'report.pdf',
+    timestamp: new Date(Date.now() - 3200_000).toISOString(),
+    from_me: false,
+    contact_name: 'Alice (WA)',
+    contact_phone: '+15551234567',
+    content_type: 'document',
+    media_url: '/media/claire.local/abc123doc',
+    media_mime_type: 'application/pdf',
+  },
 ];
 
 const MOCK_AI_SUGGESTIONS = [
@@ -431,6 +475,19 @@ async function mockBackend(page) {
   // Supabase realtime — stub WebSocket preflight requests
   await page.route('**/realtime/**', async (route) => {
     await route.fulfill({ status: 200, body: '{}' });
+  });
+
+  // Matrix media proxy — return a 1x1 PNG for any /media/ requests
+  const TINY_PNG = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'base64'
+  );
+  await page.route('**/media/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: TINY_PNG,
+    });
   });
 }
 
@@ -844,6 +901,75 @@ test.describe('Core loop — mock backend', () => {
     await expect(
       page.getByTestId('urgent-cards-container').getByText('Alice (WA)')
     ).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 13. Media in — incoming image fixture renders in chat (#35)
+  test('incoming image message renders in chat', async ({ page }) => {
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+
+    // The image fixture message should render (testID added in this ticket)
+    await expect(page.getByTestId('media-image-chatmsg-img')).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 13b. Media in — audio, video, and document fixtures render in chat (#35)
+  test('incoming audio, video, and document messages render in chat', async ({ page }) => {
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+
+    // Audio fixture
+    await expect(page.getByTestId('media-audio-chatmsg-audio')).toBeVisible({ timeout: 8_000 });
+    // Video fixture
+    await expect(page.getByTestId('media-video-chatmsg-video')).toBeVisible({ timeout: 8_000 });
+    // Document fixture
+    await expect(page.getByTestId('media-document-chatmsg-doc')).toBeVisible({ timeout: 8_000 });
+  });
+
+  // 13c. Media send path — send button dispatches to platform API (#35)
+  test('send path: text message dispatches to platform send API', async ({ page }) => {
+    await signIn(page);
+
+    const sessionsResponsePromise = page.waitForResponse('**/platforms/**', { timeout: 10_000 }).catch(() => null);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+
+    await sessionsResponsePromise;
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-input')).toBeVisible({ timeout: 8_000 });
+
+    // Intercept the send API call
+    const sendRequestPromise = page.waitForRequest(
+      (req) => req.url().includes('/send') && req.method() === 'POST',
+      { timeout: 8_000 }
+    );
+
+    await page.getByTestId('chat-input').fill('Test media send path');
+    await page.getByTestId('chat-send-button').click();
+
+    // Verify the send API was called
+    const sendReq = await sendRequestPromise;
+    expect(sendReq).toBeTruthy();
+
+    // Input should be cleared after send
+    await expect(page.getByTestId('chat-input')).toHaveValue('', { timeout: 5_000 });
   });
 });
 


### PR DESCRIPTION
Closes #35

## Changes

- Added `testID` props to all media message bubble variants in `chat/[chatId].tsx`: `media-image-{id}`, `media-audio-{id}`, `media-video-{id}`, `media-document-{id}`
- Added 4 media fixture messages (image with `/media/` URL, audio, video, document) to `MOCK_CHAT_MESSAGES` in `core-flows.spec.mjs`
- Added `/media/**` proxy stub to `mockBackend()` returning a 1×1 PNG so image loads don't 404
- Added 3 new Playwright e2e tests:
  1. Incoming image message renders (checks `media-image-chatmsg-img`)
  2. Incoming audio/video/document messages render
  3. Send path dispatches to platform API (verifies `POST /send` is called)

Risk: auto-merge
Verified: all 33 Playwright e2e tests pass locally with `MOCK_BRIDGE=true bunx playwright test`