### PR TITLE
docs: add reliable notification rollout and acceptance gate

### DIFF
--- a/docs/deployment/NOTIFICATION_ROLLOUT.md
+++ b/docs/deployment/NOTIFICATION_ROLLOUT.md
@@ -1,0 +1,161 @@
+# Notification rollout and acceptance
+
+The reliable notification implementation is already present on `main`. It is
+not complete in an environment until the API, database migration, provider
+credentials, and newly built clients are deployed together.
+
+## What ships
+
+- Expo Push delivery for iOS and Android.
+- Direct APNs delivery for the native macOS app.
+- Device-aware registration and deregistration.
+- Redis/Bull delivery jobs and Expo receipt polling.
+- Delivery audit rows, invalid-token cleanup, quiet hours, badges, deep links,
+  and per-device active-chat suppression.
+
+Windows and browser background push are not part of this rollout.
+
+## 1. Apply the database migration
+
+Apply migrations through the normal production migration process. The required
+notification migration is:
+
+```text
+supabase/migrations/20260815000000_reliable_notification_devices.sql
+```
+
+Reload the PostgREST schema after applying it:
+
+```sql
+NOTIFY pgrst, 'reload schema';
+```
+
+Confirm both tables exist:
+
+```sql
+select to_regclass('public.notification_devices');
+select to_regclass('public.notification_deliveries');
+```
+
+## 2. Configure providers
+
+The API requires its normal Supabase and Redis configuration. macOS delivery
+also requires these server-only secrets:
+
+| Variable | Meaning |
+|---|---|
+| `APNS_KEY_ID` | Apple push signing key ID |
+| `APNS_TEAM_ID` | Apple Developer team ID |
+| `APNS_PRIVATE_KEY` | Contents of the APNs `.p8` key; escaped newlines are accepted |
+| `APNS_MACOS_TOPIC` | Signed macOS app bundle identifier |
+| `APNS_USE_SANDBOX` | `true` for development-signed builds; `false` for production |
+
+Never expose those values through an `EXPO_PUBLIC_` variable or commit them.
+
+For mobile, verify the EAS project has valid APNs and FCM credentials. The
+mobile build must include the same EAS project ID configured in `mobile/app.json`.
+
+## 3. Deploy the API
+
+Deploy the current `main` server after the migration and secrets are ready.
+Redis must be reachable by the API; notification workers run in the API process
+and use the `notification-delivery` Bull queue.
+
+Run the automated readiness check from the repository root:
+
+```bash
+CLAIRE_API_URL=https://<api-host> \
+SUPABASE_URL=https://<supabase-api-host> \
+SUPABASE_ANON_KEY=<anon-key> \
+bun run notifications:check
+```
+
+The check intentionally uses only the public anon key. A successful result
+proves that the deployed API route exists and PostgREST can see both tables; it
+does not prove provider delivery.
+
+## 4. Build new clients
+
+Old installed builds cannot register through the new device endpoint. Produce
+and install fresh binaries after the API deployment:
+
+```bash
+cd mobile
+bunx eas build --profile preview --platform ios
+bunx eas build --profile preview --platform android
+```
+
+Use physical devices. Expo Go and simulators do not provide a valid production
+acceptance path for remote push.
+
+Build and sign the macOS target with the Push Notifications capability. Its
+`aps-environment`, `APNS_USE_SANDBOX`, and provisioning profile must agree.
+
+## 5. Prove registration
+
+Sign in, grant notification permission, then foreground each client once.
+There must be one enabled registration per device:
+
+```sql
+select user_id, device_id, platform, provider, enabled, app_version,
+       timezone, last_seen_at, token_refreshed_at
+from public.notification_devices
+order by last_seen_at desc;
+```
+
+Expected providers:
+
+- iOS and Android: `expo`
+- macOS: `apns`
+
+Do not paste raw device tokens into tickets or logs.
+
+## 6. Provider acceptance
+
+Send a genuinely new incoming message from a connected network. Outgoing,
+backfilled, and duplicate-upsert messages are intentionally ineligible.
+
+Inspect the audit trail without exposing tokens:
+
+```sql
+select message_id, device_id, state, attempts, provider_ticket_id,
+       provider_receipt_id, error_code, error_message, created_at,
+       submitted_at, delivered_at, failed_at
+from public.notification_deliveries
+order by created_at desc
+limit 50;
+```
+
+For Expo, `submitted` is not final acceptance. Wait for receipt polling to mark
+the row `delivered` or `failed`. Direct APNs success is recorded as `delivered`.
+
+## 7. Acceptance matrix
+
+For iOS, Android, and macOS, record results for:
+
+- foreground, background, locked, and fully quit;
+- notification tap opening the correct conversation and message;
+- badge increase and clearing after the chat is read;
+- quiet hours and global/message notification preferences;
+- two signed-in devices receiving independently;
+- active-chat suppression only on the device displaying that chat;
+- sign-out deregistration and token rotation;
+- WhatsApp, Telegram, and Instagram incoming messages.
+
+Record OS/app version, platform, message ID, provider ticket/receipt ID,
+delivery state, latency, and failure reason in the notification umbrella issue.
+
+## Troubleshooting order
+
+1. No `notification_devices` row: inspect permission, physical-device status,
+   EAS project ID, authentication, and the public API URL embedded in the build.
+2. Registration exists but no delivery row: confirm the message was incoming,
+   live, non-duplicate, and preferences permit it.
+3. `suppressed`: inspect `error_code` for `quiet_hours` or `active_chat`.
+4. `queued`: check Redis connectivity and API worker logs.
+5. `failed`: use `error_code`; invalid tokens are disabled automatically.
+6. Expo remains `submitted`: inspect receipt polling and queue health.
+
+Rollback the client or API independently only if their public interfaces remain
+compatible. Do not roll back the database migration while registrations or
+delivery rows still reference the new tables.

--- a/docs/deployment/PRODUCTION_SETUP.md
+++ b/docs/deployment/PRODUCTION_SETUP.md
@@ -69,6 +69,10 @@ bunx eas build --profile preview --platform ios
 bunx eas build --profile production --platform ios
 ```
 
+Remote notifications require a coordinated database, API, provider, and client
+rollout. Follow [Notification rollout and acceptance](./NOTIFICATION_ROLLOUT.md)
+before treating a successful build as notification-ready.
+
 ## Operator notes
 
 Database passwords, Railway project IDs, proxy hosts, and incident runbooks must stay in private ops docs. If you find a live credential or hostname in this repository, treat it as exposed: rotate it and open a security issue.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:plugins": "bun test examples/plugins",
     "landing": "bunx serve landing",
     "catalog:generate": "bun run scripts/generate-platform-catalog.ts",
+    "notifications:check": "bash scripts/check-notification-readiness.sh",
     "dev:prod": "concurrently \"bun run dev:server\" \"bun run mobile:prod\"",
     "mobile:prod": "cd mobile && bun run start:prod",
     "mobile:prod:local": "cd mobile && bun run start:prod:local",

--- a/scripts/check-notification-readiness.sh
+++ b/scripts/check-notification-readiness.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLAIRE_API_URL:?Set CLAIRE_API_URL to the deployed Claire API origin}"
+: "${SUPABASE_URL:?Set SUPABASE_URL to the deployed Supabase API origin}"
+: "${SUPABASE_ANON_KEY:?Set SUPABASE_ANON_KEY to the public anon key}"
+
+api_origin="${CLAIRE_API_URL%/}"
+supabase_origin="${SUPABASE_URL%/}"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+health_status="$(curl --silent --show-error --output "$temporary_directory/health.json" --write-out '%{http_code}' --max-time 15 "$api_origin/health")"
+if [[ "$health_status" != "200" ]]; then
+  echo "FAIL API health returned HTTP $health_status"
+  exit 1
+fi
+echo "PASS API health"
+
+route_status="$(curl --silent --show-error --output "$temporary_directory/route.json" --write-out '%{http_code}' --max-time 15 --request PUT "$api_origin/notification-devices" --header 'Content-Type: application/json' --data '{}')"
+if [[ "$route_status" != "401" ]]; then
+  echo "FAIL notification registration route returned HTTP $route_status; expected 401 without authentication"
+  exit 1
+fi
+echo "PASS notification registration route is deployed"
+
+for table_name in notification_devices notification_deliveries; do
+  table_status="$(curl --silent --show-error --output "$temporary_directory/$table_name.json" --write-out '%{http_code}' --max-time 15 "$supabase_origin/rest/v1/$table_name?select=id&limit=1" --header "apikey: $SUPABASE_ANON_KEY")"
+  if [[ "$table_status" != "200" ]]; then
+    echo "FAIL PostgREST table $table_name returned HTTP $table_status"
+    exit 1
+  fi
+  echo "PASS PostgREST exposes $table_name"
+done
+
+echo "READY deployment prerequisites are visible; continue with physical-device registration and provider acceptance"


### PR DESCRIPTION
## Summary

- documents the coordinated database, API, provider, and client rollout required to activate reliable notifications
- adds `bun run notifications:check` to verify the deployed API route and notification tables before physical-device testing
- defines registration checks, provider receipt acceptance, the iOS/Android/macOS test matrix, troubleshooting order, and rollback constraints

## Why this PR is operational rather than a duplicate implementation

The notification implementation from `2f3cd43` is already an ancestor of `main`. The current production environment is behind that code and schema:

- production `/health` returns 200
- production `PUT /notification-devices` returns 404 instead of the expected unauthenticated 401
- production PostgREST does not expose `notification_devices` or `notification_deliveries`
- installed mobile builds predate the implementation

This PR packages the remaining work and makes deployment readiness executable.

## Verification

- `bash -n scripts/check-notification-readiness.sh`
- `git diff --check`
- ran the check against production: API health passed and the notification-route gate correctly failed on HTTP 404

## Completion checklist

- [ ] Apply `20260815000000_reliable_notification_devices.sql`
- [ ] Reload the PostgREST schema
- [ ] Configure macOS APNs secrets and verify Expo APNs/FCM credentials
- [ ] Deploy current `main` API with Redis available
- [ ] Run `bun run notifications:check` successfully
- [ ] Build and install fresh iOS, Android, and signed macOS clients
- [ ] Confirm one registration per physical device
- [ ] Capture provider receipt/delivery evidence for the acceptance matrix

Closes the deployment-documentation portion of #110; physical-device acceptance remains required before closing the umbrella issue.
