### PR TITLE
Resolve bridge contact identities

### DIFF
--- a/apps/server/src/adapters/matrix/bridge-http-client.test.ts
+++ b/apps/server/src/adapters/matrix/bridge-http-client.test.ts
@@ -57,6 +57,8 @@ describe('BridgeHttpClient identifier resolution', () => {
       request = new Request(input, init);
       return new Response(JSON.stringify({
         id: '15166100494',
+        name: 'Bridge profile name',
+        identifiers: ['15166100494@s.whatsapp.net'],
         mxid: '@whatsapp_15166100494:claire.local',
       }), { status: 200, headers: { 'content-type': 'application/json' } });
     };
@@ -71,6 +73,8 @@ describe('BridgeHttpClient identifier resolution', () => {
       const result = await client.resolveIdentifier('+15166100494', '15166100494');
 
       expect(result.mxid).toBe('@whatsapp_15166100494:claire.local');
+      expect(result.name).toBe('Bridge profile name');
+      expect(result.identifiers).toEqual(['15166100494@s.whatsapp.net']);
       expect(request?.method).toBe('GET');
       expect(new URL(request!.url).pathname).toBe(
         '/_matrix/provision/v3/resolve_identifier/%2B15166100494'

--- a/apps/server/src/adapters/matrix/index.ts
+++ b/apps/server/src/adapters/matrix/index.ts
@@ -46,6 +46,9 @@ import {
 import { logger } from '../../utils/logger';
 import {
   displayNameFromBridge,
+  incomingContactId,
+  isOpaqueWhatsAppLid,
+  phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from '../../services/contact-identity';
 
@@ -123,6 +126,13 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
   private readonly doublePuppetEnabled: boolean = process.env.ENABLE_DOUBLE_PUPPETING === 'true';
   // Event IDs that this server sent (to avoid double-counting bot's own sends as incoming)
   private localSentEventIds: Set<string> = new Set();
+  // Contact identity lookups are bridge-local, but can occur for every Matrix
+  // event in a busy room. Coalesce identical requests so a single LID never
+  // turns into a burst of provisioning calls.
+  private readonly contactIdentityLookups = new Map<
+    string,
+    Promise<import('./types').ResolvedBridgeContactIdentity | null>
+  >();
   private durableSessionStorageAvailable = true;
 
   /**
@@ -233,6 +243,65 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
     }
   }
 
+  /** Resolve provider metadata without ever treating a routing identifier as display data. */
+  private async resolveRemoteContactIdentity(
+    platform: Platform,
+    platformContactId: string,
+    session: PlatformSession
+  ): Promise<import('./types').ResolvedBridgeContactIdentity | null> {
+    const platformUserId = session.platformUserId || session.phoneNumber;
+    if (!this.config.resolveContactIdentity || !platformUserId) return null;
+    // WhatsApp phone ghosts already contain the canonical phone number. LIDs
+    // are the only current provider identifier that requires a remote lookup.
+    if (platform !== Platform.WHATSAPP || !isOpaqueWhatsAppLid(platformContactId)) return null;
+
+    const key = `${platform}:${platformUserId}:${platformContactId}`;
+    const existing = this.contactIdentityLookups.get(key);
+    if (existing) return existing;
+
+    const lookup = this.config
+      .resolveContactIdentity(platform, platformContactId, platformUserId)
+      .catch(() => {
+        // Identity enrichment is best effort. Message delivery must retain its
+        // normal path if a bridge is temporarily unavailable.
+        this.contactIdentityLookups.delete(key);
+        return null;
+      });
+    this.contactIdentityLookups.set(key, lookup);
+    return lookup;
+  }
+
+  private async enrichRemoteMessageContact(
+    message: UnifiedMessage,
+    session: PlatformSession
+  ): Promise<void> {
+    if (message.isFromMe) return;
+    const platformContactId = incomingContactId(message);
+    if (!platformContactId) return;
+
+    const identity = await this.resolveRemoteContactIdentity(
+      message.platform,
+      platformContactId,
+      session
+    );
+    if (!identity) return;
+
+    const displayName = displayNameFromBridge(
+      identity.displayName,
+      message.platform,
+      platformContactId
+    );
+    if (displayName) message.senderName = displayName;
+
+    const phoneNumber = phoneNumberFromBridgeIdentifiers([identity.phoneNumber]);
+    if (phoneNumber) {
+      message.platformMetadata = {
+        ...message.platformMetadata,
+        contactPhone: phoneNumber,
+      };
+    }
+  }
+
   private mediaProxyPath(mediaUrl: unknown): string | null {
     if (typeof mediaUrl !== 'string' || !mediaUrl) return null;
     if (mediaUrl.startsWith('/media/')) return mediaUrl;
@@ -287,7 +356,11 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
       ? displayNameFromBridge(message.senderName, message.platform, contact.platformContactId)
       : null;
     const contactPhone = contact
-      ? phoneNumberFromPlatformContactId(message.platform, contact.platformContactId)
+      ? phoneNumberFromBridgeIdentifiers([
+          typeof message.platformMetadata?.contactPhone === 'string'
+            ? message.platformMetadata.contactPhone
+            : undefined,
+        ]) || phoneNumberFromPlatformContactId(message.platform, contact.platformContactId)
       : null;
     let contactId: string | null = null;
     if (!message.isFromMe && contact) {
@@ -515,6 +588,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
         selfGhostIds,
         matrixUserId
       );
+      await this.enrichRemoteMessageContact(unifiedMessage, session);
 
       // Matrix receives bridged provider events after mautrix has translated
       // them. These events prove arrival at both observable boundaries; the
@@ -1384,6 +1458,26 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
           avatarUrl,
           session.userId
         );
+
+        if (contact) {
+          const identity = await this.resolveRemoteContactIdentity(
+            contact.platform,
+            contact.platformContactId,
+            session
+          );
+          if (identity) {
+            const resolvedName = displayNameFromBridge(
+              identity.displayName,
+              contact.platform,
+              contact.platformContactId
+            );
+            if (resolvedName) contact.displayName = resolvedName;
+            const resolvedPhone = phoneNumberFromBridgeIdentifiers([identity.phoneNumber]);
+            if (resolvedPhone) contact.phoneNumber = resolvedPhone;
+            if (identity.username) contact.username = identity.username;
+            if (identity.avatarUrl) contact.avatarUrl = identity.avatarUrl;
+          }
+        }
 
         if (contact && !contacts.some((c) => c.platformContactId === contact.platformContactId)) {
           contacts.push(contact);

--- a/apps/server/src/adapters/matrix/types.ts
+++ b/apps/server/src/adapters/matrix/types.ts
@@ -21,6 +21,23 @@ export interface MatrixConfig {
     platform: Platform,
     platformUserId: string
   ) => Promise<string[]>;
+  /**
+   * Resolve a remote bridge identity through the user's authenticated bridge
+   * login. This is used for provider-owned identifiers (notably WhatsApp
+   * LIDs) that are stable routing keys but are not suitable for display.
+   */
+  resolveContactIdentity?: (
+    platform: Platform,
+    platformContactId: string,
+    platformUserId: string
+  ) => Promise<ResolvedBridgeContactIdentity | null>;
+}
+
+export interface ResolvedBridgeContactIdentity {
+  displayName?: string;
+  phoneNumber?: string;
+  username?: string;
+  avatarUrl?: string;
 }
 
 /**

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,6 +42,7 @@ import { voiceProfileService } from './services/voice-profile-service';
 import {
   displayNameFromBridge,
   incomingContactId,
+  phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from './services/contact-identity';
 import { promiseDetector } from './services/promise-detector';
@@ -371,6 +372,25 @@ async function initializePlatforms() {
           const resolved = await bridge.resolveIdentifier(platformUserId, platformUserId);
           return resolved.mxid ? [resolved.mxid] : [];
         },
+        resolveContactIdentity: async (platform, platformContactId, platformUserId) => {
+          if (platform !== Platform.WHATSAPP || !process.env.WHATSAPP_BRIDGE_SECRET) {
+            return null;
+          }
+          const bridge = new BridgeHttpClient(
+            process.env.WHATSAPP_BRIDGE_URL || 'http://mautrixwhatsapp.railway.internal:29318',
+            process.env.WHATSAPP_BRIDGE_SECRET,
+            process.env.WHATSAPP_BRIDGE_USER_ID || '@claire_bot:claire.local'
+          );
+          const resolved = await bridge.resolveIdentifier(platformContactId, platformUserId);
+          return {
+            displayName: resolved.name,
+            phoneNumber: phoneNumberFromBridgeIdentifiers([
+              ...(resolved.identifiers || []),
+              resolved.id,
+            ]) || undefined,
+            avatarUrl: resolved.avatar_url,
+          };
+        },
       });
 
       platformManager.setMatrixMode(matrixAdapter);
@@ -444,6 +464,11 @@ async function initializePlatforms() {
       // the bridge has not supplied one; omitting it preserves a previously
       // learned name on conflict instead of overwriting it with a LID.
       const senderContactId = incomingContactId(message);
+      const resolvedContactPhone = phoneNumberFromBridgeIdentifiers([
+        typeof message.platformMetadata?.contactPhone === 'string'
+          ? message.platformMetadata.contactPhone
+          : undefined,
+      ]);
       const chatDisplayName =
         message.chatType === 'group'
           ? message.chatName || message.chatId
@@ -490,10 +515,9 @@ async function initializePlatforms() {
           message.platform,
           platformContactId
         );
-        const contactPhone = phoneNumberFromPlatformContactId(
-          message.platform,
-          platformContactId
-        );
+        const contactPhone =
+          resolvedContactPhone ||
+          phoneNumberFromPlatformContactId(message.platform, platformContactId);
         {
           const { data: contact, error: contactError } = await supabase
             .from('contacts')
@@ -593,7 +617,8 @@ async function initializePlatforms() {
               : displayNameFromBridge(message.senderName, message.platform, senderContactId),
             contact_phone: message.isFromMe
               ? null
-              : phoneNumberFromPlatformContactId(message.platform, senderContactId),
+              : resolvedContactPhone ||
+                phoneNumberFromPlatformContactId(message.platform, senderContactId),
             reply_to_message_id: replyToInternalMessageId,
             reply_to_platform_message_id: message.replyToMessageId || null,
             metadata: message.platformMetadata || null,

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -4,6 +4,7 @@ import {
   displayNameFromBridge,
   incomingContactId,
   isOpaqueWhatsAppLid,
+  phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from './contact-identity';
 
@@ -29,5 +30,15 @@ describe('incoming contact identity', () => {
   test('keeps a genuine bridge profile name and phone-number contact ID', () => {
     expect(displayNameFromBridge('Lucas', Platform.WHATSAPP, '15165551212')).toBe('Lucas');
     expect(phoneNumberFromPlatformContactId(Platform.WHATSAPP, '15165551212')).toBe('15165551212');
+  });
+
+  test('extracts a canonical number from trusted bridge identifiers, never an LID', () => {
+    expect(
+      phoneNumberFromBridgeIdentifiers([
+        'lid-192204836479059',
+        '15165551212@s.whatsapp.net',
+      ])
+    ).toBe('+15165551212');
+    expect(phoneNumberFromBridgeIdentifiers(['lid-192204836479059'])).toBeNull();
   });
 });

--- a/apps/server/src/services/contact-identity.ts
+++ b/apps/server/src/services/contact-identity.ts
@@ -23,6 +23,25 @@ export function phoneNumberFromPlatformContactId(
 }
 
 /**
+ * Extract an E.164 phone number from bridge-owned identifiers. mautrix can
+ * return a plain number, an E.164 number, or a WhatsApp JID such as
+ * `15165551212@s.whatsapp.net`. This is intentionally strict: bridge IDs and
+ * LIDs must never be mistaken for phone numbers.
+ */
+export function phoneNumberFromBridgeIdentifiers(
+  identifiers: Array<string | null | undefined>
+): string | null {
+  for (const identifier of identifiers) {
+    if (!identifier) continue;
+    const source = identifier.trim().replace(/^tel:/i, '').split('@')[0];
+    if (isOpaqueWhatsAppLid(source)) continue;
+    const digits = source.replace(/^\+/, '');
+    if (/^\d{7,15}$/.test(digits)) return `+${digits}`;
+  }
+  return null;
+}
+
+/**
  * Keep bridge fallbacks out of customer-facing names. The bridge profile name
  * wins whenever it is meaningful; names which merely repeat the Matrix/bridge
  * identifier are deliberately treated as unavailable.

--- a/docker/matrix/bridges/telegram/config.yaml
+++ b/docker/matrix/bridges/telegram/config.yaml
@@ -29,7 +29,10 @@ telegram:
 
 bridge:
     username_template: "_telegram_{{.}}"
-    displayname_template: "{{.Name}} (TG)"
+    # Prefer Telegram's profile name, then its @username. `.Name` is not a
+    # current mautrix-telegram profile field, which can leave Claire with an
+    # opaque identifier instead of the name Telegram provides.
+    displayname_template: '{{if .Deleted}}Deleted account {{.UserID}}{{else}}{{or .FullName .Username "Telegram user"}}{{end}} (TG)'
     command_prefix: "!tg"
 
     permissions:


### PR DESCRIPTION
## Summary\n- resolve WhatsApp LIDs through the authenticated mautrix provisioning API\n- persist verified profile names and E.164 phone numbers without exposing LIDs\n- use current Telegram profile-name/username template\n\n## Verification\n- bun test v1.3.0 (b0a6feca)\n- \n- focused ESLint