### PR TITLE
Fix mobile Google OAuth callback

### DIFF
--- a/client/app/(auth)/confirm.tsx
+++ b/client/app/(auth)/confirm.tsx
@@ -12,41 +12,51 @@ export default function ConfirmScreen() {
 
   const handleEmailConfirmation = async () => {
     try {
-      // Extract tokens from URL params
+      const code = params.code as string | undefined;
       const access_token = params.access_token as string;
       const refresh_token = params.refresh_token as string;
+      const oauthError = params.error_description || params.error;
 
-      if (access_token && refresh_token) {
-        // Set the session with the tokens from email confirmation
-        const { data, error } = await supabase.auth.setSession({
-          access_token,
-          refresh_token,
-        });
+      if (oauthError) {
+        console.error('OAuth callback error:', oauthError);
+        router.replace('/(auth)/signin');
+        return;
+      }
 
-        if (error) {
-          console.error('Error setting session:', error);
-          router.replace('/(auth)/signin');
-          return;
-        }
+      const result = code
+        ? await supabase.auth.exchangeCodeForSession(code)
+        : access_token && refresh_token
+          ? await supabase.auth.setSession({
+              access_token,
+              refresh_token,
+            })
+          : null;
 
-        if (data.session) {
-          // Email confirmed and user logged in
-          // Check if they have WhatsApp connected
-          const { data: sessions } = await supabase
-            .from('whatsapp_sessions')
-            .select('*')
-            .eq('user_id', data.session.user.id)
-            .eq('status', 'connected')
-            .single();
+      if (!result) {
+        router.replace('/(auth)/signin');
+        return;
+      }
 
-          if (sessions) {
-            router.replace('/(tabs)/dashboard');
-          } else {
-            router.replace('/(auth)/login');
-          }
+      if (result.error) {
+        console.error('Error setting session:', result.error);
+        router.replace('/(auth)/signin');
+        return;
+      }
+
+      if (result.data.session) {
+        const { data: sessions } = await supabase
+          .from('whatsapp_sessions')
+          .select('*')
+          .eq('user_id', result.data.session.user.id)
+          .eq('status', 'connected')
+          .single();
+
+        if (sessions) {
+          router.replace('/(tabs)/dashboard');
+        } else {
+          router.replace('/(auth)/login');
         }
       } else {
-        // No tokens, redirect to signin
         router.replace('/(auth)/signin');
       }
     } catch (error) {

--- a/client/services/googleAuth.ts
+++ b/client/services/googleAuth.ts
@@ -9,7 +9,7 @@ const redirectUri = AuthSession.makeRedirectUri({
   path: 'confirm',
 });
 
-function extractSessionFromUrl(url: string) {
+function extractAuthResponse(url: string) {
   const parsedUrl = new URL(url);
   const hashParams = new URLSearchParams(parsedUrl.hash.substring(1));
   const searchParams = parsedUrl.searchParams;
@@ -17,7 +17,14 @@ function extractSessionFromUrl(url: string) {
   const accessToken = hashParams.get('access_token') || searchParams.get('access_token');
   const refreshToken = hashParams.get('refresh_token') || searchParams.get('refresh_token');
 
-  return { accessToken, refreshToken };
+  return {
+    accessToken,
+    refreshToken,
+    code: searchParams.get('code'),
+    error: searchParams.get('error') || hashParams.get('error'),
+    errorDescription:
+      searchParams.get('error_description') || hashParams.get('error_description'),
+  };
 }
 
 export const googleAuth = {
@@ -38,15 +45,27 @@ export const googleAuth = {
       });
 
       if (result.type === 'success') {
-        const { accessToken, refreshToken } = extractSessionFromUrl(result.url);
+        const response = extractAuthResponse(result.url);
 
-        if (!accessToken || !refreshToken) {
-          throw new Error('No auth tokens in OAuth response');
+        if (response.error) {
+          throw new Error(response.errorDescription || response.error);
+        }
+
+        if (response.code) {
+          const { data: session, error: sessionError } =
+            await supabase.auth.exchangeCodeForSession(response.code);
+
+          if (sessionError) throw sessionError;
+          return { session, error: null };
+        }
+
+        if (!response.accessToken || !response.refreshToken) {
+          throw new Error('No authorization code or auth tokens in OAuth response');
         }
 
         const { data: session, error: sessionError } = await supabase.auth.setSession({
-          access_token: accessToken,
-          refresh_token: refreshToken,
+          access_token: response.accessToken,
+          refresh_token: response.refreshToken,
         });
 
         if (sessionError) throw sessionError;

--- a/client/services/supabase.ts
+++ b/client/services/supabase.ts
@@ -11,6 +11,6 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: platformCapabilities.isWeb,
-    flowType: 'implicit',
+    flowType: platformCapabilities.isWeb ? 'implicit' : 'pkce',
   },
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import { reminderScheduler } from './services/reminder-scheduler';
 import { verifySchemaCached } from './services/schema-verification';
 import { resolvePlatformMode } from './config/platform-mode';
 import authRoutes from './routes/auth';
+import { buildOAuthCallbackUrl, resolveOAuthClient } from './utils/oauth-callback';
 import messageRoutes from './routes/messages';
 import { BridgeHttpClient } from './adapters/matrix/bridge-http-client';
 import aiRoutes from './routes/ai';
@@ -125,10 +126,36 @@ app.use('/push-tokens', pushTokenRoutes);
 app.use('/contacts', contactRoutes);
 app.use('/auto-reply', autoReplyRoutes);
 
-// Handle Supabase email confirmation redirects
-app.get('/', (_req, res) => {
-  // If there's a hash fragment with tokens, serve the confirmation page
-  res.sendFile(__dirname + '/routes/email-confirm.html');
+// GoTrue falls back to its site URL when a custom application scheme is not
+// allow-listed. Route OAuth codes back to the correct Claire client while
+// retaining the email-confirmation page for requests without OAuth fields.
+app.get('/', (req, res, next) => {
+  const code = typeof req.query.code === 'string' ? req.query.code : null;
+  const error = typeof req.query.error === 'string' ? req.query.error : null;
+  const errorDescription = typeof req.query.error_description === 'string'
+    ? req.query.error_description
+    : null;
+
+  if (code || error) {
+    const client = resolveOAuthClient(req.query.client, req.get('user-agent') || '');
+    const callback = buildOAuthCallbackUrl({
+      client,
+      code,
+      error,
+      errorDescription,
+    });
+    logger.info('Forwarding Supabase OAuth callback to Claire client', {
+      client,
+      hasCode: Boolean(code),
+      hasError: Boolean(error),
+    });
+    res.setHeader('Cache-Control', 'no-store');
+    return res.redirect(302, callback);
+  }
+
+  return res.sendFile(__dirname + '/routes/email-confirm.html', (sendError) => {
+    if (sendError) next(sendError);
+  });
 });
 
 // Matrix media proxy — serves mxc:// content via the admin token

--- a/server/src/utils/oauth-callback.test.ts
+++ b/server/src/utils/oauth-callback.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { buildOAuthCallbackUrl, resolveOAuthClient } from './oauth-callback';
+
+describe('OAuth callback routing', () => {
+  test('routes iOS and Android auth sessions to the mobile scheme', () => {
+    expect(resolveOAuthClient(undefined, 'Claire/1 CFNetwork iPhone OS/26.0')).toBe('mobile');
+    expect(resolveOAuthClient(undefined, 'Mozilla/5.0 (Linux; Android 16)')).toBe('mobile');
+  });
+
+  test('routes desktop browsers to the desktop scheme', () => {
+    expect(resolveOAuthClient(undefined, 'Mozilla/5.0 (Macintosh; Intel Mac OS X)')).toBe('desktop');
+  });
+
+  test('allows an explicit client marker to override user-agent detection', () => {
+    expect(resolveOAuthClient('mobile', 'Mozilla/5.0 (Macintosh)')).toBe('mobile');
+    expect(resolveOAuthClient('desktop', 'Mozilla/5.0 (iPhone)')).toBe('desktop');
+  });
+
+  test('preserves the authorization code and provider error details', () => {
+    expect(buildOAuthCallbackUrl({
+      userAgent: 'Mozilla/5.0 (iPhone)',
+      code: 'auth-code',
+    })).toBe('claire://confirm?code=auth-code');
+
+    expect(buildOAuthCallbackUrl({
+      client: 'desktop',
+      error: 'access_denied',
+      errorDescription: 'Login cancelled',
+    })).toBe('clairedesktop://auth/callback?error=access_denied&error_description=Login+cancelled');
+  });
+});

--- a/server/src/utils/oauth-callback.ts
+++ b/server/src/utils/oauth-callback.ts
@@ -1,0 +1,36 @@
+export type OAuthClient = 'mobile' | 'desktop';
+
+function requestedClient(value: unknown): OAuthClient | null {
+  if (value === 'mobile' || value === 'desktop') return value;
+  return null;
+}
+
+export function resolveOAuthClient(client: unknown, userAgent = ''): OAuthClient {
+  const explicitClient = requestedClient(client);
+  if (explicitClient) return explicitClient;
+
+  return /iPhone|iPad|iPod|Android/i.test(userAgent) ? 'mobile' : 'desktop';
+}
+
+export function buildOAuthCallbackUrl(options: {
+  client?: unknown;
+  userAgent?: string;
+  code?: string | null;
+  error?: string | null;
+  errorDescription?: string | null;
+}): string {
+  const client = resolveOAuthClient(options.client, options.userAgent);
+  const callback = new URL(
+    client === 'mobile'
+      ? 'claire://confirm'
+      : 'clairedesktop://auth/callback',
+  );
+
+  if (options.code) callback.searchParams.set('code', options.code);
+  if (options.error) callback.searchParams.set('error', options.error);
+  if (options.errorDescription) {
+    callback.searchParams.set('error_description', options.errorDescription);
+  }
+
+  return callback.toString();
+}


### PR DESCRIPTION
## Summary
- route Supabase OAuth callbacks to the correct mobile or desktop URL scheme
- use PKCE for native Expo authentication and exchange authorization codes
- support OAuth codes and errors in the cold-start confirm route
- add callback routing regression tests

## Verification
- server TypeScript check passed in the active workspace
- client TypeScript check passed in the active workspace
- client Jest: 13 passed
- callback routing tests: 4 passed
- iOS simulator recognized `claire://confirm` and returned to Claire