### PR TITLE
feat: wire GroupChatSummary to /ai/group-summary endpoint (#41)

### DIFF
--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -17,6 +17,7 @@ import { ChatSmartCardTray } from '../../components/ChatSmartCardTray';
 import { ResponseSuggestion } from '../../components/ResponseSuggestion';
 import { ContactClarificationCard } from '../../components/ContactClarificationCard';
 import { useConversationSettingsStore } from '../../stores/conversationSettingsStore';
+import { GroupChatSummary } from '../../components/GroupChatSummary';
 import { Platform } from '../../types/platform';
 
 interface ChatMessage {
@@ -369,6 +370,11 @@ export default function ChatScreen() {
         behavior={RNPlatform.OS === 'ios' ? 'padding' : 'height'}
         keyboardVerticalOffset={0}
       >
+        {/* Group Summary Banner — only shown for group chats */}
+        {is_group === '1' && chatId && (
+          <GroupChatSummary chatId={chatId} />
+        )}
+
         {loading ? (
           <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }} testID="chat-loading">
             <ActivityIndicator size="large" color="#10b981" />

--- a/client/components/GroupChatSummary.tsx
+++ b/client/components/GroupChatSummary.tsx
@@ -1,292 +1,92 @@
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useState, useEffect } from 'react';
-import { Users, TrendingUp, Clock, ChevronRight } from 'lucide-react-native';
-import { supabase } from '../services/supabase';
-import { formatDistanceToNow } from 'date-fns';
+import { Users, ChevronDown, ChevronUp } from 'lucide-react-native';
+import { API_BASE_URL } from '../services/platforms';
+import { useAuthStore } from '../stores/authStore';
 
 interface GroupChatSummaryProps {
   chatId: string;
-  userId: string;
-  onViewDetails?: () => void;
 }
 
-interface GroupStats {
-  totalMessages: number;
-  activeParticipants: number;
-  lastActivityTime: string;
-  topContributors: Array<{
-    name: string;
-    messageCount: number;
-    percentage: number;
-  }>;
-  recentTopics: string[];
-  peakActivityHour: number;
-  averageResponseTime: number;
-}
-
-export function GroupChatSummary({ chatId, userId, onViewDetails }: GroupChatSummaryProps) {
-  const [stats, setStats] = useState<GroupStats | null>(null);
-  const [loading, setLoading] = useState(true);
+export function GroupChatSummary({ chatId }: GroupChatSummaryProps) {
+  const token = useAuthStore((state) => state.token);
+  const [summary, setSummary] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
-    fetchGroupStats();
-  }, [chatId]);
+    if (expanded && !summary && !loading) {
+      fetchSummary();
+    }
+  }, [expanded]);
 
-  const fetchGroupStats = async () => {
+  const fetchSummary = async () => {
+    setLoading(true);
+    setError(null);
     try {
-      // Fetch group messages
-      const { data: messages, error } = await supabase
-        .from('messages')
-        .select('*')
-        .eq('whatsapp_chat_id', chatId)
-        .eq('user_id', userId)
-        .eq('is_group', true)
-        .order('timestamp', { ascending: false })
-        .limit(500);
-
-      if (error) throw error;
-
-      if (!messages || messages.length === 0) {
-        setLoading(false);
-        return;
+      const resp = await fetch(`${API_BASE_URL}/api/ai/group-summary/${encodeURIComponent(chatId)}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const json = await resp.json();
+      if (json.success && json.data?.summary) {
+        setSummary(json.data.summary);
+      } else {
+        throw new Error('Invalid response');
       }
-
-      // Calculate statistics
-      const participantMap = new Map<string, number>();
-      const hourMap = new Map<number, number>();
-      let totalResponseTime = 0;
-      let responseCount = 0;
-
-      messages.forEach((msg, index) => {
-        // Count messages per participant
-        const participant = msg.contact_name || 'Unknown';
-        participantMap.set(participant, (participantMap.get(participant) || 0) + 1);
-
-        // Track peak activity hours
-        const hour = new Date(msg.timestamp).getHours();
-        hourMap.set(hour, (hourMap.get(hour) || 0) + 1);
-
-        // Calculate response times
-        if (index > 0 && !msg.from_me) {
-          const prevMsg = messages[index - 1];
-          if (prevMsg.from_me) {
-            const responseTime = new Date(msg.timestamp).getTime() - new Date(prevMsg.timestamp).getTime();
-            totalResponseTime += responseTime;
-            responseCount++;
-          }
-        }
-      });
-
-      // Get top contributors
-      const topContributors = Array.from(participantMap.entries())
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 5)
-        .map(([name, count]) => ({
-          name,
-          messageCount: count,
-          percentage: Math.round((count / messages.length) * 100),
-        }));
-
-      // Find peak activity hour
-      let peakHour = 0;
-      let peakCount = 0;
-      hourMap.forEach((count, hour) => {
-        if (count > peakCount) {
-          peakCount = count;
-          peakHour = hour;
-        }
-      });
-
-      // Extract recent topics (simplified - just look for frequently used words)
-      const recentMessages = messages.slice(0, 50);
-      const wordFrequency = new Map<string, number>();
-      
-      recentMessages.forEach(msg => {
-        const words = msg.content.toLowerCase().split(/\s+/);
-        words.forEach((word: string) => {
-          if (word.length > 4 && !['hello', 'thanks', 'please', 'today'].includes(word)) {
-            wordFrequency.set(word, (wordFrequency.get(word) || 0) + 1);
-          }
-        });
-      });
-
-      const recentTopics = Array.from(wordFrequency.entries())
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 3)
-        .map(([word]) => word);
-
-      setStats({
-        totalMessages: messages.length,
-        activeParticipants: participantMap.size,
-        lastActivityTime: messages[0].timestamp,
-        topContributors,
-        recentTopics,
-        peakActivityHour: peakHour,
-        averageResponseTime: responseCount > 0 ? totalResponseTime / responseCount / 1000 / 60 : 0, // in minutes
-      });
-    } catch (error) {
-      console.error('Error fetching group stats:', error);
+    } catch {
+      setError('Could not load summary.');
     } finally {
       setLoading(false);
     }
   };
 
-  if (loading) {
-    return (
-      <View className="bg-white dark:bg-gray-800 rounded-lg p-4 m-4">
-        <Text className="text-gray-500 dark:text-gray-400">Loading group statistics...</Text>
-      </View>
-    );
-  }
-
-  if (!stats) {
-    return null;
-  }
-
-  const formatHour = (hour: number) => {
-    if (hour === 0) return '12 AM';
-    if (hour === 12) return '12 PM';
-    return hour > 12 ? `${hour - 12} PM` : `${hour} AM`;
-  };
-
   return (
-    <View className="bg-white dark:bg-gray-800 rounded-lg m-4 overflow-hidden">
+    <View
+      testID="group-chat-summary"
+      style={{
+        backgroundColor: '#f0fdf4',
+        borderTopWidth: 1,
+        borderTopColor: '#d1fae5',
+        paddingHorizontal: 16,
+        paddingVertical: 10,
+      }}
+    >
       <TouchableOpacity
-        onPress={() => setExpanded(!expanded)}
-        className="p-4"
+        onPress={() => setExpanded((v) => !v)}
+        style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
+        testID="group-chat-summary-toggle"
       >
-        {/* Header */}
-        <View className="flex-row items-center justify-between mb-3">
-          <View className="flex-row items-center">
-            <Users size={20} color="#3b82f6" />
-            <Text className="ml-2 text-lg font-semibold text-gray-900 dark:text-white">
-              Group Activity Summary
-            </Text>
-          </View>
-          <View style={{ transform: [{ rotate: expanded ? '90deg' : '0deg' }] }}>
-            <ChevronRight 
-              size={20} 
-              color="#6b7280"
-            />
-          </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <Users size={16} color="#10b981" />
+          <Text style={{ fontSize: 13, fontWeight: '600', color: '#065f46' }}>
+            Group Summary
+          </Text>
         </View>
-
-        {/* Quick Stats */}
-        <View className="flex-row justify-between">
-          <View className="flex-1">
-            <Text className="text-2xl font-bold text-gray-900 dark:text-white">
-              {stats.totalMessages}
-            </Text>
-            <Text className="text-xs text-gray-500 dark:text-gray-400">
-              Total Messages
-            </Text>
-          </View>
-          <View className="flex-1">
-            <Text className="text-2xl font-bold text-gray-900 dark:text-white">
-              {stats.activeParticipants}
-            </Text>
-            <Text className="text-xs text-gray-500 dark:text-gray-400">
-              Active Members
-            </Text>
-          </View>
-          <View className="flex-1">
-            <Text className="text-sm font-medium text-gray-900 dark:text-white">
-              {formatDistanceToNow(new Date(stats.lastActivityTime), { addSuffix: true })}
-            </Text>
-            <Text className="text-xs text-gray-500 dark:text-gray-400">
-              Last Activity
-            </Text>
-          </View>
-        </View>
+        {expanded ? (
+          <ChevronUp size={16} color="#6b7280" />
+        ) : (
+          <ChevronDown size={16} color="#6b7280" />
+        )}
       </TouchableOpacity>
 
-      {/* Expanded Details */}
       {expanded && (
-        <View className="px-4 pb-4 border-t border-gray-200 dark:border-gray-700 mt-3 pt-3">
-          {/* Top Contributors */}
-          <View className="mb-4">
-            <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Top Contributors
+        <View style={{ marginTop: 8 }} testID="group-chat-summary-content">
+          {loading ? (
+            <ActivityIndicator size="small" color="#10b981" testID="group-chat-summary-loading" />
+          ) : error ? (
+            <Text style={{ fontSize: 13, color: '#dc2626' }} testID="group-chat-summary-error">
+              {error}
             </Text>
-            {stats.topContributors.map((contributor, index) => (
-              <View key={index} className="flex-row items-center justify-between mb-1">
-                <Text className="text-sm text-gray-600 dark:text-gray-400">
-                  {contributor.name}
-                </Text>
-                <View className="flex-row items-center">
-                  <View className="bg-gray-200 dark:bg-gray-700 rounded-full h-2 w-20 mr-2">
-                    <View 
-                      className="bg-blue-500 rounded-full h-2"
-                      style={{ width: `${contributor.percentage}%` }}
-                    />
-                  </View>
-                  <Text className="text-xs text-gray-500 dark:text-gray-400 w-10 text-right">
-                    {contributor.percentage}%
-                  </Text>
-                </View>
-              </View>
-            ))}
-          </View>
-
-          {/* Activity Insights */}
-          <View className="flex-row justify-between mb-4">
-            <View className="flex-1 mr-2">
-              <View className="flex-row items-center mb-1">
-                <Clock size={14} color="#6b7280" />
-                <Text className="ml-1 text-xs font-medium text-gray-700 dark:text-gray-300">
-                  Peak Activity
-                </Text>
-              </View>
-              <Text className="text-sm text-gray-600 dark:text-gray-400">
-                {formatHour(stats.peakActivityHour)}
-              </Text>
-            </View>
-            <View className="flex-1">
-              <View className="flex-row items-center mb-1">
-                <TrendingUp size={14} color="#6b7280" />
-                <Text className="ml-1 text-xs font-medium text-gray-700 dark:text-gray-300">
-                  Avg Response
-                </Text>
-              </View>
-              <Text className="text-sm text-gray-600 dark:text-gray-400">
-                {stats.averageResponseTime.toFixed(0)} min
-              </Text>
-            </View>
-          </View>
-
-          {/* Recent Topics */}
-          {stats.recentTopics.length > 0 && (
-            <View>
-              <Text className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Trending Topics
-              </Text>
-              <View className="flex-row flex-wrap">
-                {stats.recentTopics.map((topic, index) => (
-                  <View 
-                    key={index}
-                    className="bg-blue-100 dark:bg-blue-900/30 rounded-full px-3 py-1 mr-2 mb-2"
-                  >
-                    <Text className="text-xs text-blue-600 dark:text-blue-400">
-                      {topic}
-                    </Text>
-                  </View>
-                ))}
-              </View>
-            </View>
-          )}
-
-          {/* View Details Button */}
-          {onViewDetails && (
-            <TouchableOpacity
-              onPress={onViewDetails}
-              className="bg-blue-500 rounded-lg py-2 mt-3"
+          ) : summary ? (
+            <Text
+              style={{ fontSize: 13, color: '#374151', lineHeight: 19 }}
+              testID="group-chat-summary-text"
             >
-              <Text className="text-white text-center font-medium">
-                View Full Analytics
-              </Text>
-            </TouchableOpacity>
-          )}
+              {summary}
+            </Text>
+          ) : null}
         </View>
       )}
     </View>

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -252,6 +252,32 @@ const MOCK_CHATS = [
   },
 ];
 
+// Group chat fixture — used by the group-summary e2e test
+const MOCK_GROUP_CHAT_ID = 'mock-chat-wa-group-1';
+const MOCK_GROUP_INBOX_MESSAGE = {
+  id: 'msg-group-1',
+  chat_id: MOCK_GROUP_CHAT_ID,
+  contact_name: null,
+  chat_name: 'Friday Crew',
+  contact_phone: null,
+  content: 'Hey team, meeting at 3pm!',
+  timestamp: new Date(Date.now() - 1800_000).toISOString(),
+  from_me: false,
+  is_group: true,
+  platform: 'whatsapp',
+  platform_message_id: 'wa-group-msg-1',
+  status: 'delivered',
+  chats: { name: 'Friday Crew', platform_chat_id: MOCK_GROUP_CHAT_ID },
+  ai_suggestions: [],
+};
+
+const MOCK_GROUP_SUMMARY_RESP = {
+  success: true,
+  data: {
+    summary: 'The group discussed meeting logistics and upcoming plans. (mock summary)',
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Route mocking helper — intercept all Supabase + server API calls.
 //
@@ -479,6 +505,15 @@ async function mockBackend(page) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ success: true, data: MOCK_MORNING_BRIEF }),
+    });
+  });
+
+  // Bun server API: group summary
+  await page.route('**/ai/group-summary/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_GROUP_SUMMARY_RESP),
     });
   });
 
@@ -1057,6 +1092,80 @@ test.describe('Core loop — mock backend', () => {
     if (firstCardTestId) {
       await expect(page.getByTestId(firstCardTestId)).toBeVisible({ timeout: 3_000 });
     }
+  });
+
+  // 15. Group-chat summary — banner renders and shows summary text after expand (#41)
+  test('group chat summary banner renders and shows summary on expand', async ({ page }) => {
+    // Override the messages endpoint to return a group message as the first inbox entry
+    await page.route('**/rest/v1/**', async (route) => {
+      const url = route.request().url();
+      if (url.includes('/messages')) {
+        if (url.includes('chat_id=eq.')) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              {
+                id: 'gchatmsg-1',
+                content: 'Hey team, meeting at 3pm!',
+                timestamp: new Date(Date.now() - 1800_000).toISOString(),
+                from_me: false,
+                contact_name: 'Alice',
+                contact_phone: null,
+                content_type: 'text',
+              },
+            ]),
+          });
+        } else {
+          // Inbox: return only the group message so the first card leads to a group chat
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([MOCK_GROUP_INBOX_MESSAGE, ...MOCK_INBOX_MESSAGES]),
+          });
+        }
+      } else if (url.includes('/chats')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: MOCK_GROUP_CHAT_ID,
+            user_id: MOCK_USER_ID,
+            platform: 'whatsapp',
+            platform_chat_id: MOCK_GROUP_CHAT_ID,
+            name: 'Friday Crew',
+          }),
+        });
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      }
+    });
+
+    await signIn(page);
+
+    // First message card should be the group chat
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+
+    // Navigate into the group chat (first card = Friday Crew)
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+
+    // Group summary banner should be present for group chats
+    await expect(page.getByTestId('group-chat-summary')).toBeVisible({ timeout: 8_000 });
+
+    // Tap the toggle to expand
+    await page.getByTestId('group-chat-summary-toggle').click();
+
+    // Summary content area should appear
+    await expect(page.getByTestId('group-chat-summary-content')).toBeVisible({ timeout: 5_000 });
+
+    // Summary text (mocked) should appear
+    await expect(
+      page.getByText('The group discussed meeting logistics and upcoming plans.')
+    ).toBeVisible({ timeout: 8_000 });
   });
 });
 

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -377,4 +377,72 @@ router.get('/morning-brief',
   }
 );
 
+/**
+ * GET /ai/group-summary/:chatId
+ * Returns an AI-generated text summary of recent group-chat activity.
+ *
+ * In MOCK_BRIDGE mode (no real AI configured) the endpoint returns a
+ * deterministic canned summary so Playwright e2e tests pass with zero
+ * external deps.
+ */
+router.get('/group-summary/:chatId',
+  requireAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'User not authenticated' });
+      }
+
+      const { chatId } = req.params;
+
+      // Fetch the 50 most-recent messages for this group chat
+      const { data: messages, error } = await supabase
+        .from('messages')
+        .select('content, contact_name, timestamp, from_me')
+        .eq('chat_id', chatId)
+        .eq('user_id', userId)
+        .order('timestamp', { ascending: false })
+        .limit(50);
+
+      if (error) throw error;
+
+      if (!messages || messages.length === 0) {
+        return res.json({
+          success: true,
+          data: { summary: 'No messages yet in this group.' },
+        });
+      }
+
+      // Build a compact transcript for the AI prompt
+      const transcript = messages
+        .slice()
+        .reverse()
+        .map((m) => `${m.contact_name || (m.from_me ? 'You' : 'Unknown')}: ${m.content}`)
+        .join('\n');
+
+      let summary: string;
+
+      if (!aiProcessor.isConfigured) {
+        // Mock mode — deterministic fallback so tests pass without real AI
+        const participants = new Set(messages.map((m) => m.contact_name || 'Unknown'));
+        summary = `This group has ${messages.length} recent messages from ${participants.size} participant${participants.size === 1 ? '' : 's'}. Topics discussed include updates and coordination. (mock summary)`;
+      } else {
+        summary = await aiProcessor.summarizeText(
+          'You are a concise assistant. Summarize the following group chat transcript in 2-3 sentences, focusing on the main topics and any action items.',
+          transcript,
+        );
+      }
+
+      res.json({
+        success: true,
+        data: { summary },
+      });
+    } catch (error) {
+      logger.error('Error generating group summary:', error);
+      res.status(500).json({ success: false, error: 'Failed to generate group summary' });
+    }
+  }
+);
+
 export default router;

--- a/server/src/services/ai-processor.ts
+++ b/server/src/services/ai-processor.ts
@@ -346,6 +346,13 @@ class AIProcessor {
       return [];
     }
   }
+
+  /**
+   * Summarize a block of text (e.g. a group-chat transcript).
+   */
+  async summarizeText(systemPrompt: string, userPrompt: string): Promise<string> {
+    return this.callAI(systemPrompt, userPrompt);
+  }
 }
 
 export const aiProcessor = new AIProcessor();


### PR DESCRIPTION
Closes #41

## Summary
- Added \`GET /ai/group-summary/:chatId\` server route that fetches the 50 most-recent group messages and returns an AI-generated text summary (falls back to a deterministic mock-mode summary when no AI provider is configured)
- Added \`summarizeText()\` public method on \`AIProcessor\` to expose \`callAI\` without breaking encapsulation
- Rewrote \`GroupChatSummary.tsx\` to call the endpoint on demand (expand toggle) instead of doing client-side statistical analysis
- Integrated the component into the chat screen — it renders for group chats (\`is_group=1\`) above the message list
- Added Playwright e2e test 15: group fixture, open group chat, verify summary banner, expand, assert summary text renders

## Test plan
- [x] \`bun run lint\` — 0 errors (warnings are pre-existing)
- [x] \`bun run typecheck\` — passes
- [x] \`bun test\` (server) — 72/74 pass (2 pre-existing failures)
- [x] \`bun test\` (client) — 5/7 pass (2 pre-existing failures)
- [x] \`MOCK_BRIDGE=true bunx playwright test\` — **37/37 passed** including new group-summary test

Risk: auto-merge
Verified: all 37 Playwright e2e tests pass, including new group-summary test

🤖 Generated with [Claude Code](https://claude.com/claude-code)