### PR TITLE
feat: on-demand 'Draft reply' button (#22)

### DIFF
--- a/client/app/chat/[chatId].tsx
+++ b/client/app/chat/[chatId].tsx
@@ -398,14 +398,19 @@ export default function ChatScreen() {
           />
         )}
 
-        {/* AI Response Suggestions */}
-        {messages.filter(m => !m.from_me).length > 0 && (
-          <ResponseSuggestion
-            chatId={chatId!}
-            messageId={[...messages].reverse().find(m => !m.from_me)?.id ?? ''}
-            onSelectSuggestion={(text) => setInputText(text)}
-          />
-        )}
+        {/* AI Response Suggestions / Draft reply button */}
+        {messages.filter(m => !m.from_me).length > 0 && (() => {
+          const lastInbound = [...messages].reverse().find(m => !m.from_me);
+          return (
+            <ResponseSuggestion
+              chatId={chatId!}
+              messageId={lastInbound?.id ?? ''}
+              messageContent={lastInbound?.content}
+              isGroup={is_group === '1'}
+              onSelectSuggestion={(text) => setInputText(text)}
+            />
+          );
+        })()}
 
         {/* Contact Clarification Card */}
         {showClarificationCard && (

--- a/client/components/ResponseSuggestion.tsx
+++ b/client/components/ResponseSuggestion.tsx
@@ -2,10 +2,13 @@ import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator } from 'rea
 import { useState, useEffect } from 'react';
 import { Sparkles, Send, RefreshCw, ThumbsUp, ThumbsDown } from 'lucide-react-native';
 import { supabase } from '../services/supabase';
+import { platformsApi } from '../services/platforms';
 
 interface ResponseSuggestionProps {
   messageId: string;
   chatId: string;
+  messageContent?: string;
+  isGroup?: boolean;
   suggestions?: string[];
   onSelectSuggestion: (suggestion: string) => void;
   onGenerateNew?: () => void;
@@ -22,6 +25,8 @@ interface AISuggestion {
 
 export function ResponseSuggestion({
   messageId,
+  messageContent,
+  isGroup,
   suggestions: propSuggestions,
   onSelectSuggestion,
   onGenerateNew,
@@ -29,6 +34,8 @@ export function ResponseSuggestion({
 }: ResponseSuggestionProps) {
   const [suggestions, setSuggestions] = useState<AISuggestion[]>([]);
   const [loading, setLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   useEffect(() => {
@@ -74,6 +81,25 @@ export function ResponseSuggestion({
       console.error('Error fetching AI suggestions:', error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDraftReply = async () => {
+    if (!messageContent || generating) return;
+    setGenerating(true);
+    setGenerateError(null);
+    try {
+      const draft = await platformsApi.generateDraftReply(
+        messageId,
+        messageContent,
+        isGroup ? 'group' : 'individual'
+      );
+      onSelectSuggestion(draft);
+    } catch (err) {
+      console.error('Draft reply generation failed:', err);
+      setGenerateError('Could not generate a draft. Please try again.');
+    } finally {
+      setGenerating(false);
     }
   };
 
@@ -138,8 +164,49 @@ export function ResponseSuggestion({
     );
   }
 
+  // No stored suggestions — show "Draft reply" button if messageContent available
   if (suggestions.length === 0) {
-    return null;
+    if (!messageContent) return null;
+    return (
+      <View
+        style={{
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          alignItems: 'flex-start',
+        }}
+        testID="draft-reply-container"
+      >
+        <TouchableOpacity
+          onPress={handleDraftReply}
+          disabled={generating}
+          testID="draft-reply-button"
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: generating ? '#e5e7eb' : '#eff6ff',
+            borderRadius: 16,
+            paddingHorizontal: 12,
+            paddingVertical: 7,
+            borderWidth: 1,
+            borderColor: generating ? '#d1d5db' : '#bfdbfe',
+          }}
+        >
+          {generating ? (
+            <ActivityIndicator size="small" color="#3b82f6" style={{ marginRight: 6 }} />
+          ) : (
+            <Sparkles size={14} color="#3b82f6" style={{ marginRight: 6 }} />
+          )}
+          <Text style={{ fontSize: 13, color: generating ? '#9ca3af' : '#2563eb', fontWeight: '500' }}>
+            {generating ? 'Drafting…' : 'Draft reply'}
+          </Text>
+        </TouchableOpacity>
+        {generateError && (
+          <Text style={{ fontSize: 12, color: '#dc2626', marginTop: 4 }} testID="draft-reply-error">
+            {generateError}
+          </Text>
+        )}
+      </View>
+    );
   }
 
   return (
@@ -199,9 +266,9 @@ export function ResponseSuggestion({
                       suggestion.feedback === 'positive' ? 'bg-green-100 dark:bg-green-900/30 rounded' : ''
                     }`}
                   >
-                    <ThumbsUp 
-                      size={14} 
-                      color={suggestion.feedback === 'positive' ? '#10b981' : '#6b7280'} 
+                    <ThumbsUp
+                      size={14}
+                      color={suggestion.feedback === 'positive' ? '#10b981' : '#6b7280'}
                     />
                   </TouchableOpacity>
                   <TouchableOpacity
@@ -210,9 +277,9 @@ export function ResponseSuggestion({
                       suggestion.feedback === 'negative' ? 'bg-red-100 dark:bg-red-900/30 rounded' : ''
                     }`}
                   >
-                    <ThumbsDown 
-                      size={14} 
-                      color={suggestion.feedback === 'negative' ? '#ef4444' : '#6b7280'} 
+                    <ThumbsDown
+                      size={14}
+                      color={suggestion.feedback === 'negative' ? '#ef4444' : '#6b7280'}
                     />
                   </TouchableOpacity>
                 </View>

--- a/client/e2e/core-flows.spec.mjs
+++ b/client/e2e/core-flows.spec.mjs
@@ -526,6 +526,22 @@ async function mockBackend(page) {
     });
   });
 
+  // Bun server API: on-demand AI response generation (POST /ai/responses/generate)
+  await page.route('**/ai/responses/generate**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          messageId: 'chatmsg-1',
+          suggestions: ['Sure, I can do that!', 'Sounds good, let me check.'],
+          confidence: 0.9,
+        },
+      }),
+    });
+  });
+
   // Supabase realtime — stub WebSocket preflight requests
   await page.route('**/realtime/**', async (route) => {
     await route.fulfill({ status: 200, body: '{}' });
@@ -732,6 +748,62 @@ test.describe('Core loop — mock backend', () => {
     await expect(page.getByTestId('chat-input')).toHaveValue(
       'Sounds great, but let me check my schedule first!',
       { timeout: 3_000 }
+    );
+  });
+
+  // 5e. On-demand "Draft reply" button — tapping fills the composer via /ai/responses/generate (#22)
+  test('draft reply button populates composer via on-demand generate', async ({ page }) => {
+    // Override ai_suggestions to return empty (no pre-stored suggestions) so the
+    // Draft reply button is shown instead of the suggestion strip.
+    await page.route('**/rest/v1/**', async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+      if (url.includes('/ai_suggestions')) {
+        // Return empty list for both GET and PATCH
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      } else if (url.includes('/messages')) {
+        if (url.includes('chat_id=eq.')) {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_CHAT_MESSAGES) });
+        } else {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_INBOX_MESSAGES) });
+        }
+      } else if (url.includes('/chats')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_CHATS[0]) });
+      } else if (url.includes('/platform_sessions')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_PLATFORM_SESSIONS) });
+      } else if (url.includes('/smart_cards')) {
+        if (method === 'PATCH') {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+        } else {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+        }
+      } else if (url.includes('/contact_profiles')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(null) });
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      }
+    });
+
+    await signIn(page);
+
+    await expect(
+      page.locator('[data-testid^="message-card-"]').first()
+    ).toBeVisible({ timeout: 8_000 });
+    await page.locator('[data-testid^="message-card-"]').first().click();
+
+    await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+
+    // Draft reply button should appear (no stored suggestions)
+    await expect(page.getByTestId('draft-reply-button')).toBeVisible({ timeout: 8_000 });
+
+    // Tap the button — calls /ai/responses/generate (mocked)
+    await page.getByTestId('draft-reply-button').click();
+
+    // Composer should be filled with the first suggestion from the mock response
+    await expect(page.getByTestId('chat-input')).toHaveValue(
+      'Sure, I can do that!',
+      { timeout: 8_000 }
     );
   });
 

--- a/client/services/platforms.ts
+++ b/client/services/platforms.ts
@@ -239,6 +239,26 @@ export const platformsApi = {
     );
     return response.data;
   },
+
+  /**
+   * Generate an on-demand AI draft reply for a given message.
+   * Returns the first generated suggestion text.
+   */
+  async generateDraftReply(
+    messageId: string,
+    content: string,
+    chatType: 'individual' | 'group' = 'individual'
+  ): Promise<string> {
+    const response = await api.post<{
+      success: boolean;
+      data: { suggestions: string[]; confidence: number };
+    }>('/ai/responses/generate', { messageId, content, chatType });
+    const suggestions = response.data?.data?.suggestions;
+    if (!suggestions || suggestions.length === 0) {
+      throw new Error('No suggestions returned');
+    }
+    return suggestions[0];
+  },
 };
 
 /**

--- a/docs/E2E_SELECTORS.md
+++ b/docs/E2E_SELECTORS.md
@@ -129,6 +129,9 @@ All stable `testID` values (rendered as `data-testid` on web via React Native We
 | `ai-suggestion-scroll` | Horizontal `ScrollView` containing chips |
 | `ai-suggestion-chip-<index>` | Individual suggestion card `TouchableOpacity` (0-based) |
 | `ai-suggestion-use-<index>` | "Use" button inside chip (0-based); tapping fills the composer |
+| `draft-reply-container` | Wrapper `View` shown when no stored suggestions exist |
+| `draft-reply-button` | "Draft reply" `TouchableOpacity`; calls `/ai/responses/generate` on-demand |
+| `draft-reply-error` | Error text shown if generation fails |
 
 ---
 


### PR DESCRIPTION
Closes #22

## Summary
- Adds a **"Draft reply"** button to the chat screen that appears when no pre-stored AI suggestions exist for the last inbound message
- Tapping the button calls `POST /ai/responses/generate` and immediately populates the composer with the first returned suggestion
- `ResponseSuggestion` component gains `messageContent` and `isGroup` props enabling the on-demand flow alongside the existing stored-suggestion strip
- New `generateDraftReply()` method added to `platformsApi` (uses existing axios instance with auth headers)

## Test plan
- [x] Unit: pre-existing server + client unit tests pass (no regressions)
- [x] E2E: new test `5e — draft reply button populates composer via on-demand generate` mocks `/ai/responses/generate` → verifies `chat-input` is filled with returned text
- [x] Existing AI suggestion e2e tests (5a–5d) unaffected

Risk: auto-merge
Verified: mock Playwright e2e (test 5e), `draft-reply-button` testID confirmed in component

🤖 Generated with [Claude Code](https://claude.com/claude-code)