### PR TITLE
fix(deploy): include workspace manifests for Railway

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,7 +1,5 @@
 apps/server/sessions/
 docker/
-apps/client/
-apps/website/
 docs/
 after_settings_tap.png
 *.png


### PR DESCRIPTION
The server Dockerfile copies the client and website manifests while resolving the Bun workspace. Do not exclude those directories from the Railway upload context.

This unblocks deployment of the production operations monitor fix.