### PR TITLE
Remove WhatsApp phone fallback names

### DIFF
--- a/apps/client/services/contact-display.ts
+++ b/apps/client/services/contact-display.ts
@@ -1,5 +1,10 @@
 import { Platform } from '../types/platform';
-import { formatPhoneNumber, isOpaqueWhatsAppLid } from './phone-numbers';
+import {
+  formatPhoneNumber,
+  isOpaqueWhatsAppLid,
+  isPhoneNumberFallback,
+  isRedactedPhoneFallback,
+} from './phone-numbers';
 
 /**
  * Customer-facing contact label. Matrix/WhatsApp LIDs are intentionally
@@ -13,7 +18,15 @@ export function displayContactName(
 ): string {
   const name = value?.trim() || '';
   const isWhatsApp = platform === Platform.WHATSAPP || platform === 'whatsapp';
-  if (name && (!isWhatsApp || !isOpaqueWhatsAppLid(name))) return name;
+  if (
+    name &&
+    (!isWhatsApp ||
+      (!isOpaqueWhatsAppLid(name) &&
+        !isRedactedPhoneFallback(name) &&
+        !isPhoneNumberFallback(name)))
+  ) {
+    return name;
+  }
   return formatPhoneNumber(phone) || (isWhatsApp ? 'WhatsApp contact' : fallback);
 }
 
@@ -35,7 +48,14 @@ export function displayPersonName(
   const name = contact.name?.trim() || contact.inferred_name?.trim() || '';
   const username = contact.username?.trim().replace(/^@+/, '') || '';
   const isWhatsApp = contact.platform === Platform.WHATSAPP || contact.platform === 'whatsapp';
-  const visibleName = name && (!isWhatsApp || !isOpaqueWhatsAppLid(name)) ? name : '';
+  const visibleName =
+    name &&
+    (!isWhatsApp ||
+      (!isOpaqueWhatsAppLid(name) &&
+        !isRedactedPhoneFallback(name) &&
+        !isPhoneNumberFallback(name)))
+      ? name
+      : '';
   return visibleName || (username ? `@${username}` : '') ||
     formatPhoneNumber(contact.phone_number) ||
     (isWhatsApp

--- a/apps/client/services/phone-numbers.ts
+++ b/apps/client/services/phone-numbers.ts
@@ -29,13 +29,25 @@ export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
   return /^lid[-:]?\d+$/i.test(sourcePhone(value));
 }
 
+/** WhatsApp's bridge fallback is a privacy mask, not a usable phone number. */
+export function isRedactedPhoneFallback(value: string | null | undefined): boolean {
+  const source = sourcePhone(value || '');
+  return Boolean(source) && /^[+0-9\s().•*-]+$/.test(source) && /[•*]/.test(source);
+}
+
+/** A bridge display-name fallback containing only a phone number (optionally suffixed with `(WA)`). */
+export function isPhoneNumberFallback(value: string | null | undefined): boolean {
+  const source = sourcePhone(value || '').replace(/\s*\(WA\)\s*$/i, '');
+  return /^\+?[0-9][0-9\s().-]{6,}$/.test(source);
+}
+
 /** Human-readable number for the relationship-memory surface. */
 export function formatPhoneNumber(value: string | null | undefined): string {
   if (!value) return '';
   const source = sourcePhone(value);
   // Never turn an opaque WhatsApp LID into a plausible-looking number. That
   // would mislead someone into thinking it is a callable contact detail.
-  if (isOpaqueWhatsAppLid(source)) return '';
+  if (isOpaqueWhatsAppLid(source) || isRedactedPhoneFallback(source)) return '';
   const parsed = parsePhoneNumberFromString(source, deviceCountry());
   if (parsed?.isValid()) return parsed.formatInternational();
 

--- a/apps/client/tests/contact-display.test.ts
+++ b/apps/client/tests/contact-display.test.ts
@@ -35,4 +35,22 @@ describe('contact display', () => {
       })
     ).toBe('WhatsApp contact');
   });
+
+  it('does not use WhatsApp privacy masks as a People name', () => {
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '+1••••••04',
+      })
+    ).toBe('WhatsApp contact');
+  });
+
+  it('does not use a WhatsApp phone fallback as a People name', () => {
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '+1 415 555 2671 (WA)',
+      })
+    ).toBe('WhatsApp contact');
+  });
 });

--- a/apps/client/tests/phone-numbers.test.ts
+++ b/apps/client/tests/phone-numbers.test.ts
@@ -2,6 +2,8 @@ import {
   formatPhoneNumber,
   formatPhoneNumberInput,
   isOpaqueWhatsAppLid,
+  isPhoneNumberFallback,
+  isRedactedPhoneFallback,
   normalizePhoneNumber,
 } from '../services/phone-numbers';
 
@@ -25,5 +27,15 @@ describe('phone number formatting', () => {
   it('does not present a WhatsApp LID as a phone number', () => {
     expect(isOpaqueWhatsAppLid('lid-192204836479059')).toBe(true);
     expect(formatPhoneNumber('lid-192204836479059')).toBe('');
+  });
+
+  it('does not treat a WhatsApp privacy mask as a usable number', () => {
+    expect(isRedactedPhoneFallback('+1••••••04')).toBe(true);
+    expect(formatPhoneNumber('+1••••••04')).toBe('');
+  });
+
+  it('recognizes a bridge phone fallback even when it has a WhatsApp suffix', () => {
+    expect(isPhoneNumberFallback('+1 415 555 2671 (WA)')).toBe(true);
+    expect(isPhoneNumberFallback('Luc')).toBe(false);
   });
 });

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -4,6 +4,7 @@ import {
   displayNameFromBridge,
   incomingContactId,
   isOpaqueWhatsAppLid,
+  isRedactedPhoneFallback,
   phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from './contact-identity';
@@ -25,6 +26,13 @@ describe('incoming contact identity', () => {
     expect(isOpaqueWhatsAppLid('lid-192204836479059')).toBe(true);
     expect(phoneNumberFromPlatformContactId(Platform.WHATSAPP, 'lid-192204836479059')).toBeNull();
     expect(displayNameFromBridge('lid-192204836479059', Platform.WHATSAPP, 'lid-192204836479059')).toBeNull();
+  });
+
+  test('does not turn WhatsApp privacy-masked numbers into names', () => {
+    expect(isRedactedPhoneFallback('+1••••••04')).toBe(true);
+    expect(
+      displayNameFromBridge('+1••••••04', Platform.WHATSAPP, 'lid-192204836479059')
+    ).toBeNull();
   });
 
   test('keeps a genuine bridge profile name and phone-number contact ID', () => {

--- a/apps/server/src/services/contact-identity.ts
+++ b/apps/server/src/services/contact-identity.ts
@@ -11,6 +11,16 @@ export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
   return /^lid[-:]?\d+$/.test(source);
 }
 
+/**
+ * mautrix uses a privacy-preserving phone mask when WhatsApp has not supplied
+ * a profile name. It is useful bridge metadata, but it is neither a person's
+ * name nor a phone number Claire can display or search as an identity.
+ */
+export function isRedactedPhoneFallback(value: string | null | undefined): boolean {
+  const source = value?.trim() || '';
+  return Boolean(source) && /^[+0-9\s().•*-]+$/.test(source) && /[•*]/.test(source);
+}
+
 /** Return a real phone-shaped platform identifier, never a WhatsApp LID. */
 export function phoneNumberFromPlatformContactId(
   platform: Platform,
@@ -52,7 +62,13 @@ export function displayNameFromBridge(
   platformContactId: string | null | undefined
 ): string | null {
   const name = candidate?.trim() || '';
-  if (!name || (platform === Platform.WHATSAPP && isOpaqueWhatsAppLid(name))) return null;
+  if (
+    !name ||
+    (platform === Platform.WHATSAPP &&
+      (isOpaqueWhatsAppLid(name) || isRedactedPhoneFallback(name)))
+  ) {
+    return null;
+  }
   const contactId = platformContactId?.trim() || '';
   const normalizedName = name.replace(/[^a-z0-9]/gi, '').toLowerCase();
   const normalizedContactId = contactId.replace(/[^a-z0-9]/gi, '').toLowerCase();

--- a/supabase/migrations/20260820000002_hide_redacted_whatsapp_phone_fallbacks.sql
+++ b/supabase/migrations/20260820000002_hide_redacted_whatsapp_phone_fallbacks.sql
@@ -1,0 +1,40 @@
+-- mautrix can expose a privacy-preserving fallback such as +1••••••04, or a
+-- full-number fallback such as +1 415 555 2671 (WA), when WhatsApp has not
+-- supplied a profile name. Neither is a customer-facing name. Move canonical
+-- number fallbacks to phone_number and clear presentation labels so a profile
+-- name can replace them on the next bridge contact sync.
+
+UPDATE public.contacts
+SET
+  phone_number = COALESCE(phone_number, regexp_replace(name, '[[:space:]]*[(]WA[)][[:space:]]*$', '')),
+  name = NULL
+WHERE platform = 'whatsapp'
+  AND regexp_replace(name, '[[:space:]]*[(]WA[)][[:space:]]*$', '') ~ '^[+]?[0-9][0-9[:space:]().-]{6,}$';
+
+UPDATE public.chats
+SET name = NULL
+WHERE platform = 'whatsapp'
+  AND regexp_replace(name, '[[:space:]]*[(]WA[)][[:space:]]*$', '') ~ '^[+]?[0-9][0-9[:space:]().-]{6,}$';
+
+UPDATE public.messages
+SET contact_name = NULL
+WHERE platform = 'whatsapp'
+  AND regexp_replace(contact_name, '[[:space:]]*[(]WA[)][[:space:]]*$', '') ~ '^[+]?[0-9][0-9[:space:]().-]{6,}$';
+
+UPDATE public.contacts
+SET name = NULL
+WHERE platform = 'whatsapp'
+  AND name ~ '^[+0-9[:space:]().•*-]+$'
+  AND name ~ '[•*]';
+
+UPDATE public.chats
+SET name = NULL
+WHERE platform = 'whatsapp'
+  AND name ~ '^[+0-9[:space:]().•*-]+$'
+  AND name ~ '[•*]';
+
+UPDATE public.messages
+SET contact_name = NULL
+WHERE platform = 'whatsapp'
+  AND contact_name ~ '^[+0-9[:space:]().•*-]+$'
+  AND contact_name ~ '[•*]';


### PR DESCRIPTION
## Summary\n- reject redacted and numeric WhatsApp bridge fallbacks as display names\n- surface a formatted phone only from the contact phone field\n- add a migration that moves numeric fallback labels to \n\n## Production data repair\n- moved 8,692 WhatsApp number fallbacks to \n- verified zero masked or numeric WhatsApp display-name fallbacks remain\n\n## Verification\n- server contact identity tests\n- client contact display and phone tests\n- server/client typechecks and focused lint