### PR TITLE
fix: home message highlight and duplicate inbox search

### DIFF
--- a/apps/client/features/home/home-screen.tsx
+++ b/apps/client/features/home/home-screen.tsx
@@ -129,7 +129,12 @@ export function HomeScreen() {
       time: formatInboxTimestamp(message.timestamp),
       kind: 'message' as const,
       urgent: 'score' in message && typeof message.score === 'number' && message.score >= 70,
-      onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: message.chat_id, contact_name: message.contact_name || '', chat_name: message.chat_name || '', platform: message.platform || '', is_group: message.is_group ? '1' : '0', highlightMessageId: message.id } }),
+      // No highlightMessageId: these rows are always a conversation's newest
+      // message, so it is already the last bubble. Ringing it in focus blue
+      // marks the obvious and reads as an unexplained state. The highlight is
+      // for search results and assistant citations, where the message is buried
+      // in history and the reader needs to be told which one they were sent to.
+      onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: message.chat_id, contact_name: message.contact_name || '', chat_name: message.chat_name || '', platform: message.platform || '', is_group: message.is_group ? '1' : '0' } }),
     }; }),
     ...openPromises.slice(0, Math.max(0, 4 - Math.min(urgent.length, 3))).map(promise => ({
       key: `promise-${promise.id}`,

--- a/apps/client/features/inbox/inbox-screen.tsx
+++ b/apps/client/features/inbox/inbox-screen.tsx
@@ -308,10 +308,10 @@ export function InboxScreen() {
       <MobileHeader
         title="Inbox"
         safeArea
-        actions={<View style={{ flexDirection: 'row', gap: space[2] }}>
-          <MobileIconButton label="Search everything" testID="inbox-open-search" onPress={() => router.push('/(tabs)/search' as never)}><Search size={20} color={colors.ink} /></MobileIconButton>
-          <MobileIconButton label="New message" testID="inbox-compose" onPress={() => router.push('/compose' as never)}><PenSquare size={20} color={colors.ink} /></MobileIconButton>
-        </View>}
+        // The header carried a second magnifying glass beside the search field
+        // directly below it — two controls, one obvious meaning, different
+        // destinations.
+        actions={<MobileIconButton label="New message" testID="inbox-compose" onPress={() => router.push('/compose' as never)}><PenSquare size={20} color={colors.ink} /></MobileIconButton>}
       />
       <View style={{ paddingHorizontal: space[4], gap: space[3], paddingBottom: space[3], borderBottomWidth: 1, borderBottomColor: colors.neutral[200] }}>
         <MobileSearchField style={{ minHeight: 46, borderRadius: 13, paddingHorizontal: space[4], backgroundColor: colors.neutral[100] }} inputStyle={{ fontSize: 15, lineHeight: 20 }} icon={<Search size={24} strokeWidth={1.7} color={colors.neutral[600]} />} value={query} onChangeText={setQuery} placeholder="Search conversations" returnKeyType="search" testID="messages-search-input" />


### PR DESCRIPTION
## Summary
- `feat/conversation-feed` is already on `main` via #146; this PR is the leftover local polish from that branch.
- Opening a chat from Home no longer highlights the newest message (it is already the last bubble; the highlight is for search and assistant citations).
- Inbox header no longer shows a second search button next to the search field below it.

## Test plan
- [ ] From Home, tap a day-item conversation and confirm the latest bubble is not ringed in focus blue
- [ ] From Search or an assistant citation, confirm the target message still highlights
- [ ] On Inbox, confirm the header only has compose, and the search field still filters conversations
- [ ] Confirm the global Search tab is still reachable from its own tab / More destination


Made with [Cursor](https://cursor.com)