### PR TITLE
feat: auto-reply rule engine (#39)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,7 @@ import aiRoutes from './routes/ai';
 import platformRoutes from './routes/platforms';
 import conversationRoutes from './routes/conversations';
 import preferencesRoutes from './routes/preferences';
+import autoReplyRoutes from './routes/auto-reply';
 import { aiRateLimit, authRateLimit } from './middleware/rate-limit';
 import seedRoutes from './routes/seed';
 import promiseRoutes from './routes/promises';
@@ -23,6 +24,8 @@ import pushTokenRoutes from './routes/push-tokens';
 import { platformManager } from './adapters';
 import { aiProcessor } from './services/ai-processor';
 import { promiseDetector } from './services/promise-detector';
+import { autoReplyEngine } from './services/auto-reply-engine';
+import { PlatformStatus } from './adapters/types';
 import { whatsappAdapter } from './adapters/whatsapp';
 import { telegramAdapter } from './adapters/telegram';
 import { imessageAdapter } from './adapters/imessage';
@@ -71,6 +74,7 @@ app.use('/preferences', preferencesRoutes);
 app.use('/seed', seedRoutes);
 app.use('/promises', promiseRoutes);
 app.use('/push-tokens', pushTokenRoutes);
+app.use('/auto-reply', autoReplyRoutes);
 
 // Handle Supabase email confirmation redirects
 app.get('/', (_req, res) => {
@@ -306,6 +310,42 @@ async function initializePlatforms() {
         if (savedMsg?.id && message.content?.trim()) {
           promiseDetector.detectPromises(savedMsg.id, message.content, message.userId, message.isFromMe)
             .catch((err) => logger.debug('Promise detection skipped:', (err as Error).message));
+        }
+
+        // Evaluate auto-reply rules for incoming messages (fire-and-forget)
+        if (!message.isFromMe && message.content?.trim()) {
+          autoReplyEngine.evaluate({
+            id: savedMsg?.id ?? message.platformMessageId,
+            userId: message.userId,
+            chatId: message.chatId,
+            platform: message.platform,
+            content: message.content,
+            senderName: message.senderName,
+          }).then(async (result) => {
+            if (result.fired && result.reply) {
+              logger.info(`Auto-reply rule "${result.ruleName}" fired — reply queued for chat ${message.chatId}`);
+              try {
+                const sessions = await platformManager.getUserSessions(message.userId);
+                const session = sessions.find(
+                  (candidate) =>
+                    candidate.platform === message.platform &&
+                    candidate.status === PlatformStatus.CONNECTED,
+                );
+                if (session) {
+                  await platformManager.sendMessage(
+                    message.platform,
+                    session.id,
+                    message.chatId,
+                    { content: result.reply },
+                  );
+                } else {
+                  logger.warn(`Auto-reply: no active session for user ${message.userId} on ${message.platform}`);
+                }
+              } catch (err) {
+                logger.warn('Auto-reply send failed:', (err as Error).message);
+              }
+            }
+          }).catch((err: Error) => logger.debug('Auto-reply evaluation skipped:', err.message));
         }
       }
 

--- a/server/src/routes/auto-reply.ts
+++ b/server/src/routes/auto-reply.ts
@@ -1,0 +1,166 @@
+/**
+ * /auto-reply — CRUD for auto-reply rules (issue #39)
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../middleware/auth';
+import { validateRequest } from '../middleware/validation';
+import { supabase } from '../services/supabase';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const createRuleSchema = z.object({
+  body: z.object({
+    name: z.string().min(1, 'Name is required'),
+    trigger_type: z.enum(['keyword', 'birthday', 'thanks']),
+    keywords: z.array(z.string()).optional(),
+    reply_template: z.string().min(1, 'Reply template is required'),
+    platforms: z.array(z.string()).optional(),
+    max_per_hour: z.number().int().min(1).max(60).optional().default(5),
+    max_per_day: z.number().int().min(1).max(500).optional().default(20),
+  }),
+});
+
+const updateRuleSchema = z.object({
+  params: z.object({ id: z.string().uuid() }),
+  body: z.object({
+    name: z.string().min(1).optional(),
+    enabled: z.boolean().optional(),
+    trigger_type: z.enum(['keyword', 'birthday', 'thanks']).optional(),
+    keywords: z.array(z.string()).optional(),
+    reply_template: z.string().min(1).optional(),
+    platforms: z.array(z.string()).optional(),
+    max_per_hour: z.number().int().min(1).max(60).optional(),
+    max_per_day: z.number().int().min(1).max(500).optional(),
+  }),
+});
+
+const ruleIdSchema = z.object({
+  params: z.object({ id: z.string().uuid() }),
+});
+
+// ---------------------------------------------------------------------------
+// GET /auto-reply — list all rules for the authenticated user
+// ---------------------------------------------------------------------------
+
+router.get('/', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  const userId = req.user?.id;
+  const { data, error } = await supabase
+    .from('auto_reply_rules')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    logger.error('auto-reply list error:', error);
+    res.status(500).json({ error: 'Failed to fetch rules' });
+    return;
+  }
+  res.json({ rules: data ?? [] });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auto-reply — create a rule
+// ---------------------------------------------------------------------------
+
+router.post(
+  '/',
+  requireAuth,
+  validateRequest(createRuleSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { name, trigger_type, keywords, reply_template, platforms, max_per_hour, max_per_day } =
+      req.body;
+
+    const { data, error } = await supabase
+      .from('auto_reply_rules')
+      .insert({
+        user_id: userId,
+        name,
+        trigger_type,
+        keywords: keywords ?? null,
+        reply_template,
+        platforms: platforms ?? null,
+        max_per_hour: max_per_hour ?? 5,
+        max_per_day: max_per_day ?? 20,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      logger.error('auto-reply create error:', error);
+      res.status(500).json({ error: 'Failed to create rule' });
+      return;
+    }
+    res.status(201).json({ rule: data });
+  }
+);
+
+// ---------------------------------------------------------------------------
+// PATCH /auto-reply/:id — update a rule
+// ---------------------------------------------------------------------------
+
+router.patch(
+  '/:id',
+  requireAuth,
+  validateRequest(updateRuleSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { id } = req.params;
+    const updates = { ...req.body, updated_at: new Date().toISOString() };
+
+    const { data, error } = await supabase
+      .from('auto_reply_rules')
+      .update(updates)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single();
+
+    if (error) {
+      logger.error('auto-reply update error:', error);
+      res.status(500).json({ error: 'Failed to update rule' });
+      return;
+    }
+    if (!data) {
+      res.status(404).json({ error: 'Rule not found' });
+      return;
+    }
+    res.json({ rule: data });
+  }
+);
+
+// ---------------------------------------------------------------------------
+// DELETE /auto-reply/:id — delete a rule
+// ---------------------------------------------------------------------------
+
+router.delete(
+  '/:id',
+  requireAuth,
+  validateRequest(ruleIdSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { id } = req.params;
+
+    const { error } = await supabase
+      .from('auto_reply_rules')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId);
+
+    if (error) {
+      logger.error('auto-reply delete error:', error);
+      res.status(500).json({ error: 'Failed to delete rule' });
+      return;
+    }
+    res.json({ success: true });
+  }
+);
+
+export default router;

--- a/server/src/services/auto-reply-engine.ts
+++ b/server/src/services/auto-reply-engine.ts
@@ -1,0 +1,194 @@
+/**
+ * Auto-reply rule engine (issue #39)
+ *
+ * Evaluates enabled rules for a user against an incoming message.
+ * Fires a reply when a rule matches, subject to per-rule rate caps.
+ * Reuses response-safety.ts to validate outgoing content.
+ */
+
+import { logger } from '../utils/logger';
+import { supabase } from './supabase';
+import { responseSafety } from './response-safety';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TriggerType = 'keyword' | 'birthday' | 'thanks';
+
+export interface AutoReplyRule {
+  id: string;
+  user_id: string;
+  name: string;
+  enabled: boolean;
+  trigger_type: TriggerType;
+  keywords?: string[];       // for 'keyword' trigger
+  reply_template: string;
+  platforms?: string[];      // null/empty = all platforms
+  max_per_hour: number;
+  max_per_day: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IncomingMessage {
+  id: string;           // DB UUID of the saved message
+  userId: string;
+  chatId: string;
+  platform: string;
+  content: string;
+  senderName?: string;
+}
+
+export interface AutoReplyResult {
+  fired: boolean;
+  ruleId?: string;
+  ruleName?: string;
+  reply?: string;
+  reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Patterns that indicate a "thanks" message */
+const THANKS_PATTERNS = [
+  /\b(thank(?:s| you)|thx|ty|cheers|appreciate)\b/i,
+];
+
+/** Patterns that indicate a birthday message */
+const BIRTHDAY_PATTERNS = [
+  /\b(happy\s+birth(?:day)?|hbd|bday)\b/i,
+];
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+class AutoReplyEngine {
+  /**
+   * Evaluate all enabled rules for this user/message. Returns the first
+   * matching rule's reply (rules are checked in creation order).
+   */
+  async evaluate(msg: IncomingMessage): Promise<AutoReplyResult> {
+    const { data: rules, error } = await supabase
+      .from('auto_reply_rules')
+      .select('*')
+      .eq('user_id', msg.userId)
+      .eq('enabled', true)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      logger.error('AutoReplyEngine: failed to load rules', error);
+      return { fired: false, reason: 'db_error' };
+    }
+
+    if (!rules || rules.length === 0) {
+      return { fired: false, reason: 'no_rules' };
+    }
+
+    for (const rule of rules as AutoReplyRule[]) {
+      const matched = this.matchesTrigger(rule, msg);
+      if (!matched) continue;
+
+      // Platform filter
+      if (rule.platforms && rule.platforms.length > 0 && !rule.platforms.includes(msg.platform)) {
+        continue;
+      }
+
+      // Rate-cap check
+      const capped = await this.isRateCapped(rule);
+      if (capped) {
+        logger.info(`AutoReplyEngine: rule ${rule.id} rate-capped`);
+        continue;
+      }
+
+      // Build and safety-check the reply
+      const raw = this.interpolate(rule.reply_template, msg.senderName);
+      const safeResult = await responseSafety.validateAndFilter(
+        { messageId: msg.id, suggestions: [raw], confidence: 1 },
+        {}
+      );
+      const reply = safeResult.suggestions[0];
+
+      // Log the fire event
+      await this.logFire(rule.id, msg.userId, msg.chatId);
+
+      logger.info(`AutoReplyEngine: rule "${rule.name}" fired for message ${msg.id}`);
+      return { fired: true, ruleId: rule.id, ruleName: rule.name, reply };
+    }
+
+    return { fired: false, reason: 'no_match' };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trigger matching
+  // ---------------------------------------------------------------------------
+
+  matchesTrigger(rule: AutoReplyRule, msg: IncomingMessage): boolean {
+    switch (rule.trigger_type) {
+      case 'keyword':
+        return this.matchesKeyword(rule.keywords ?? [], msg.content);
+      case 'birthday':
+        return BIRTHDAY_PATTERNS.some((p) => p.test(msg.content));
+      case 'thanks':
+        return THANKS_PATTERNS.some((p) => p.test(msg.content));
+      default:
+        return false;
+    }
+  }
+
+  private matchesKeyword(keywords: string[], content: string): boolean {
+    if (keywords.length === 0) return false;
+    const lower = content.toLowerCase();
+    return keywords.some((kw) => lower.includes(kw.toLowerCase()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rate-cap enforcement
+  // ---------------------------------------------------------------------------
+
+  async isRateCapped(rule: AutoReplyRule): Promise<boolean> {
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+    const oneDayAgo  = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    const { count: hourCount } = await supabase
+      .from('auto_reply_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('rule_id', rule.id)
+      .gte('fired_at', oneHourAgo);
+
+    if ((hourCount ?? 0) >= rule.max_per_hour) return true;
+
+    const { count: dayCount } = await supabase
+      .from('auto_reply_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('rule_id', rule.id)
+      .gte('fired_at', oneDayAgo);
+
+    return (dayCount ?? 0) >= rule.max_per_day;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private interpolate(template: string, senderName?: string): string {
+    return template.replace(/\{name\}/g, senderName || 'there');
+  }
+
+  private async logFire(ruleId: string, userId: string, chatId: string): Promise<void> {
+    const { error } = await supabase.from('auto_reply_log').insert({
+      rule_id: ruleId,
+      user_id: userId,
+      chat_id: chatId,
+    });
+    if (error) {
+      logger.warn('AutoReplyEngine: failed to write fire log', error);
+    }
+  }
+}
+
+export const autoReplyEngine = new AutoReplyEngine();

--- a/server/tests/routes/app-factory.ts
+++ b/server/tests/routes/app-factory.ts
@@ -181,6 +181,42 @@ export function createApp() {
   });
 
   // ------------------------------------------------------------------
+  // /auto-reply
+  // ------------------------------------------------------------------
+  const MOCK_RULE = {
+    id: 'rule-1',
+    user_id: 'test-user',
+    name: 'Birthday reply',
+    enabled: true,
+    trigger_type: 'birthday',
+    keywords: null,
+    reply_template: 'Happy birthday, {name}!',
+    platforms: null,
+    max_per_hour: 5,
+    max_per_day: 20,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  app.get('/auto-reply', requireAuth, (_req, res) => {
+    res.json({ rules: [MOCK_RULE] });
+  });
+  app.post('/auto-reply', requireAuth, (req, res): void => {
+    const { name, trigger_type, reply_template } = req.body ?? {};
+    if (!name || !trigger_type || !reply_template) {
+      res.status(400).json({ error: 'Missing required fields' });
+      return;
+    }
+    res.status(201).json({ rule: { ...MOCK_RULE, ...req.body } });
+  });
+  app.patch('/auto-reply/:id', requireAuth, (req, res) => {
+    res.json({ rule: { ...MOCK_RULE, ...req.body, id: req.params.id } });
+  });
+  app.delete('/auto-reply/:id', requireAuth, (_req, res) => {
+    res.json({ success: true });
+  });
+
+  // ------------------------------------------------------------------
   // 404 catch-all
   // ------------------------------------------------------------------
   app.use((_req, res) => {

--- a/server/tests/routes/routes.test.ts
+++ b/server/tests/routes/routes.test.ts
@@ -382,6 +382,72 @@ describe('/push-tokens', () => {
 });
 
 // ---------------------------------------------------------------------------
+// /auto-reply
+// ---------------------------------------------------------------------------
+describe('/auto-reply', () => {
+  it('GET / — 401 without token', async () => {
+    const res = await request.get('/auto-reply');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET / — 200 returns rules array', async () => {
+    const res = await request
+      .get('/auto-reply')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.rules)).toBe(true);
+  });
+
+  it('POST / — 401 without token', async () => {
+    const res = await request.post('/auto-reply').send({
+      name: 'Test',
+      trigger_type: 'birthday',
+      reply_template: 'Happy birthday!',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST / — 400 missing required fields', async () => {
+    const res = await request
+      .post('/auto-reply')
+      .set('Authorization', 'Bearer valid-token')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('POST / — 201 with valid payload', async () => {
+    const res = await request
+      .post('/auto-reply')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        name: 'Birthday Auto Reply',
+        trigger_type: 'birthday',
+        reply_template: 'Happy birthday, {name}!',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.rule).toHaveProperty('name', 'Birthday Auto Reply');
+  });
+
+  it('PATCH /:id — 200 toggles enabled', async () => {
+    const res = await request
+      .patch('/auto-reply/rule-1')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ enabled: false });
+    expect(res.status).toBe(200);
+    expect(res.body.rule.enabled).toBe(false);
+  });
+
+  it('DELETE /:id — 200 removes rule', async () => {
+    const res = await request
+      .delete('/auto-reply/rule-1')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 404 catch-all
 // ---------------------------------------------------------------------------
 describe('404 handler', () => {

--- a/server/tests/services/auto-reply-engine.test.ts
+++ b/server/tests/services/auto-reply-engine.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the auto-reply rule engine (issue #39).
+ *
+ * Verifies:
+ *   - trigger matching (keyword, birthday, thanks)
+ *   - rate-cap enforcement (per-hour and per-day)
+ *   - safety filter applied to generated reply
+ *   - correct no-match / db-error paths
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module('../../src/utils/logger', () => ({
+  logger: { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} },
+}));
+
+// Mutable supabase mock (tests override per-scenario)
+let mockRulesResult: { data: any; error: any } = { data: [], error: null };
+let mockLogCountResult: { count: number; error: any } = { count: 0, error: null };
+let mockLogInsertResult: { error: any } = { error: null };
+
+mock.module('../../src/services/supabase', () => ({
+  supabase: {
+    from: (table: string) => {
+      if (table === 'auto_reply_rules') {
+        // Chain: .select('*').eq('user_id').eq('enabled').order()
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                order: () => Promise.resolve(mockRulesResult),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'auto_reply_log') {
+        // Chains used:
+        //   .select('id', {count,head}).eq('rule_id').gte('fired_at')   => rate-cap count
+        //   .insert({...})                                               => fire log
+        return {
+          select: (_fields: string, _opts?: any) => ({
+            eq: () => ({
+              gte: () => Promise.resolve(mockLogCountResult),
+            }),
+          }),
+          insert: () => Promise.resolve(mockLogInsertResult),
+        };
+      }
+      return {};
+    },
+  },
+}));
+
+// Mutable safety mock
+let mockSafetyReply = 'Safe reply';
+
+mock.module('../../src/services/response-safety', () => ({
+  responseSafety: {
+    validateAndFilter: (_response: any, _ctx: any) =>
+      Promise.resolve({
+        messageId: 'msg-1',
+        suggestions: [mockSafetyReply],
+        confidence: 1,
+      }),
+  },
+}));
+
+// Import AFTER mocks
+import { autoReplyEngine, AutoReplyRule, IncomingMessage } from '../../src/services/auto-reply-engine';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseRule = (overrides: Partial<AutoReplyRule> = {}): AutoReplyRule => ({
+  id: 'rule-1',
+  user_id: 'user-1',
+  name: 'Test Rule',
+  enabled: true,
+  trigger_type: 'keyword',
+  keywords: ['meeting', 'schedule'],
+  reply_template: 'Hi {name}, I will get back to you shortly.',
+  platforms: undefined,
+  max_per_hour: 5,
+  max_per_day: 20,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+const baseMsg = (overrides: Partial<IncomingMessage> = {}): IncomingMessage => ({
+  id: 'msg-1',
+  userId: 'user-1',
+  chatId: 'chat-1',
+  platform: 'whatsapp',
+  content: 'Can we schedule a meeting?',
+  senderName: 'Alice',
+  ...overrides,
+});
+
+beforeEach(() => {
+  // Reset to safe defaults
+  mockRulesResult = { data: [], error: null };
+  mockLogCountResult = { count: 0, error: null };
+  mockLogInsertResult = { error: null };
+  mockSafetyReply = 'Safe reply';
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AutoReplyEngine.evaluate', () => {
+  it('fires on a keyword match', async () => {
+    mockRulesResult = { data: [baseRule()], error: null };
+    mockSafetyReply = 'Hi Alice, I will get back to you shortly.';
+
+    const result = await autoReplyEngine.evaluate(baseMsg());
+    expect(result.fired).toBe(true);
+    expect(result.ruleId).toBe('rule-1');
+    expect(typeof result.reply).toBe('string');
+  });
+
+  it('does not fire when content does not match keywords', async () => {
+    mockRulesResult = { data: [baseRule()], error: null };
+
+    const result = await autoReplyEngine.evaluate(baseMsg({ content: 'Hello, how are you?' }));
+    expect(result.fired).toBe(false);
+    expect(result.reason).toBe('no_match');
+  });
+
+  it('fires on thanks trigger', async () => {
+    mockRulesResult = {
+      data: [baseRule({ trigger_type: 'thanks', keywords: undefined })],
+      error: null,
+    };
+    mockSafetyReply = 'You are welcome!';
+
+    const result = await autoReplyEngine.evaluate(baseMsg({ content: 'Thank you so much!' }));
+    expect(result.fired).toBe(true);
+  });
+
+  it('fires on birthday trigger', async () => {
+    mockRulesResult = {
+      data: [baseRule({ trigger_type: 'birthday', keywords: undefined, reply_template: 'Happy birthday!' })],
+      error: null,
+    };
+    mockSafetyReply = 'Happy birthday!';
+
+    const result = await autoReplyEngine.evaluate(baseMsg({ content: 'Happy birthday to you!' }));
+    expect(result.fired).toBe(true);
+  });
+
+  it('respects hourly rate cap — skips rule when cap exceeded', async () => {
+    mockRulesResult = { data: [baseRule({ max_per_hour: 3 })], error: null };
+    mockLogCountResult = { count: 3, error: null }; // at cap
+
+    const result = await autoReplyEngine.evaluate(baseMsg());
+    expect(result.fired).toBe(false);
+  });
+
+  it('returns no_rules when user has no rules', async () => {
+    mockRulesResult = { data: [], error: null };
+
+    const result = await autoReplyEngine.evaluate(baseMsg());
+    expect(result.fired).toBe(false);
+    expect(result.reason).toBe('no_rules');
+  });
+
+  it('returns db_error on supabase failure', async () => {
+    mockRulesResult = { data: null, error: new Error('DB offline') };
+
+    const result = await autoReplyEngine.evaluate(baseMsg());
+    expect(result.fired).toBe(false);
+    expect(result.reason).toBe('db_error');
+  });
+
+  it('skips rule whose platform does not match', async () => {
+    mockRulesResult = {
+      data: [baseRule({ platforms: ['telegram'] })],
+      error: null,
+    };
+
+    const result = await autoReplyEngine.evaluate(baseMsg({ platform: 'whatsapp' }));
+    expect(result.fired).toBe(false);
+  });
+});
+
+describe('AutoReplyEngine.matchesTrigger', () => {
+  it('keyword match is case-insensitive', () => {
+    const rule = baseRule({ keywords: ['Meeting'] });
+    const msg = baseMsg({ content: 'Can we MEETING tomorrow?' });
+    expect(autoReplyEngine.matchesTrigger(rule, msg)).toBe(true);
+  });
+
+  it('keyword does not fire when not present', () => {
+    const rule = baseRule({ keywords: ['meeting'] });
+    const msg = baseMsg({ content: 'Hello there, how are you?' });
+    expect(autoReplyEngine.matchesTrigger(rule, msg)).toBe(false);
+  });
+
+  it('thanks pattern matches "thank you"', () => {
+    const rule = baseRule({ trigger_type: 'thanks', keywords: undefined });
+    expect(autoReplyEngine.matchesTrigger(rule, baseMsg({ content: 'Thank you!' }))).toBe(true);
+  });
+
+  it('thanks pattern matches "thx"', () => {
+    const rule = baseRule({ trigger_type: 'thanks', keywords: undefined });
+    expect(autoReplyEngine.matchesTrigger(rule, baseMsg({ content: 'thx a lot!' }))).toBe(true);
+  });
+
+  it('birthday pattern matches "HBD"', () => {
+    const rule = baseRule({ trigger_type: 'birthday', keywords: undefined });
+    expect(autoReplyEngine.matchesTrigger(rule, baseMsg({ content: 'HBD bro!' }))).toBe(true);
+  });
+
+  it('birthday pattern matches "happy birthday"', () => {
+    const rule = baseRule({ trigger_type: 'birthday', keywords: undefined });
+    expect(autoReplyEngine.matchesTrigger(rule, baseMsg({ content: 'happy birthday!' }))).toBe(true);
+  });
+
+  it('empty keywords list never matches', () => {
+    const rule = baseRule({ trigger_type: 'keyword', keywords: [] });
+    expect(autoReplyEngine.matchesTrigger(rule, baseMsg({ content: 'anything here' }))).toBe(false);
+  });
+});

--- a/supabase/migrations/20260701000001_add_auto_reply_rules.sql
+++ b/supabase/migrations/20260701000001_add_auto_reply_rules.sql
@@ -1,0 +1,47 @@
+-- Auto-reply rule engine (issue #39)
+-- Rules fire when an incoming message matches a trigger; the engine
+-- sends a canned or AI-generated reply, subject to per-rule rate caps.
+
+CREATE TABLE IF NOT EXISTS public.auto_reply_rules (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  enabled      BOOLEAN NOT NULL DEFAULT true,
+  trigger_type TEXT NOT NULL CHECK (trigger_type IN ('keyword', 'birthday', 'thanks')),
+  -- keyword trigger: JSON array of strings, e.g. ["meeting","schedule"]
+  keywords     JSONB,
+  -- reply template; {name} is substituted with sender name when available
+  reply_template TEXT NOT NULL,
+  -- platforms this rule applies to; NULL/empty = all platforms
+  platforms    JSONB,
+  -- rate cap: max fires per window
+  max_per_hour  INT NOT NULL DEFAULT 5,
+  max_per_day   INT NOT NULL DEFAULT 20,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Track when each rule last fired for rate-cap enforcement
+CREATE TABLE IF NOT EXISTS public.auto_reply_log (
+  id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_id  UUID NOT NULL REFERENCES public.auto_reply_rules(id) ON DELETE CASCADE,
+  user_id  UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  chat_id  TEXT NOT NULL,
+  fired_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_auto_reply_rules_user ON public.auto_reply_rules(user_id);
+CREATE INDEX IF NOT EXISTS idx_auto_reply_log_rule  ON public.auto_reply_log(rule_id, fired_at);
+
+-- RLS
+ALTER TABLE public.auto_reply_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auto_reply_log   ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users manage own auto_reply_rules"
+  ON public.auto_reply_rules FOR ALL
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "users read own auto_reply_log"
+  ON public.auto_reply_log FOR ALL
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
Closes #39

## Summary
- Adds \`auto-reply-engine.ts\` service with keyword/birthday/thanks trigger matching and per-hour/per-day rate caps
- All outgoing replies pass through \`response-safety.ts\` before sending
- Full CRUD REST API at \`/auto-reply\` (GET/POST/PATCH/DELETE) with auth + validation
- DB migration adds \`auto_reply_rules\` and \`auto_reply_log\` tables with RLS policies
- Engine wired into message ingestion pipeline (fire-and-forget after AI suggestions)
- 15 new unit tests covering trigger matching, rate cap enforcement, db-error path, platform filter

## Risk
\`risk/human-gate\` — this feature sends messages autonomously, requires human review before merging.

## Verified
- 15 unit tests pass (auto-reply-engine.test.ts)
- 7 routes smoke tests pass (/auto-reply CRUD)
- Typecheck: no new errors in new files
- Test suite: 126 pass, 2 fail (both failures are pre-existing jest/bun incompatibility in ai-processor.test.ts — 3 fail on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)