### PR TITLE
feat: database schema-drift verification (#99)

### DIFF
--- a/docs/SCHEMA_VERIFICATION.md
+++ b/docs/SCHEMA_VERIFICATION.md
@@ -1,0 +1,70 @@
+# Database schema & drift verification (#99)
+
+Production once ran "healthy" while the Supabase schema was behind the deployed
+code — a missing `messages.snoozed_until` column had to be added by hand. This
+document defines how migrations are applied and how drift is detected so that
+never silently happens again.
+
+## Applying migrations (one command, no manual SQL)
+
+All schema lives in `supabase/migrations/*.sql` and is written to be idempotent
+(`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`). Apply the full set to
+any target with the Supabase CLI:
+
+```bash
+supabase db push        # applies pending migrations to the linked project
+```
+
+For a raw Postgres/Railway connection without the CLI, apply the files in
+lexical order (they are timestamp-prefixed):
+
+```bash
+for f in supabase/migrations/*.sql; do psql "$DATABASE_URL" -f "$f"; done
+```
+
+After applying, reload the PostgREST schema cache so the API sees new
+columns/tables immediately:
+
+```sql
+NOTIFY pgrst, 'reload schema';
+```
+
+## Drift detection
+
+The application declares the columns it requires in
+`server/src/services/schema-verification.ts` (`REQUIRED_SCHEMA`). **Extend that
+list whenever a migration adds a column/table the code reads or writes.**
+
+Two surfaces consume it:
+
+1. **Pre-deploy gate** — run before shipping code that depends on new schema:
+
+   ```bash
+   cd server && bun run verify:schema
+   ```
+
+   Exits `0` when the live DB satisfies `REQUIRED_SCHEMA`, `1` on drift (listing
+   the missing tables/columns), `2` if the check could not run. Wire this into
+   the deploy pipeline as a pre-release step against the production database.
+
+2. **Runtime readiness** — `GET /health` includes a `schema` check. On drift it
+   reports `status: "degraded"` with HTTP `503` and a `checks.schema` entry
+   listing the affected tables, so an incompatible deploy fails readiness before
+   taking traffic. The result is cached for 60s to keep polling cheap.
+
+Detection is RLS-safe: a missing column/table returns a Postgres
+`42703`/`42P01` (or PostgREST `PGRST204`/`PGRST205`) error regardless of
+row-level security, while a present-but-empty table simply returns no rows.
+Transient/operational errors (network, expired JWT) are **not** reported as
+drift.
+
+## Backup & rollback expectations
+
+- **Backup**: Railway Supabase runs automated daily backups; take an on-demand
+  snapshot immediately before applying migrations to production.
+- **Forward-only**: migrations are additive and idempotent; re-running them is
+  safe. Prefer a new corrective migration over editing a shipped one.
+- **Rollback**: if a deploy fails `verify:schema` or `/health` schema readiness,
+  roll the *application* back to the previous release (which matched the prior
+  schema) rather than dropping columns. Additive columns left in place are
+  harmless to older code.

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "test:coverage": "bun test --coverage",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify:schema": "bun run src/scripts/verify-schema.ts"
   },
   "dependencies": {
     "@anthropic-ai/bedrock-sdk": "^0.27.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import { supabase } from './services/supabase';
 import { redis } from './services/redis';
 import { sessionMonitor } from './services/session-monitor';
 import { reminderScheduler } from './services/reminder-scheduler';
+import { verifySchemaCached } from './services/schema-verification';
 import authRoutes from './routes/auth';
 import messageRoutes from './routes/messages';
 import aiRoutes from './routes/ai';
@@ -111,7 +112,10 @@ app.get('/media/:server/:mediaId', async (req, res) => {
 
 // Health / readiness check — reports DB, Redis, and Matrix (when configured)
 app.get('/health', async (_req, res) => {
-  const checks: Record<string, { status: 'ok' | 'error'; latencyMs?: number; error?: string }> = {};
+  const checks: Record<
+    string,
+    { status: 'ok' | 'error'; latencyMs?: number; error?: string; detail?: unknown }
+  > = {};
 
   // --- Supabase / DB ---
   try {
@@ -122,6 +126,23 @@ app.get('/health', async (_req, res) => {
       : { status: 'ok', latencyMs: Date.now() - t0 };
   } catch (err) {
     checks.db = { status: 'error', error: (err as Error).message };
+  }
+
+  // --- Schema drift (#99): deploy must not be ahead of the DB schema ---
+  if (checks.db?.status === 'ok') {
+    try {
+      const t0 = Date.now();
+      const result = await verifySchemaCached();
+      checks.schema = result.ok
+        ? { status: 'ok', latencyMs: Date.now() - t0 }
+        : {
+            status: 'error',
+            error: `Schema drift: ${result.drift.map((d) => d.table).join(', ')}`,
+            detail: result.drift,
+          };
+    } catch (err) {
+      checks.schema = { status: 'error', error: (err as Error).message };
+    }
   }
 
   // --- Redis ---

--- a/server/src/scripts/verify-schema.ts
+++ b/server/src/scripts/verify-schema.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+/**
+ * Pre-deploy schema-drift check (#99).
+ *
+ * Exits non-zero if the live database is missing any column/table the
+ * application requires, so a deploy can be gated before incompatible code
+ * serves traffic. Uses the same Supabase env as the server.
+ *
+ * Usage: bun run verify:schema
+ */
+import { verifySchema } from '../services/schema-verification';
+import { logger } from '../utils/logger';
+
+async function main(): Promise<void> {
+  const result = await verifySchema();
+
+  if (result.ok) {
+    logger.info(`[schema] OK — ${result.checkedTables} tables verified`);
+    // eslint-disable-next-line no-console
+    console.log(`✅ schema OK (${result.checkedTables} tables verified)`);
+    process.exit(0);
+  }
+
+  // eslint-disable-next-line no-console
+  console.error('❌ SCHEMA DRIFT DETECTED — the database is behind the deployed code:');
+  for (const entry of result.drift) {
+    // eslint-disable-next-line no-console
+    console.error(`   - ${entry.table} (${entry.columns.join(', ')}): ${entry.error}`);
+  }
+  // eslint-disable-next-line no-console
+  console.error('\nApply pending migrations before deploying (see docs/SCHEMA_VERIFICATION.md).');
+  process.exit(1);
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('[schema] verification could not run:', err);
+  process.exit(2);
+});

--- a/server/src/services/schema-verification.test.ts
+++ b/server/src/services/schema-verification.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for schema-drift verification (#99).
+ * Supabase is mocked so a per-table "missing column/table" error can be simulated.
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+// Per-table error the mocked supabase client should return (null = column exists).
+let errorByTable: Record<string, { code?: string; message?: string } | null> = {};
+
+mock.module('./supabase', () => ({
+  supabase: {
+    from: (table: string) => ({
+      select: (_columns: string) => ({
+        limit: async (_n: number) => ({ data: [], error: errorByTable[table] ?? null }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../utils/logger', () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  stream: { write: () => {} },
+}));
+
+const {
+  verifySchema,
+  verifySchemaCached,
+  resetSchemaVerificationCache,
+  isMissingSchemaError,
+} = await import('./schema-verification');
+
+const REQS = [
+  { table: 'present_table', columns: ['a', 'b'] },
+  { table: 'missing_table', columns: ['c'] },
+];
+
+describe('schema-verification (#99)', () => {
+  beforeEach(() => {
+    errorByTable = {};
+    resetSchemaVerificationCache();
+  });
+
+  describe('isMissingSchemaError', () => {
+    it('flags undefined column/table Postgres codes', () => {
+      expect(isMissingSchemaError({ code: '42703', message: 'column x does not exist' })).toBe(true);
+      expect(isMissingSchemaError({ code: '42P01', message: 'relation y does not exist' })).toBe(true);
+    });
+
+    it('flags PostgREST schema-cache codes and messages', () => {
+      expect(isMissingSchemaError({ code: 'PGRST205', message: 'Could not find the table' })).toBe(true);
+      expect(isMissingSchemaError({ message: "column messages.snoozed_until does not exist" })).toBe(true);
+    });
+
+    it('does NOT flag transient/operational errors', () => {
+      expect(isMissingSchemaError({ code: '08006', message: 'connection failure' })).toBe(false);
+      expect(isMissingSchemaError({ code: 'PGRST301', message: 'JWT expired' })).toBe(false);
+      expect(isMissingSchemaError(null)).toBe(false);
+    });
+  });
+
+  describe('verifySchema', () => {
+    it('reports ok when every required table/column resolves', async () => {
+      const result = await verifySchema([{ table: 'present_table', columns: ['a', 'b'] }]);
+      expect(result.ok).toBe(true);
+      expect(result.drift).toHaveLength(0);
+      expect(result.checkedTables).toBe(1);
+    });
+
+    it('reports drift for a missing table', async () => {
+      errorByTable = {
+        missing_table: { code: '42P01', message: 'relation "missing_table" does not exist' },
+      };
+      const result = await verifySchema(REQS);
+      expect(result.ok).toBe(false);
+      expect(result.drift.map((d) => d.table)).toEqual(['missing_table']);
+      expect(result.checkedTables).toBe(2);
+    });
+
+    it('reports drift for a missing column', async () => {
+      errorByTable = {
+        present_table: { code: '42703', message: 'column present_table.b does not exist' },
+      };
+      const result = await verifySchema([{ table: 'present_table', columns: ['a', 'b'] }]);
+      expect(result.ok).toBe(false);
+      expect(result.drift[0]?.columns).toEqual(['a', 'b']);
+    });
+
+    it('does not treat a transient error as drift', async () => {
+      errorByTable = { present_table: { code: '08006', message: 'connection failure' } };
+      const result = await verifySchema([{ table: 'present_table', columns: ['a'] }]);
+      expect(result.ok).toBe(true);
+      expect(result.drift).toHaveLength(0);
+    });
+  });
+
+  describe('verifySchemaCached', () => {
+    it('caches the result until reset', async () => {
+      // First call: everything ok, cached.
+      const first = await verifySchemaCached(60_000);
+      expect(first.ok).toBe(true);
+
+      // Introduce drift on a real required table; cache should hide it.
+      errorByTable = { messages: { code: '42703', message: 'column messages.snoozed_until does not exist' } };
+      const cached = await verifySchemaCached(60_000);
+      expect(cached.ok).toBe(true);
+
+      // After reset, the drift is observed.
+      resetSchemaVerificationCache();
+      const fresh = await verifySchemaCached(60_000);
+      expect(fresh.ok).toBe(false);
+      expect(fresh.drift.some((d) => d.table === 'messages')).toBe(true);
+    });
+  });
+});

--- a/server/src/services/schema-verification.ts
+++ b/server/src/services/schema-verification.ts
@@ -1,0 +1,115 @@
+/**
+ * Database schema-drift verification (#99).
+ *
+ * Production once ran healthy while the Supabase schema was behind the deployed
+ * code (a missing `messages.snoozed_until` column had to be added by hand). This
+ * module declares the columns the running application requires and checks them
+ * against the live database, so drift is reported explicitly (via /health) and
+ * can gate a deploy (via the `verify:schema` script) instead of surfacing as
+ * runtime 500s.
+ *
+ * Detection is RLS-safe: a missing column/table yields a Postgres/PostgREST
+ * "undefined column/table" error regardless of row-level security, whereas a
+ * present-but-empty table simply returns no rows (no error).
+ */
+
+import { supabase } from './supabase';
+import { logger } from '../utils/logger';
+
+export interface SchemaRequirement {
+  table: string;
+  columns: string[];
+}
+
+/**
+ * Columns the application reads or writes. Extend this whenever a migration adds
+ * a column/table the code depends on — that keeps drift detection honest.
+ * Only include columns that exist once ALL migrations are applied.
+ */
+export const REQUIRED_SCHEMA: SchemaRequirement[] = [
+  { table: 'messages', columns: ['snoozed_until', 'is_group', 'contact_name', 'contact_phone', 'media_mime_type'] },
+  { table: 'chats', columns: ['whatsapp_chat_id', 'last_message_at'] },
+  { table: 'contacts', columns: ['inferred_relationship', 'inference_confidence'] },
+  { table: 'ai_suggestions', columns: ['selected_index', 'feedback'] },
+  { table: 'push_tokens', columns: ['token', 'device_id'] },
+  { table: 'auto_reply_rules', columns: ['trigger_type', 'reply_template'] },
+  { table: 'contact_memory', columns: ['key', 'value', 'confidence'] },
+  { table: 'chat_categories', columns: ['category'] },
+  { table: 'contact_profiles', columns: ['key_facts'] },
+  { table: 'smart_cards', columns: ['dismissed'] },
+];
+
+export interface SchemaDriftEntry {
+  table: string;
+  columns: string[];
+  error: string;
+}
+
+export interface SchemaVerificationResult {
+  ok: boolean;
+  checkedTables: number;
+  drift: SchemaDriftEntry[];
+}
+
+// Postgres error codes for a missing column / relation.
+const UNDEFINED_COLUMN = '42703';
+const UNDEFINED_TABLE = '42P01';
+
+interface SupabaseErrorLike {
+  code?: string;
+  message?: string;
+}
+
+/**
+ * True only for errors that mean the schema is missing something — not for
+ * transient/operational errors (network, auth), which must NOT be reported as
+ * drift.
+ */
+export function isMissingSchemaError(error: SupabaseErrorLike | null | undefined): boolean {
+  if (!error) return false;
+  const code = error.code ?? '';
+  if (code === UNDEFINED_COLUMN || code === UNDEFINED_TABLE) return true;
+  // PostgREST schema-cache codes: PGRST204 (unknown column), PGRST205 (unknown table).
+  if (code === 'PGRST204' || code === 'PGRST205') return true;
+  const message = (error.message ?? '').toLowerCase();
+  return message.includes('does not exist') || message.includes('could not find the');
+}
+
+/**
+ * Verify the live database exposes every required table/column.
+ * One lightweight query per table (selecting all required columns, limit 1).
+ */
+export async function verifySchema(
+  requirements: SchemaRequirement[] = REQUIRED_SCHEMA
+): Promise<SchemaVerificationResult> {
+  const drift: SchemaDriftEntry[] = [];
+
+  for (const { table, columns } of requirements) {
+    const { error } = await supabase.from(table).select(columns.join(',')).limit(1);
+    if (isMissingSchemaError(error)) {
+      drift.push({ table, columns, error: error?.message ?? 'missing table or column' });
+    } else if (error) {
+      // Operational error — log but don't claim drift (avoids false readiness failures).
+      logger.warn(`[schema] Non-schema error probing ${table}: ${error.message}`);
+    }
+  }
+
+  return { ok: drift.length === 0, checkedTables: requirements.length, drift };
+}
+
+// Schema only changes on deploy/migration, so a short TTL keeps /health cheap
+// even under frequent readiness polling.
+let cache: { at: number; result: SchemaVerificationResult } | null = null;
+
+export async function verifySchemaCached(ttlMs = 60_000): Promise<SchemaVerificationResult> {
+  const now = Date.now();
+  if (cache && now - cache.at < ttlMs) return cache.result;
+  const result = await verifySchema();
+  cache = { at: now, result };
+  return result;
+}
+
+/** Clear the cached verification (used by tests / after a migration run). */
+export function resetSchemaVerificationCache(): void {
+  cache = null;
+}


### PR DESCRIPTION
Closes part of #99. Production once ran "healthy" while the Supabase schema was behind the deployed code (a missing `messages.snoozed_until` had to be added by hand). This surfaces that as a readiness failure / deploy gate instead of runtime 500s.

## What
- **`services/schema-verification.ts`** — `REQUIRED_SCHEMA` manifest (columns the app reads/writes) + `verifySchema()` probing the live DB (one query per table). RLS-safe: a missing column/table yields `42703`/`42P01`/`PGRST204`/`PGRST205`; transient errors are **not** flagged as drift. Cached wrapper keeps readiness polling cheap.
- **`/health`** — adds a `schema` check; on drift → `degraded` + **HTTP 503** listing affected tables.
- **`bun run verify:schema`** — pre-deploy gate; exits non-zero on drift.
- **`docs/SCHEMA_VERIFICATION.md`** — migration apply, PostgREST reload, backup/rollback.

## Verification
Server lint clean, typecheck 0, **327 tests pass** (incl. 8 new schema suites).

## Not covered here
Wiring `verify:schema` into the Railway pre-deploy pipeline needs the production DB connection (ops step); the script + docs make it a one-liner. Extend `REQUIRED_SCHEMA` as future migrations add depended-on columns.

Risk: human-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)