### PR TITLE
fix(ops): surface partial bridge outages

### DIFF
--- a/apps/server/src/services/operations-health.test.ts
+++ b/apps/server/src/services/operations-health.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { classifyMessageFreshness } from './operations-health';
+import { classifyBridgeSessions, classifyMessageFreshness } from './operations-health';
 
 describe('classifyMessageFreshness', () => {
   it('is healthy when the current window has traffic', () => {
@@ -12,5 +12,18 @@ describe('classifyMessageFreshness', () => {
 
   it('does not alert merely because an account is quiet', () => {
     expect(classifyMessageFreshness(0, 0, 120).status).toBe('unknown');
+  });
+});
+
+describe('classifyBridgeSessions', () => {
+  it('warns when a platform session needs attention even if another is connected', () => {
+    expect(classifyBridgeSessions(1, 2)).toEqual({
+      status: 'warning',
+      summary: '1 durable bridge session(s) connected; 2 require attention',
+    });
+  });
+
+  it('is critical when no sessions are connected', () => {
+    expect(classifyBridgeSessions(0, 1).status).toBe('critical');
   });
 });

--- a/apps/server/src/services/operations-health.ts
+++ b/apps/server/src/services/operations-health.ts
@@ -17,3 +17,22 @@ export function classifyMessageFreshness(
   }
   return { status: 'unknown', summary: 'No recent traffic baseline; freshness cannot be inferred' };
 }
+
+export function classifyBridgeSessions(
+  connected: number,
+  disconnected: number,
+): { status: OperationsStatus; summary: string } {
+  if (connected === 0 && disconnected > 0) {
+    return { status: 'critical', summary: 'No durable bridge sessions are connected' };
+  }
+  if (disconnected > 0) {
+    return {
+      status: 'warning',
+      summary: `${connected} durable bridge session(s) connected; ${disconnected} require attention`,
+    };
+  }
+  if (connected > 0) {
+    return { status: 'healthy', summary: `${connected} durable bridge session(s) connected` };
+  }
+  return { status: 'unknown', summary: 'No messaging accounts are connected' };
+}

--- a/apps/server/src/services/operations-monitor.ts
+++ b/apps/server/src/services/operations-monitor.ts
@@ -3,7 +3,7 @@ import { pushNotificationService } from './push-notification';
 import { redis } from './redis';
 import { type DbRow, supabase } from './supabase';
 import { logger } from '../utils/logger';
-import { classifyMessageFreshness } from './operations-health';
+import { classifyBridgeSessions, classifyMessageFreshness } from './operations-health';
 
 export type OperationsStatus = 'healthy' | 'warning' | 'critical' | 'unknown';
 
@@ -102,10 +102,7 @@ class OperationsMonitor {
     if (error) return { component: 'bridge_sessions', status: 'critical', summary: 'Could not read durable bridge sessions', details: { error: error.code || 'query_failed' } };
     const connected = (data || []).filter((row: DbRow) => row.status === 'connected').length;
     const disconnected = (data || []).filter((row: DbRow) => row.status === 'disconnected' || row.status === 'failed').length;
-    if (connected === 0 && disconnected > 0) {
-      return { component: 'bridge_sessions', status: 'critical', summary: 'No durable bridge sessions are connected', details: { connected, disconnected } };
-    }
-    return { component: 'bridge_sessions', status: connected > 0 ? 'healthy' : 'unknown', summary: connected > 0 ? `${connected} durable bridge session(s) connected` : 'No messaging accounts are connected', details: { connected, disconnected } };
+    return { component: 'bridge_sessions', ...classifyBridgeSessions(connected, disconnected), details: { connected, disconnected } };
   }
 
   private async checkMessageFlow(): Promise<OperationsComponentCheck[]> {


### PR DESCRIPTION
The monitor previously reported a healthy bridge fleet whenever any bridge session was connected. This makes connected WhatsApp mask disconnected or failed Instagram sessions.

This change classifies partial failures as a warning and preserves a critical state when no session is connected.

Verified with unit tests and server typecheck.