### PR TITLE
fix(contacts): hide opaque WhatsApp LIDs

### DIFF
--- a/apps/client/app/chat/[chatId].tsx
+++ b/apps/client/app/chat/[chatId].tsx
@@ -42,6 +42,7 @@ import { useConversationSettingsStore } from '../../stores/conversationSettingsS
 import { GroupChatSummary } from '../../components/GroupChatSummary';
 import { Platform } from '../../types/platform';
 import { PlatformName } from '../../components/PlatformIcon';
+import { displayContactName } from '../../services/contact-display';
 import {
   setActiveNotificationChat,
   syncNotificationBadge,
@@ -487,7 +488,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
   const displayName =
     is_group === '1'
       ? chat_name || contact_name || 'Group'
-      : contact_name || chat_name || 'Unknown';
+      : displayContactName(contact_name || chat_name, platform, undefined, 'Contact');
   const activeSession = connectedSessions.find(
     (session) => session.platform === (platform as Platform) && session.status === 'connected'
   );

--- a/apps/client/app/chat/settings/[chatId].tsx
+++ b/apps/client/app/chat/settings/[chatId].tsx
@@ -13,6 +13,7 @@ import { PlatformBadge } from '../../../components/PlatformIcon';
 import { Platform } from '../../../types/platform';
 import type { ChatCategory } from '../../../types/conversationSettings';
 import { formatPhoneNumber, formatPhoneNumberInput, normalizePhoneNumber } from '../../../services/phone-numbers';
+import { displayContactName } from '../../../services/contact-display';
 
 const TONES = [
   { key: 'warm', title: 'Warm + direct', description: 'Clear, human, confident' },
@@ -46,13 +47,16 @@ export default function ConversationSettingsScreen() {
   const { settings, fetchSettings, setCategory, updateProfile, refreshInsights } = useConversationSettingsStore();
   const chatSettings = settings[chatId];
   const isLoading = chatSettings?.isLoading ?? true;
-  const displayName = is_group === '1' ? (chat_name || contact_name || 'Group') : (contact_name || chat_name || 'Unknown');
   const [sourcePhone, setSourcePhone] = useState('');
   const [details, setDetails] = useState({ phone: '', email: '', location: '' });
   const [memory, setMemory] = useState('');
   const [instruction, setInstruction] = useState('');
   const [tone, setTone] = useState<ToneKey | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const displayName =
+    is_group === '1'
+      ? chat_name || contact_name || 'Group'
+      : displayContactName(contact_name || chat_name, platform, sourcePhone, 'Contact');
 
   useEffect(() => { if (chatId) void fetchSettings(chatId); }, [chatId, fetchSettings]);
 

--- a/apps/client/hooks/useInboxMessages.ts
+++ b/apps/client/hooks/useInboxMessages.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery, useQueryClient, type InfiniteData, type QueryClient }
 import { supabase, type DbRow } from '../services/supabase';
 import { Platform } from '../types/platform';
 import { cacheTimeline, hydrateMobileCache, usesNativeMobileCache, type CachedChat } from '../services/mobile-cache';
+import { displayContactName } from '../services/contact-display';
 
 export interface InboxMessage {
   id: string;
@@ -116,10 +117,14 @@ function conversationRowToInboxMessage(row: DbRow): InboxMessage {
   const chatId = String(row.chat_id);
   const platform = (row.platform as Platform) || Platform.WHATSAPP;
   const isGroup = row.is_group === true;
-  const displayName = (row.chat_name as string)
+  const persistedName = (row.chat_name as string)
     || (row.contact_name as string)
     || (row.contact_inferred_name as string)
     || undefined;
+  const contactPhone = (row.contact_phone as string) || undefined;
+  const displayName = isGroup
+    ? persistedName
+    : displayContactName(persistedName, platform, contactPhone);
   return {
     id: (row.last_message_id as string) || chatId,
     conversation_key: conversationKey(chatId, platform),
@@ -134,7 +139,7 @@ function conversationRowToInboxMessage(row: DbRow): InboxMessage {
     is_group: isGroup,
     status: row.last_message_status as InboxMessage['status'],
     chat_id: chatId,
-    contact_phone: (row.contact_phone as string) || undefined,
+    contact_phone: contactPhone,
     platform,
     unread_count: typeof row.unread_count === 'number' ? row.unread_count : 0,
     has_ai_response: row.last_message_has_ai_response === true,
@@ -190,6 +195,7 @@ export function patchInboxRealtimeMessage(
   if (!row.chat_id && !row.id) return;
   const platform = row.platform || Platform.WHATSAPP;
   const key = conversationKey(row.chat_id || row.id, platform);
+  const incomingName = displayContactName(row.contact_name, platform, row.contact_phone);
   if (usesNativeMobileCache() && userId && row.chat_id && row.timestamp) {
     void cacheTimeline(userId, row.chat_id, [row as RawMessage & { id: string; chat_id: string; timestamp: string }]).catch(() => undefined);
   }
@@ -207,7 +213,7 @@ export function patchInboxRealtimeMessage(
           from_me: row.from_me ?? message.from_me,
           is_group: row.is_group ?? message.is_group,
           status: row.status ?? message.status,
-          contact_name: row.contact_name || message.contact_name,
+          contact_name: row.contact_name ? incomingName : message.contact_name,
           contact_phone: row.contact_phone || message.contact_phone,
           unread_count: row.from_me === false
             ? (message.unread_count || 0) + 1
@@ -224,8 +230,8 @@ export function patchInboxRealtimeMessage(
     const newMessage: InboxMessage = {
       id: row.id,
       conversation_key: key,
-      contact_name: row.contact_name,
-      chat_name: row.contact_name,
+      contact_name: incomingName,
+      chat_name: incomingName,
       content: row.content ?? '',
       timestamp: row.timestamp ?? new Date().toISOString(),
       from_me: row.from_me ?? false,
@@ -287,7 +293,10 @@ function cachedInboxMessages(chats: CachedChat[]): InboxMessage[] {
     const latest = chat.latest_message as Record<string, unknown> | null | undefined;
     if (!latest || typeof latest.id !== 'string') return [];
     const contact = chat.contact as Record<string, unknown> | null | undefined;
-    const name = typeof chat.name === 'string' ? chat.name : typeof contact?.name === 'string' ? contact.name : undefined;
+    const persistedName = typeof chat.name === 'string' ? chat.name : typeof contact?.name === 'string' ? contact.name : undefined;
+    const name = chat.is_group === true
+      ? persistedName
+      : displayContactName(persistedName, chat.platform as Platform | undefined);
     return [{
       id: latest.id,
       conversation_key: conversationKey(chat.id, chat.platform as Platform | undefined),

--- a/apps/client/services/contact-display.ts
+++ b/apps/client/services/contact-display.ts
@@ -1,0 +1,18 @@
+import { Platform } from '../types/platform';
+import { formatPhoneNumber, isOpaqueWhatsAppLid } from './phone-numbers';
+
+/**
+ * Customer-facing contact label. Matrix/WhatsApp LIDs are intentionally
+ * hidden: they are opaque bridge routing IDs, not names.
+ */
+export function displayContactName(
+  value: string | null | undefined,
+  platform: Platform | string | null | undefined,
+  phone?: string | null,
+  fallback = 'Conversation'
+): string {
+  const name = value?.trim() || '';
+  const isWhatsApp = platform === Platform.WHATSAPP || platform === 'whatsapp';
+  if (name && (!isWhatsApp || !isOpaqueWhatsAppLid(name))) return name;
+  return formatPhoneNumber(phone) || (isWhatsApp ? 'WhatsApp contact' : fallback);
+}

--- a/apps/client/services/phone-numbers.ts
+++ b/apps/client/services/phone-numbers.ts
@@ -23,10 +23,19 @@ function sourcePhone(value: string) {
   return value.trim().split('@')[0] || value.trim();
 }
 
+/** A WhatsApp LID is a routing identifier, not a telephone number. */
+export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return /^lid[-:]?\d+$/i.test(sourcePhone(value));
+}
+
 /** Human-readable number for the relationship-memory surface. */
 export function formatPhoneNumber(value: string | null | undefined): string {
   if (!value) return '';
   const source = sourcePhone(value);
+  // Never turn an opaque WhatsApp LID into a plausible-looking number. That
+  // would mislead someone into thinking it is a callable contact detail.
+  if (isOpaqueWhatsAppLid(source)) return '';
   const parsed = parsePhoneNumberFromString(source, deviceCountry());
   if (parsed?.isValid()) return parsed.formatInternational();
 

--- a/apps/client/tests/contact-display.test.ts
+++ b/apps/client/tests/contact-display.test.ts
@@ -1,0 +1,12 @@
+import { Platform } from '../types/platform';
+import { displayContactName } from '../services/contact-display';
+
+describe('contact display', () => {
+  it('hides an opaque WhatsApp LID when no profile name is available', () => {
+    expect(displayContactName('lid-192204836479059', Platform.WHATSAPP)).toBe('WhatsApp contact');
+  });
+
+  it('keeps a real bridge profile name', () => {
+    expect(displayContactName('Lucas', Platform.WHATSAPP, '192204836479059')).toBe('Lucas');
+  });
+});

--- a/apps/client/tests/phone-numbers.test.ts
+++ b/apps/client/tests/phone-numbers.test.ts
@@ -1,6 +1,7 @@
 import {
   formatPhoneNumber,
   formatPhoneNumberInput,
+  isOpaqueWhatsAppLid,
   normalizePhoneNumber,
 } from '../services/phone-numbers';
 
@@ -19,5 +20,10 @@ describe('phone number formatting', () => {
 
   it('does not manufacture a canonical value for an invalid number', () => {
     expect(normalizePhoneNumber('+52 931 193 75748')).toBeNull();
+  });
+
+  it('does not present a WhatsApp LID as a phone number', () => {
+    expect(isOpaqueWhatsAppLid('lid-192204836479059')).toBe(true);
+    expect(formatPhoneNumber('lid-192204836479059')).toBe('');
   });
 });

--- a/apps/server/src/adapters/matrix/index.ts
+++ b/apps/server/src/adapters/matrix/index.ts
@@ -44,6 +44,10 @@ import {
   toPersistedMatrixSession,
 } from './session-persistence';
 import { logger } from '../../utils/logger';
+import {
+  displayNameFromBridge,
+  phoneNumberFromPlatformContactId,
+} from '../../services/contact-identity';
 
 interface MatrixSdkLogger {
   trace(...args: unknown[]): void;
@@ -245,14 +249,11 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
   /** Do not replace a known name with the bridge's phone-number fallback. */
   private contactNameForStorage(
     displayName: string | undefined,
-    platformContactId: string
+    platformContactId: string,
+    platform: Platform
   ): string | null {
     const name = displayName ? this.userMapper.cleanDisplayName(displayName) : '';
-    if (!name) return null;
-    const normalizedId = platformContactId.replace(/[^a-z0-9]/gi, '').toLowerCase();
-    const normalizedName = name.replace(/[^a-z0-9]/gi, '').toLowerCase();
-    if (normalizedName === normalizedId || /^[+\d().\s-]+$/.test(name)) return null;
-    return name;
+    return displayNameFromBridge(name, platform, platformContactId);
   }
 
   /** Correct rows already written by an older sender/media conversion path. */
@@ -282,6 +283,12 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
       replyToInternalMessageId = replyTarget?.id || null;
     }
     const contact = this.userMapper.ghostUserToPlatformContact(message.senderId);
+    const contactName = contact
+      ? displayNameFromBridge(message.senderName, message.platform, contact.platformContactId)
+      : null;
+    const contactPhone = contact
+      ? phoneNumberFromPlatformContactId(message.platform, contact.platformContactId)
+      : null;
     let contactId: string | null = null;
     if (!message.isFromMe && contact) {
       const { data: contactRow } = await supabase
@@ -297,8 +304,8 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
       .from('messages')
       .update({
         from_me: message.isFromMe,
-        contact_name: message.isFromMe ? null : message.senderName || null,
-        contact_phone: message.isFromMe ? null : contact?.platformContactId || null,
+        contact_name: message.isFromMe ? null : contactName,
+        contact_phone: message.isFromMe ? null : contactPhone,
         contact_id: contactId,
         is_group: message.chatType === 'group',
         type: message.contentType,
@@ -313,11 +320,15 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
     if (error)
       this.log('warn', `Failed to repair Matrix message ${message.platformMessageId}`, { error });
     else {
+      const repairedChatName =
+        message.chatType === 'group'
+          ? message.chatName || message.chatId
+          : displayNameFromBridge(message.chatName, message.platform, message.chatId) || contactName;
       const { error: chatError } = await supabase
         .from('chats')
         .update({
           is_group: message.chatType === 'group',
-          name: message.chatName || message.chatId,
+          ...(repairedChatName ? { name: repairedChatName } : {}),
         })
         .eq('id', existing.chat_id);
       if (chatError)
@@ -1640,16 +1651,21 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
         )
           continue;
 
-        const name = this.contactNameForStorage(contact.displayName, contact.platformContactId);
+        const name = this.contactNameForStorage(
+          contact.displayName,
+          contact.platformContactId,
+          contact.platform
+        );
+        const phoneNumber =
+          contact.phoneNumber ||
+          phoneNumberFromPlatformContactId(contact.platform, contact.platformContactId);
         const payload: DbRow = {
           user_id: session.userId,
           platform: contact.platform,
           platform_contact_id: contact.platformContactId,
           whatsapp_id: contact.platformContactId,
           avatar_url: contact.avatarUrl || null,
-          phone_number:
-            contact.phoneNumber ||
-            (/^\d+$/.test(contact.platformContactId) ? contact.platformContactId : null),
+          ...(phoneNumber ? { phone_number: phoneNumber } : {}),
           ...(contact.username ? { username: contact.username } : {}),
           // Omitting an unknown name is intentional: on conflict Supabase then
           // preserves a real name that was learned from an earlier sync.
@@ -1659,7 +1675,25 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
           .from('contacts')
           .upsert(payload, { onConflict: 'user_id,platform,platform_contact_id' });
 
-        if (!error) synced++;
+        if (!error) {
+          synced++;
+          // A contact profile can arrive after room history. Propagate its
+          // verified bridge display name to an existing direct chat so an old
+          // LID/anonymous fallback is repaired without waiting for a new
+          // message event.
+          if (name) {
+            const { error: chatNameError } = await supabase
+              .from('chats')
+              .update({ name })
+              .eq('user_id', session.userId)
+              .eq('platform', contact.platform)
+              .eq('platform_chat_id', contact.platformContactId)
+              .eq('is_group', false);
+            if (chatNameError) {
+              this.log('warn', `Failed to sync contact name to chat`, { chatNameError });
+            }
+          }
+        }
       }
 
       this.log('info', `Synced ${synced} contacts for session ${sessionId}`);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -39,7 +39,11 @@ import { platformManager } from './adapters';
 import { aiProcessor } from './services/ai-processor';
 import { conversationAssistant } from './services/conversation-assistant';
 import { voiceProfileService } from './services/voice-profile-service';
-import { incomingContactId } from './services/contact-identity';
+import {
+  displayNameFromBridge,
+  incomingContactId,
+  phoneNumberFromPlatformContactId,
+} from './services/contact-identity';
 import { promiseDetector } from './services/promise-detector';
 import { operationsMonitor } from './services/operations-monitor';
 import { operationsTelemetry } from './services/operations-telemetry';
@@ -435,6 +439,17 @@ async function initializePlatforms() {
       logger.info('New platform message accepted', { platform: message.platform });
       const aiProcessingEnabled = await isAiProcessingEnabled(message.userId);
 
+      // A WhatsApp LID is an opaque bridge identifier, not a contact name or
+      // number. Prefer the real bridge profile name and omit the field when
+      // the bridge has not supplied one; omitting it preserves a previously
+      // learned name on conflict instead of overwriting it with a LID.
+      const senderContactId = incomingContactId(message);
+      const chatDisplayName =
+        message.chatType === 'group'
+          ? message.chatName || message.chatId
+          : displayNameFromBridge(message.chatName, message.platform, message.chatId) ||
+            displayNameFromBridge(message.senderName, message.platform, senderContactId);
+
       // 1. Upsert chat record to get its UUID
       const { data: chat, error: chatError } = await supabase
         .from('chats')
@@ -444,7 +459,7 @@ async function initializePlatforms() {
             whatsapp_chat_id: message.chatId,
             platform_chat_id: message.chatId,
             platform: message.platform,
-            name: message.chatName || message.chatId,
+            ...(chatDisplayName ? { name: chatDisplayName } : {}),
             is_group: message.chatType === 'group',
             last_message_at: message.timestamp,
           },
@@ -467,9 +482,18 @@ async function initializePlatforms() {
       // inbox a stable avatar/name relationship instead of trying to infer it
       // from the latest message row on every render.
       let contactId: string | null = null;
-      const senderContactId = incomingContactId(message);
+      let storedContactName: string | null = null;
       if (senderContactId) {
         const platformContactId = senderContactId;
+        const contactName = displayNameFromBridge(
+          message.senderName,
+          message.platform,
+          platformContactId
+        );
+        const contactPhone = phoneNumberFromPlatformContactId(
+          message.platform,
+          platformContactId
+        );
         {
           const { data: contact, error: contactError } = await supabase
             .from('contacts')
@@ -479,22 +503,50 @@ async function initializePlatforms() {
                 platform: message.platform,
                 platform_contact_id: platformContactId,
                 whatsapp_id: platformContactId,
-                name: message.senderName || platformContactId,
-                phone_number: /^\d+$/.test(platformContactId) ? platformContactId : null,
+                ...(contactName ? { name: contactName } : {}),
+                ...(contactPhone ? { phone_number: contactPhone } : {}),
               },
               { onConflict: 'user_id,platform,platform_contact_id' }
             )
-            .select('id')
+            .select('id, name')
             .single();
           if (contactError) {
             logger.debug('Failed to upsert contact:', contactError);
           } else {
             contactId = contact?.id || null;
+            storedContactName = displayNameFromBridge(
+              contact?.name,
+              message.platform,
+              platformContactId
+            );
           }
         }
       }
       if (contactId && message.chatType === 'individual') {
         await supabase.from('chats').update({ contact_id: contactId }).eq('id', chat.id);
+      }
+      if (message.chatType === 'individual' && !chatDisplayName) {
+        // Outgoing messages do not have a remote sender to upsert above, and
+        // some bridges only learn the profile name during contact sync. Reuse
+        // that canonical record to repair a previously anonymous chat.
+        let resolvedName = storedContactName;
+        if (!resolvedName) {
+          const { data: knownContact } = await supabase
+            .from('contacts')
+            .select('name')
+            .eq('user_id', message.userId)
+            .eq('platform', message.platform)
+            .eq('platform_contact_id', message.chatId)
+            .maybeSingle();
+          resolvedName = displayNameFromBridge(
+            knownContact?.name,
+            message.platform,
+            message.chatId
+          );
+        }
+        if (resolvedName) {
+          await supabase.from('chats').update({ name: resolvedName }).eq('id', chat.id);
+        }
       }
 
       // A bridge may deliver a reply before its referenced message (especially
@@ -536,8 +588,12 @@ async function initializePlatforms() {
             timestamp: message.timestamp,
             is_group: message.chatType === 'group',
             contact_id: contactId,
-            contact_name: message.isFromMe ? null : message.senderName || null,
-            contact_phone: message.isFromMe ? null : senderContactId,
+            contact_name: message.isFromMe
+              ? null
+              : displayNameFromBridge(message.senderName, message.platform, senderContactId),
+            contact_phone: message.isFromMe
+              ? null
+              : phoneNumberFromPlatformContactId(message.platform, senderContactId),
             reply_to_message_id: replyToInternalMessageId,
             reply_to_platform_message_id: message.replyToMessageId || null,
             metadata: message.platformMetadata || null,

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { Platform } from '../adapters/types';
-import { incomingContactId } from './contact-identity';
+import {
+  displayNameFromBridge,
+  incomingContactId,
+  isOpaqueWhatsAppLid,
+  phoneNumberFromPlatformContactId,
+} from './contact-identity';
 
 describe('incoming contact identity', () => {
   test('keeps a direct Mac iMessage phone handle', () => {
@@ -13,5 +18,16 @@ describe('incoming contact identity', () => {
 
   test('continues to map a Matrix ghost to its platform identifier', () => {
     expect(incomingContactId({ platform: Platform.WHATSAPP, isFromMe: false, senderId: '@whatsapp_15165551212:claire.local' })).toBe('15165551212');
+  });
+
+  test('treats WhatsApp LIDs as opaque identifiers, never customer data', () => {
+    expect(isOpaqueWhatsAppLid('lid-192204836479059')).toBe(true);
+    expect(phoneNumberFromPlatformContactId(Platform.WHATSAPP, 'lid-192204836479059')).toBeNull();
+    expect(displayNameFromBridge('lid-192204836479059', Platform.WHATSAPP, 'lid-192204836479059')).toBeNull();
+  });
+
+  test('keeps a genuine bridge profile name and phone-number contact ID', () => {
+    expect(displayNameFromBridge('Lucas', Platform.WHATSAPP, '15165551212')).toBe('Lucas');
+    expect(phoneNumberFromPlatformContactId(Platform.WHATSAPP, '15165551212')).toBe('15165551212');
   });
 });

--- a/apps/server/src/services/contact-identity.ts
+++ b/apps/server/src/services/contact-identity.ts
@@ -1,5 +1,47 @@
 import { Platform, type UnifiedMessage } from '../adapters/types';
 
+/**
+ * WhatsApp can identify a contact with a locally scoped ID (LID) instead of a
+ * phone-number JID. A LID is an opaque routing identifier: it is neither a
+ * profile name nor a phone number and must never be shown as either.
+ */
+export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const source = value.trim().split('@')[0].toLowerCase();
+  return /^lid[-:]?\d+$/.test(source);
+}
+
+/** Return a real phone-shaped platform identifier, never a WhatsApp LID. */
+export function phoneNumberFromPlatformContactId(
+  platform: Platform,
+  platformContactId: string | null | undefined
+): string | null {
+  if (!platformContactId || isOpaqueWhatsAppLid(platformContactId)) return null;
+  const source = platformContactId.trim().split('@')[0];
+  if (platform === Platform.WHATSAPP && /^\+?\d{7,15}$/.test(source)) return source;
+  return null;
+}
+
+/**
+ * Keep bridge fallbacks out of customer-facing names. The bridge profile name
+ * wins whenever it is meaningful; names which merely repeat the Matrix/bridge
+ * identifier are deliberately treated as unavailable.
+ */
+export function displayNameFromBridge(
+  candidate: string | null | undefined,
+  platform: Platform,
+  platformContactId: string | null | undefined
+): string | null {
+  const name = candidate?.trim() || '';
+  if (!name || (platform === Platform.WHATSAPP && isOpaqueWhatsAppLid(name))) return null;
+  const contactId = platformContactId?.trim() || '';
+  const normalizedName = name.replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const normalizedContactId = contactId.replace(/[^a-z0-9]/gi, '').toLowerCase();
+  if (normalizedName && normalizedName === normalizedContactId) return null;
+  if (platform === Platform.WHATSAPP && /^[+\d().\s-]+$/.test(name)) return null;
+  return name;
+}
+
 /** Resolve a stable per-platform contact identifier for an incoming message. */
 export function incomingContactId(message: Pick<UnifiedMessage, 'platform' | 'isFromMe' | 'senderId'>): string | null {
   if (message.isFromMe || !message.senderId || message.senderId === 'me') return null;

--- a/supabase/migrations/20260820000001_hide_whatsapp_lids_from_display_fields.sql
+++ b/supabase/migrations/20260820000001_hide_whatsapp_lids_from_display_fields.sql
@@ -1,0 +1,30 @@
+-- A WhatsApp LID (`lid-…`) is an opaque bridge routing identifier, not a
+-- customer name or telephone number. Older ingest paths copied it into
+-- display fields; keep the durable identifier columns intact while clearing
+-- only those unsafe presentation fallbacks.
+
+UPDATE public.contacts
+SET
+  name = CASE WHEN lower(coalesce(name, '')) ~ '^lid[-:]?[0-9]+$' THEN NULL ELSE name END,
+  phone_number = CASE WHEN lower(coalesce(phone_number, '')) ~ '^lid[-:]?[0-9]+$' THEN NULL ELSE phone_number END
+WHERE platform = 'whatsapp'
+  AND (
+    lower(coalesce(name, '')) ~ '^lid[-:]?[0-9]+$'
+    OR lower(coalesce(phone_number, '')) ~ '^lid[-:]?[0-9]+$'
+  );
+
+UPDATE public.chats
+SET name = NULL
+WHERE platform = 'whatsapp'
+  AND lower(coalesce(name, '')) ~ '^lid[-:]?[0-9]+$';
+
+UPDATE public.messages
+SET
+  contact_name = CASE WHEN lower(coalesce(contact_name, '')) ~ '^lid[-:]?[0-9]+$' THEN NULL ELSE contact_name END,
+  contact_phone = CASE WHEN lower(coalesce(contact_phone, '')) ~ '^lid[-:]?[0-9]+$' THEN NULL ELSE contact_phone END
+WHERE platform = 'whatsapp'
+  AND (
+    lower(coalesce(contact_name, '')) ~ '^lid[-:]?[0-9]+$'
+    OR lower(coalesce(contact_phone, '')) ~ '^lid[-:]?[0-9]+$'
+  );
+


### PR DESCRIPTION
## Summary\n- never persist WhatsApp LIDs as contact names or phone numbers\n- repair existing unsafe display fields with a migration\n- propagate bridged profile names to direct chats and format valid phone numbers safely\n\n## Verification\n- bun test apps/server/src/services/contact-identity.test.ts\n- cd apps/client && bunx jest tests/phone-numbers.test.ts tests/contact-display.test.ts --runInBand\n- TypeScript checks for server and client\n- focused ESLint