### PR TITLE
fix(server): restore morning brief on production schema

### DIFF
--- a/apps/server/src/routes/ai.ts
+++ b/apps/server/src/routes/ai.ts
@@ -507,7 +507,7 @@ router.get('/morning-brief',
       const since = new Date(Date.now() - 7 * 24 * 3600_000).toISOString(); // last 7 days
       const { data: rows, error } = await supabase
         .from('messages')
-        .select(`id, chat_id, content, timestamp, from_me, is_group, contact_name, chat_name, platform,
+        .select(`id, chat_id, content, timestamp, from_me, is_group, contact_name, platform,
                  chats!messages_chat_id_fkey(name, platform_chat_id)`)
         .eq('user_id', userId)
         .eq('from_me', false)
@@ -540,7 +540,7 @@ router.get('/morning-brief',
           id: row.id,
           chat_id: chatId,
           contact_name: row.contact_name ?? undefined,
-          chat_name: (row.chats as any)?.name || row.chat_name || undefined,
+          chat_name: (row.chats as any)?.name || undefined,
           content: row.content,
           timestamp: row.timestamp,
           from_me: row.from_me,


### PR DESCRIPTION
Removes the nonexistent messages.chat_name column from the morning-brief query. The existing chats join already provides the chat name.\n\nVerified with server typecheck and lint.