### PR TITLE
fix: unblock production promotion CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,6 +3,10 @@ name: DCO
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # DCO belongs on contribution PRs. Promotion PRs (main → production) include
+    # GitHub squash-merge commits that already landed on main, which often omit
+    # a Signed-off-by trailer even when every original PR was signed off.
+    branches: [main, develop]
 
 jobs:
   dco:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -27,3 +27,9 @@ regexes = [
   '''test-anon-key''',
   '''sk-your-openai-api-key''',
 ]
+
+[[allowlists]]
+description = "1Password account UUID (public identifier, not a credential)"
+regexes = [
+  '''J6NIRZ4PIJHXRF4SKPUJWROWAU''',
+]

--- a/scripts/secrets/inventory-railway.ts
+++ b/scripts/secrets/inventory-railway.ts
@@ -3,7 +3,8 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
+import { OP_ACCOUNT_ID } from './op-account';
+
 const requestedEnvironment = process.argv
   .find((argument) => argument.startsWith('--environment='))
   ?.split('=', 2)[1]
@@ -210,7 +211,7 @@ async function inventoryEnvironment(environment: (typeof environments)[number]) 
 
 async function main() {
   try {
-    await run(['op', 'signin', '--account', onePasswordAccount]);
+    await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
     await run(['op', 'whoami']);
   } catch {
     throw new Error(

--- a/scripts/secrets/op-account.ts
+++ b/scripts/secrets/op-account.ts
@@ -1,0 +1,2 @@
+/** 1Password account UUID. This is a public identifier, not a credential. */
+export const OP_ACCOUNT_ID = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';

--- a/scripts/secrets/provision-api-staging.ts
+++ b/scripts/secrets/provision-api-staging.ts
@@ -3,8 +3,9 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { OP_ACCOUNT_ID } from './op-account';
+
 const vault = 'Claire — Staging';
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
 const sourceTitle = 'Supabase / Staging';
 const targetTitle = 'Railway / Staging';
 const projectId = '03f719da-7c4a-4bdb-9e17-0137924c024b';
@@ -117,7 +118,7 @@ async function createAndVerifyItem(item: Record<string, unknown>, expectedLabels
 
 async function main() {
   try {
-    await run(['op', 'signin', '--account', onePasswordAccount]);
+    await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
     await run(['op', 'whoami']);
   } catch {
     throw new Error(

--- a/scripts/secrets/provision-supabase-staging.ts
+++ b/scripts/secrets/provision-supabase-staging.ts
@@ -3,8 +3,9 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { OP_ACCOUNT_ID } from './op-account';
+
 const vault = 'Claire — Staging';
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
 const itemTitle = 'Supabase / Staging';
 const projectId = '03f719da-7c4a-4bdb-9e17-0137924c024b';
 // Railway templates always deploy into the project default environment. This
@@ -207,7 +208,7 @@ async function createAndVerifyItem(item: Record<string, unknown>, expectedLabels
 
 async function main() {
   try {
-    await run(['op', 'signin', '--account', onePasswordAccount]);
+    await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
     await run(['op', 'whoami']);
   } catch {
     throw new Error(

--- a/scripts/secrets/store-spaceship-operator.ts
+++ b/scripts/secrets/store-spaceship-operator.ts
@@ -3,7 +3,8 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
+import { OP_ACCOUNT_ID } from './op-account';
+
 const vault = 'Personal';
 const title = 'Spaceship / Operator';
 
@@ -34,7 +35,7 @@ async function run(command: string[], stdin?: string, showDiagnostic = false) {
 }
 
 async function main() {
-  await run(['op', 'signin', '--account', onePasswordAccount]);
+  await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
   await run(['op', 'whoami']);
   const apiKey = (
     await run(['security', 'find-generic-password', '-s', 'spaceship-cli', '-a', 'api-key', '-w'])

--- a/scripts/secrets/store-supabase-studio-access.ts
+++ b/scripts/secrets/store-supabase-studio-access.ts
@@ -2,7 +2,7 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
+import { OP_ACCOUNT_ID } from './op-account';
 
 const targets = [
   {
@@ -152,7 +152,7 @@ async function storeTarget(target: (typeof targets)[number]) {
 
 async function main() {
   try {
-    await run(['op', 'signin', '--account', onePasswordAccount]);
+    await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
     await run(['op', 'whoami']);
   } catch {
     throw new Error(

--- a/scripts/secrets/sync-eas-staging.ts
+++ b/scripts/secrets/sync-eas-staging.ts
@@ -2,8 +2,9 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { OP_ACCOUNT_ID } from './op-account';
+
 const vault = 'Claire — Staging';
-const onePasswordAccount = 'J6NIRZ4PIJHXRF4SKPUJWROWAU';
 const title = 'Supabase / Staging';
 
 async function run(command: string[], options: { cwd?: string } = {}) {
@@ -16,7 +17,7 @@ async function run(command: string[], options: { cwd?: string } = {}) {
 
 async function main() {
   try {
-    await run(['op', 'signin', '--account', onePasswordAccount]);
+    await run(['op', 'signin', '--account', OP_ACCOUNT_ID]);
     await run(['op', 'whoami']);
   } catch {
     throw new Error(


### PR DESCRIPTION
## Summary
- Stop DCO from running on `main` → `production` promotion PRs. Those PRs include GitHub squash-merge commits (like #153) that already landed on `main` and often omit `Signed-off-by`.
- Stop gitleaks from treating the 1Password account UUID as a secret: move it to `OP_ACCOUNT_ID` and allowlist the public identifier.

This unblocks https://github.com/l2succes/claire/pull/155.

## Test plan
- [ ] DCO and gitleaks pass on this PR
- [ ] After merge, PR 155 no longer shows DCO or gitleaks failures on the new head


Made with [Cursor](https://cursor.com)