### PR TITLE
docs: record audited Railway platform mode decision

### DIFF
--- a/docs/PLATFORM_MODE.md
+++ b/docs/PLATFORM_MODE.md
@@ -9,6 +9,27 @@ Claire can route platforms two ways:
 - **mock** — `MOCK_BRIDGE=true` replaces all adapters with scripted fixtures
   (tests / demos, no infra).
 
+## Current Railway production decision (audited 2026-08-01)
+
+The `claire` Railway project currently contains the Claire API, Redis, and the
+self-hosted Supabase services. It does **not** contain Synapse or any mautrix
+bridge services, and the Claire service has no Matrix connection variables.
+
+Until that infrastructure is provisioned, the canonical mode for the existing
+Railway environment is therefore explicitly:
+
+```text
+NODE_ENV=production
+PLATFORM_MODE=direct
+```
+
+This is an interim operational decision, not a change to the target
+architecture. Do not set `PLATFORM_MODE=matrix` on Railway until Synapse,
+mautrix-whatsapp, mautrix-telegram, and mautrix-meta are deployed and the Matrix
+variables below are populated. The production warning for direct mode is
+intentional: it keeps that architectural debt visible without making the
+currently deployable environment unusable.
+
 ## The bug this guards against
 
 `PLATFORM_MODE` defaults to `direct`. A production deploy that forgets to set it


### PR DESCRIPTION
## What changed

- records the 2026-08-01 Railway topology audit;
- documents `PLATFORM_MODE=direct` as the explicit interim mode for the existing Railway environment;
- explains that Matrix remains the target architecture and must not be enabled before Synapse and mautrix services exist;
- links the operational debt to #106.

## Why

PR #105 added the mode guard, but #96 still required the canonical-mode decision and production topology evidence. Railway currently has Claire, Redis, and Supabase services, with no Synapse/mautrix services or Matrix variables, so switching to Matrix today would make production unavailable.

## Validation

Documentation-only change. The production variable/topology audit and live deployment verification are recorded on #96.

Closes the documentation portion of #96.
