### PR TITLE
feat: enforce explicit production platform mode + report it (#96)

### DIFF
--- a/docs/PLATFORM_MODE.md
+++ b/docs/PLATFORM_MODE.md
@@ -1,0 +1,53 @@
+# Platform mode (`PLATFORM_MODE`) — production configuration (#96)
+
+Claire can route platforms two ways:
+
+- **`matrix`** — the documented production architecture: Synapse + mautrix
+  bridges. WhatsApp/Telegram/Instagram all flow through Matrix rooms.
+- **`direct`** — native per-platform adapters (whatsapp-web.js, etc.). Useful
+  for local development; **not** the intended production path.
+- **mock** — `MOCK_BRIDGE=true` replaces all adapters with scripted fixtures
+  (tests / demos, no infra).
+
+## The bug this guards against
+
+`PLATFORM_MODE` defaults to `direct`. A production deploy that forgets to set it
+boots in direct mode and silently diverges from the Matrix architecture. To
+prevent that, config validation now **fails fast in production** when
+`PLATFORM_MODE` is unset:
+
+```
+PLATFORM_MODE must be set explicitly in production (matrix|direct).
+Refusing to default to direct mode. ...
+```
+
+## Required configuration
+
+| Mode | Required env |
+| --- | --- |
+| `matrix` | `MATRIX_HOMESERVER_URL`, `MATRIX_SERVER_NAME`, and (in production) `MATRIX_ADMIN_TOKEN`. `MATRIX_BOT_USER_ID` recommended. |
+| `direct` | Per-platform credentials as applicable. |
+| mock | `MOCK_BRIDGE=true` (overrides the above). |
+
+`PLATFORM_MODE=matrix` with missing bridge config fails at startup with the list
+of missing variables.
+
+## Observability
+
+`GET /health` reports the effective mode:
+
+```json
+{ "status": "ok", "platformMode": "matrix", "checks": { "matrix": { "status": "ok" } } }
+```
+
+When `PLATFORM_MODE=matrix`, `/health` also validates the Synapse homeserver is
+reachable. Direct mode in production additionally logs a prominent startup
+warning.
+
+## Recovery
+
+1. Set `PLATFORM_MODE=matrix` (and the Matrix env above) on Railway.
+2. Redeploy. Confirm the startup log reads `Initializing platform adapters in
+   matrix mode` and `/health` shows `"platformMode": "matrix"` with `matrix: ok`.
+3. If a deploy fails startup with a platform-mode error, set the missing
+   variable(s) it names rather than removing the guard.

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { z } from 'zod';
 import path from 'path';
+import { validatePlatformMode } from './platform-mode';
 
 // Load .env from the server directory regardless of CWD
 dotenv.config({ path: path.join(__dirname, '../../.env') });
@@ -79,15 +80,17 @@ const parseEnv = () => {
   try {
     const env = envSchema.parse(process.env);
 
-    // Validate matrix config when in matrix mode
-    if (env.PLATFORM_MODE === 'matrix') {
-      if (!env.MATRIX_HOMESERVER_URL) {
-        throw new Error('MATRIX_HOMESERVER_URL is required when PLATFORM_MODE=matrix');
-      }
-      if (!env.MATRIX_SERVER_NAME) {
-        throw new Error('MATRIX_SERVER_NAME is required when PLATFORM_MODE=matrix');
-      }
-    }
+    // Validate platform mode + matrix config, and refuse a silent direct-mode
+    // fallback in production (#96).
+    validatePlatformMode({
+      nodeEnv: env.NODE_ENV,
+      platformMode: env.PLATFORM_MODE,
+      platformModeExplicit: process.env.PLATFORM_MODE !== undefined,
+      mockBridge: env.MOCK_BRIDGE,
+      matrixHomeserverUrl: env.MATRIX_HOMESERVER_URL,
+      matrixServerName: env.MATRIX_SERVER_NAME,
+      matrixAdminToken: env.MATRIX_ADMIN_TOKEN,
+    });
 
     return env;
   } catch (error) {

--- a/server/src/config/platform-mode.test.ts
+++ b/server/src/config/platform-mode.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for platform-mode validation (#96).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  validatePlatformMode,
+  resolvePlatformMode,
+  type PlatformModeEnv,
+} from './platform-mode';
+
+function env(overrides: Partial<PlatformModeEnv> = {}): PlatformModeEnv {
+  return {
+    nodeEnv: 'development',
+    platformMode: 'direct',
+    platformModeExplicit: true,
+    mockBridge: false,
+    matrixHomeserverUrl: undefined,
+    matrixServerName: undefined,
+    matrixAdminToken: undefined,
+    ...overrides,
+  };
+}
+
+const FULL_MATRIX = {
+  platformMode: 'matrix' as const,
+  matrixHomeserverUrl: 'https://matrix.example.com',
+  matrixServerName: 'example.com',
+  matrixAdminToken: 'secret-token',
+};
+
+describe('resolvePlatformMode', () => {
+  it('returns mock when the mock bridge is enabled', () => {
+    expect(resolvePlatformMode({ mockBridge: true, platformMode: 'matrix' })).toBe('mock');
+  });
+  it('returns the platform mode otherwise', () => {
+    expect(resolvePlatformMode({ mockBridge: false, platformMode: 'matrix' })).toBe('matrix');
+    expect(resolvePlatformMode({ mockBridge: false, platformMode: 'direct' })).toBe('direct');
+  });
+});
+
+describe('validatePlatformMode', () => {
+  describe('matrix mode config', () => {
+    it('accepts a fully-configured matrix mode', () => {
+      expect(() => validatePlatformMode(env(FULL_MATRIX))).not.toThrow();
+    });
+
+    it('throws when the homeserver URL is missing', () => {
+      expect(() =>
+        validatePlatformMode(env({ ...FULL_MATRIX, matrixHomeserverUrl: undefined }))
+      ).toThrow(/MATRIX_HOMESERVER_URL/);
+    });
+
+    it('requires the admin token only in production', () => {
+      const noToken = { ...FULL_MATRIX, matrixAdminToken: undefined };
+      expect(() => validatePlatformMode(env({ ...noToken, nodeEnv: 'development' }))).not.toThrow();
+      expect(() => validatePlatformMode(env({ ...noToken, nodeEnv: 'production' }))).toThrow(
+        /MATRIX_ADMIN_TOKEN/
+      );
+    });
+  });
+
+  describe('production direct-mode guard (#96)', () => {
+    it('throws when production would default to direct silently', () => {
+      expect(() =>
+        validatePlatformMode(
+          env({ nodeEnv: 'production', platformMode: 'direct', platformModeExplicit: false })
+        )
+      ).toThrow(/PLATFORM_MODE must be set explicitly/);
+    });
+
+    it('allows explicit direct mode in production', () => {
+      expect(() =>
+        validatePlatformMode(
+          env({ nodeEnv: 'production', platformMode: 'direct', platformModeExplicit: true })
+        )
+      ).not.toThrow();
+    });
+
+    it('allows the default direct mode outside production', () => {
+      expect(() =>
+        validatePlatformMode(
+          env({ nodeEnv: 'development', platformMode: 'direct', platformModeExplicit: false })
+        )
+      ).not.toThrow();
+    });
+
+    it('exempts mock-bridge mode from the guard', () => {
+      expect(() =>
+        validatePlatformMode(
+          env({ nodeEnv: 'production', platformMode: 'direct', platformModeExplicit: false, mockBridge: true })
+        )
+      ).not.toThrow();
+    });
+
+    it('accepts explicit matrix mode in production', () => {
+      expect(() =>
+        validatePlatformMode(env({ ...FULL_MATRIX, nodeEnv: 'production', platformModeExplicit: true }))
+      ).not.toThrow();
+    });
+  });
+});

--- a/server/src/config/platform-mode.ts
+++ b/server/src/config/platform-mode.ts
@@ -1,0 +1,67 @@
+/**
+ * Platform-mode resolution and validation (#96).
+ *
+ * Claire's documented production architecture is Matrix (Synapse + mautrix
+ * bridges). But `PLATFORM_MODE` defaults to `'direct'`, so a Railway deploy that
+ * simply forgets to set the variable silently boots in direct mode — diverging
+ * from the intended architecture and invalidating the multi-platform tickets.
+ *
+ * These pure helpers make the mode explicit and fail fast (with actionable
+ * messages) instead of falling back silently. Kept dependency-free so they are
+ * trivially unit-testable without loading the whole config module.
+ */
+
+export type PlatformMode = 'direct' | 'matrix';
+export type EffectivePlatformMode = 'mock' | PlatformMode;
+
+export interface PlatformModeEnv {
+  nodeEnv: string;
+  platformMode: PlatformMode;
+  /** True when PLATFORM_MODE was set explicitly (vs. taking the default). */
+  platformModeExplicit: boolean;
+  mockBridge: boolean;
+  matrixHomeserverUrl?: string;
+  matrixServerName?: string;
+  matrixAdminToken?: string;
+}
+
+/** The mode the server actually runs in, accounting for the mock bridge. */
+export function resolvePlatformMode(
+  env: Pick<PlatformModeEnv, 'mockBridge' | 'platformMode'>
+): EffectivePlatformMode {
+  return env.mockBridge ? 'mock' : env.platformMode;
+}
+
+/**
+ * Throw with an actionable message when the platform-mode configuration is
+ * invalid, or when production would silently fall back to direct mode.
+ */
+export function validatePlatformMode(env: PlatformModeEnv): void {
+  // Matrix mode needs its bridge configuration.
+  if (env.platformMode === 'matrix') {
+    const missing: string[] = [];
+    if (!env.matrixHomeserverUrl) missing.push('MATRIX_HOMESERVER_URL');
+    if (!env.matrixServerName) missing.push('MATRIX_SERVER_NAME');
+    // The admin token backs the bridge admin API + Matrix media proxy — required
+    // in production (dev/test may run a reduced Matrix setup).
+    if (env.nodeEnv === 'production' && !env.matrixAdminToken) {
+      missing.push('MATRIX_ADMIN_TOKEN');
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `PLATFORM_MODE=matrix requires: ${missing.join(', ')}. ` +
+          'Set the Synapse/mautrix configuration or switch PLATFORM_MODE.'
+      );
+    }
+  }
+
+  // #96: never silently default to 'direct' in production. An unset
+  // PLATFORM_MODE there is almost always a misconfiguration.
+  if (env.nodeEnv === 'production' && !env.mockBridge && !env.platformModeExplicit) {
+    throw new Error(
+      'PLATFORM_MODE must be set explicitly in production (matrix|direct). ' +
+        'Refusing to default to direct mode. Set PLATFORM_MODE=matrix with the ' +
+        'Synapse/mautrix configuration, or PLATFORM_MODE=direct to opt in deliberately.'
+    );
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import { redis } from './services/redis';
 import { sessionMonitor } from './services/session-monitor';
 import { reminderScheduler } from './services/reminder-scheduler';
 import { verifySchemaCached } from './services/schema-verification';
+import { resolvePlatformMode } from './config/platform-mode';
 import authRoutes from './routes/auth';
 import messageRoutes from './routes/messages';
 import aiRoutes from './routes/ai';
@@ -179,6 +180,10 @@ app.get('/health', async (_req, res) => {
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
     environment: config.NODE_ENV,
+    platformMode: resolvePlatformMode({
+      mockBridge: mockBridgeConfig.enabled,
+      platformMode: matrixConfig.mode,
+    }),
     checks,
     mockBridge: mockBridgeConfig.enabled,
   });
@@ -211,6 +216,16 @@ async function initializePlatforms() {
   } else {
     const mode = matrixConfig.enabled ? 'matrix' : 'direct';
     logger.info(`Initializing platform adapters in ${mode} mode...`);
+
+    // #96: direct mode in production diverges from the documented Matrix
+    // architecture. Config validation already blocks a *silent* default, so
+    // reaching here means direct mode was chosen explicitly — flag it loudly.
+    if (config.NODE_ENV === 'production' && mode === 'direct') {
+      logger.warn(
+        '⚠️  Running platform adapters in DIRECT mode in production — this diverges ' +
+          'from the documented Synapse/mautrix architecture. Set PLATFORM_MODE=matrix if unintended.'
+      );
+    }
 
     if (matrixConfig.enabled) {
       // Matrix mode: Use MatrixBridgeAdapter for all platforms via bridges


### PR DESCRIPTION
Addresses the core of #96. `PLATFORM_MODE` defaults to `direct`, so a Railway deploy that forgets to set it silently boots in direct mode — diverging from the documented Synapse/mautrix architecture (observed in production: *"Initializing platform adapters in direct mode"*).

## What
- **`config/platform-mode.ts`** — pure, unit-tested `validatePlatformMode()` + `resolvePlatformMode()`. In production it **refuses to default to `direct`** (PLATFORM_MODE must be set explicitly) and requires `MATRIX_ADMIN_TOKEN` for matrix mode. Wired into `config` parseEnv, so misconfig fails fast with an actionable message instead of a silent wrong-mode boot.
- **`/health`** — reports the effective `platformMode` (`matrix`|`direct`|`mock`); already validates Synapse reachability in matrix mode.
- **startup** — logs a prominent warning if production runs `direct` mode.
- **`docs/PLATFORM_MODE.md`** — required config per mode, observability, recovery steps.

## Safety
The guard only fires when `NODE_ENV=production`; dev/test keep the `direct` default. Full suite (337 tests) green.

## Ops remaining (yours)
The canonical-mode **decision** + setting `PLATFORM_MODE=matrix` and the Matrix env on Railway are ops actions. This makes a wrong/absent setting fail loudly with instructions rather than silently.

## Verification
Server lint clean, typecheck 0, **337 tests pass** (incl. 10 new platform-mode tests).

Risk: human-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)