### PR TITLE
fix(people): show conversation contacts reliably

### DIFF
--- a/apps/client/app/(tabs)/_layout.tsx
+++ b/apps/client/app/(tabs)/_layout.tsx
@@ -74,6 +74,10 @@ export default function TabLayout() {
       <Tabs.Screen name="dashboard" options={{ title: 'Home' }} />
       <Tabs.Screen name="messages" options={{ title: 'Inbox', sceneStyle: { backgroundColor: colors.paper } }} />
       <Tabs.Screen name="contacts" options={{ href: null }} />
+      {/* More-sheet destinations remain tab children so the floating bar stays
+          mounted rather than stranding people on a full-screen route. */}
+      <Tabs.Screen name="connections" options={{ href: null }} />
+      <Tabs.Screen name="settings" options={{ href: null }} />
       <Tabs.Screen name="ask-claire" options={{ title: 'Ask Claire' }} />
       <Tabs.Screen
         name="promises"

--- a/apps/client/app/(tabs)/connections.tsx
+++ b/apps/client/app/(tabs)/connections.tsx
@@ -1,0 +1,1 @@
+export { default } from '../connections';

--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Modal, Pressable, ScrollView, Text, View } from 'react-native';
-import { Check, ChevronLeft, ListFilter, Search, Sparkles } from 'lucide-react-native';
+import { Check, ListFilter, Search } from 'lucide-react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
@@ -38,6 +38,7 @@ export default function ContactsScreen() {
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
   const [showPlatformFilter, setShowPlatformFilter] = useState(false);
   const user = useAuthStore(state => state.user);
+  const requestedIdentitySyncFor = useRef<string | null>(null);
   const debouncedSearchQuery = useDebouncedValue(searchQuery);
 
   useEffect(() => {
@@ -55,11 +56,37 @@ export default function ContactsScreen() {
       filter,
     }),
     getNextPageParam: (page) => page.nextOffset,
+    // Contacts are enriched asynchronously by the connected bridges. A
+    // foreground return should always pick up newly learned names/numbers.
+    // Keep polling briefly while the bounded server-side identity sync runs.
+    refetchOnMount: 'always',
+    refetchInterval: 15_000,
   });
+
+  useEffect(() => {
+    if (!user?.id || requestedIdentitySyncFor.current === user.id) return;
+    requestedIdentitySyncFor.current = user.id;
+    // This only starts a per-user, metadata-only bridge sync. It is safe to
+    // ignore a missing/disconnected WhatsApp account; People still renders
+    // the identities already stored for other platforms.
+    void contactsApi.startIdentitySync()
+      .then(() => peopleQuery.refetch())
+      .catch(() => undefined);
+  }, [user?.id, peopleQuery.refetch]);
   const contacts = useMemo(
-    () => peopleQuery.data?.pages.flatMap((page) => page.contacts) || [],
+    () => (peopleQuery.data?.pages.flatMap((page) => page.contacts) || [])
+      .slice()
+      .sort((left, right) => {
+        const leftName = personName(left);
+        const rightName = personName(right);
+        const leftUnknown = leftName === 'WhatsApp contact' || leftName === 'Unknown person';
+        const rightUnknown = rightName === 'WhatsApp contact' || rightName === 'Unknown person';
+        if (leftUnknown !== rightUnknown) return leftUnknown ? 1 : -1;
+        return leftName.localeCompare(rightName, undefined, { sensitivity: 'base' });
+      }),
     [peopleQuery.data],
   );
+
   // Keep every supported platform visible. A zero-result Instagram filter is
   // useful feedback that the account has no synced Instagram conversations;
   // hiding it made that distinction impossible to see.
@@ -103,7 +130,6 @@ export default function ContactsScreen() {
         title="People"
         subtitle="The people behind your conversations"
         safeArea
-        leading={isDesktop ? undefined : <MobileIconButton label="Back" onPress={() => router.back()}><ChevronLeft size={20} color={colors.ink} /></MobileIconButton>}
         actions={!isDesktop ? (
           <MobileIconButton
             label="Filter by platform"
@@ -145,7 +171,7 @@ export default function ContactsScreen() {
           renderItem={({ item }) => {
             const name = personName(item);
             const identityDetail = personDetails(item);
-            const needsContext = !item.inferred_relationship && !item.is_group;
+            const secondaryDetail = identityDetail || item.inferred_relationship || (item.is_group ? 'Group conversation' : null);
             return (
               <Pressable
                 accessibilityRole="button"
@@ -160,14 +186,9 @@ export default function ContactsScreen() {
                   <MobileAvatar name={name} uri={item.avatar_url} size={48} isGroup={item.is_group} />
                   <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
                     <Text numberOfLines={1} style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{name}</Text>
-                    <Text numberOfLines={1} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{identityDetail || item.inferred_relationship || (item.is_group ? 'Group conversation' : 'Add context for better replies')}</Text>
+                    {secondaryDetail ? <Text numberOfLines={1} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{secondaryDetail}</Text> : null}
                     <PlatformName platform={contactPlatform(item)} size={12} />
                   </View>
-                  {needsContext ? (
-                    <View style={{ width: 34, height: 34, flexShrink: 0, borderRadius: 12, backgroundColor: colors.lavender, alignItems: 'center', justifyContent: 'center' }}>
-                      <Sparkles size={16} color={colors.ink} />
-                    </View>
-                  ) : null}
                 </View>
               </Pressable>
             );

--- a/apps/client/app/(tabs)/settings.tsx
+++ b/apps/client/app/(tabs)/settings.tsx
@@ -1,0 +1,1 @@
+export { default } from '../settings';

--- a/apps/client/app/connections/index.tsx
+++ b/apps/client/app/connections/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { Image } from 'expo-image';
-import { Check, ChevronLeft, ChevronRight, Laptop, Plus, RefreshCw, Smartphone } from 'lucide-react-native';
+import { Check, ChevronRight, Laptop, Plus, RefreshCw, Smartphone } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
 import { host } from '@claire/host';
@@ -147,7 +147,6 @@ export default function ConnectionsScreen() {
         <MobileHeader
           title="Connections"
           subtitle="Bring your conversations into Claire."
-          leading={<MobileIconButton label="Back" onPress={() => router.back()}><ChevronLeft size={20} color={colors.ink} /></MobileIconButton>}
           actions={<MobileIconButton label="Refresh connections" onPress={() => void load()}><RefreshCw size={18} color={colors.ink} /></MobileIconButton>}
         />
         {loading ? (

--- a/apps/client/app/people/index.tsx
+++ b/apps/client/app/people/index.tsx
@@ -1,1 +1,7 @@
-export { default } from '../(tabs)/contacts';
+import { Redirect } from 'expo-router';
+
+// People is launched from the More sheet. Keep it inside the tab navigator so
+// the persistent tab bar is available as the exit affordance.
+export default function PeopleRedirect() {
+  return <Redirect href="/(tabs)/contacts" />;
+}

--- a/apps/client/app/settings/index.tsx
+++ b/apps/client/app/settings/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, type ComponentType, type ReactNode } from 'react';
 import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
-import { Bell, Bot, Check, ChevronLeft, ChevronRight, DatabaseZap, KeyRound, Link2, LogOut, MessageCircle, Smile, Sparkles } from 'lucide-react-native';
+import { Bell, Bot, Check, ChevronRight, DatabaseZap, KeyRound, Link2, LogOut, MessageCircle, Smile, Sparkles } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
-import { MobileAvatar, MobileIconButton, SectionLabel } from '../../components/mobile/claire-mobile';
+import { MobileAvatar, MobileHeader, SectionLabel } from '../../components/mobile/claire-mobile';
 import { useAuthStore } from '../../stores/authStore';
 import { useChatPreferencesStore } from '../../stores/chatPreferencesStore';
 import { usePlatformStore } from '../../stores/platformStore';
@@ -76,7 +76,7 @@ export default function SettingsScreen() {
 
   const claireRows: SettingsRow[] = [
     { title: 'AI behavior', detail: 'Suggestions, summaries, and memory', icon: Sparkles, href: '/settings/ai', testID: 'settings-ai-settings', iconBackground: colors.lavender },
-    { title: 'Relationships', detail: 'People, categories, and prompts', icon: Smile, href: '/people', testID: 'settings-relationships', iconBackground: colors.blush },
+    { title: 'Relationships', detail: 'People, categories, and prompts', icon: Smile, href: '/(tabs)/contacts', testID: 'settings-relationships', iconBackground: colors.blush },
     {
       title: 'Promise detection',
       detail: 'Automatically suggest tracking',
@@ -112,7 +112,7 @@ export default function SettingsScreen() {
   ];
 
   const appRows: SettingsRow[] = [
-    { title: 'Connected accounts', detail: `${connected} platform${connected === 1 ? '' : 's'} active`, icon: Link2, href: '/connections', testID: 'settings-connections', iconBackground: colors.lavender },
+    { title: 'Connected accounts', detail: `${connected} platform${connected === 1 ? '' : 's'} active`, icon: Link2, href: '/(tabs)/connections', testID: 'settings-connections', iconBackground: colors.lavender },
     { title: 'Notifications', detail: 'Priority people and quiet hours', icon: Bell, href: '/settings/notifications', testID: 'settings-notifications', iconBackground: colors.sky },
     { title: 'Chat', detail: 'Plus button and reply options', icon: MessageCircle, href: '/settings/chat', testID: 'settings-chat', iconBackground: colors.neutral[100] },
     { title: 'Privacy & data', detail: 'Export, retention, and delete', icon: DatabaseZap, href: '/settings/privacy', testID: 'settings-privacy-data', iconBackground: colors.neutral[100] },
@@ -135,11 +135,7 @@ export default function SettingsScreen() {
 
   return (
     <ScrollView testID="settings-screen" style={{ flex: 1, backgroundColor: colors.cream }} contentInsetAdjustmentBehavior="automatic" contentContainerStyle={{ paddingBottom: 64 }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: space[4], paddingTop: space[2], paddingBottom: space[3], minHeight: 52 }}>
-        <MobileIconButton label="Back to inbox" onPress={() => router.replace('/(tabs)/messages')}><ChevronLeft size={20} color={colors.ink} /></MobileIconButton>
-        <Text style={{ flex: 1, textAlign: 'center', ...mobileType.sectionTitle, color: colors.ink }}>Settings</Text>
-        <View style={{ width: 40 }} />
-      </View>
+      <MobileHeader title="Settings" subtitle="Preferences, privacy, and account controls." />
 
       <View style={{ paddingHorizontal: space[4], gap: space[5] }}>
         <Pressable

--- a/apps/client/features/more/more-destinations.ts
+++ b/apps/client/features/more/more-destinations.ts
@@ -10,7 +10,7 @@ export interface MoreDestination {
 
 export const MORE_DESTINATIONS: MoreDestination[] = [
   { key: 'search', title: 'Search', detail: 'Messages, people, files, and loops', icon: Search, href: '/(tabs)/search' },
-  { key: 'people', title: 'People', detail: 'Contacts and relationship context', icon: UsersRound, href: '/people' },
-  { key: 'connections', title: 'Connections', detail: 'Messaging accounts and setup', icon: Link2, href: '/connections' },
-  { key: 'settings', title: 'Settings', detail: 'Notifications, AI, and account controls', icon: Settings, href: '/settings' },
+  { key: 'people', title: 'People', detail: 'Contacts and relationship context', icon: UsersRound, href: '/(tabs)/contacts' },
+  { key: 'connections', title: 'Connections', detail: 'Messaging accounts and setup', icon: Link2, href: '/(tabs)/connections' },
+  { key: 'settings', title: 'Settings', detail: 'Notifications, AI, and account controls', icon: Settings, href: '/(tabs)/settings' },
 ];

--- a/apps/client/services/contact-display.ts
+++ b/apps/client/services/contact-display.ts
@@ -7,6 +7,29 @@ import {
 } from './phone-numbers';
 
 /**
+ * Bridges occasionally emit a single punctuation mark as a profile display
+ * name. It is a placeholder, not something a person chose that helps the
+ * user identify a conversation. Emoji-only names remain valid: people do
+ * genuinely use them as WhatsApp profile names.
+ */
+function isMeaningfulName(value: string): boolean {
+  return /[\p{L}\p{N}\p{Extended_Pictographic}]/u.test(value);
+}
+
+function isUsableWhatsAppName(value: string): boolean {
+  return (
+    isMeaningfulName(value) &&
+    !isOpaqueWhatsAppLid(value) &&
+    !isRedactedPhoneFallback(value) &&
+    !isPhoneNumberFallback(value)
+  );
+}
+
+function isWhatsAppPlatform(platform: Platform | string | null | undefined): boolean {
+  return String(platform || '').toLowerCase() === Platform.WHATSAPP;
+}
+
+/**
  * Customer-facing contact label. Matrix/WhatsApp LIDs are intentionally
  * hidden: they are opaque bridge routing IDs, not names.
  */
@@ -17,13 +40,10 @@ export function displayContactName(
   fallback = 'Conversation'
 ): string {
   const name = value?.trim() || '';
-  const isWhatsApp = platform === Platform.WHATSAPP || platform === 'whatsapp';
+  const isWhatsApp = isWhatsAppPlatform(platform);
   if (
     name &&
-    (!isWhatsApp ||
-      (!isOpaqueWhatsAppLid(name) &&
-        !isRedactedPhoneFallback(name) &&
-        !isPhoneNumberFallback(name)))
+    (!isWhatsApp || isUsableWhatsAppName(name))
   ) {
     return name;
   }
@@ -31,9 +51,10 @@ export function displayContactName(
 }
 
 /**
- * Full contact identity used by People. Provider profile names are preferred,
- * followed by a public username, then a formatted phone number. This keeps
- * bridge routing IDs out of the product while still making every row useful.
+ * Full contact identity used by People. A real formatted phone number is the
+ * most reliable way to identify a WhatsApp-only contact, followed by the
+ * provider profile name and then a public username. This keeps bridge routing
+ * IDs and privacy masks out of the product while still making every row useful.
  */
 export function displayPersonName(
   contact: {
@@ -47,17 +68,14 @@ export function displayPersonName(
 ): string {
   const name = contact.name?.trim() || contact.inferred_name?.trim() || '';
   const username = contact.username?.trim().replace(/^@+/, '') || '';
-  const isWhatsApp = contact.platform === Platform.WHATSAPP || contact.platform === 'whatsapp';
+  const isWhatsApp = isWhatsAppPlatform(contact.platform);
   const visibleName =
     name &&
-    (!isWhatsApp ||
-      (!isOpaqueWhatsAppLid(name) &&
-        !isRedactedPhoneFallback(name) &&
-        !isPhoneNumberFallback(name)))
+    (!isWhatsApp || isUsableWhatsAppName(name))
       ? name
       : '';
-  return visibleName || (username ? `@${username}` : '') ||
-    formatPhoneNumber(contact.phone_number) ||
+  const phone = formatPhoneNumber(contact.phone_number);
+  return phone || visibleName || (username ? `@${username}` : '') ||
     (isWhatsApp
       ? 'WhatsApp contact'
       : fallback);
@@ -65,12 +83,20 @@ export function displayPersonName(
 
 /** Secondary identity detail for a People row, without duplicating its title. */
 export function displayPersonDetails(contact: {
+  name?: string | null;
+  inferred_name?: string | null;
   username?: string | null;
   phone_number?: string | null;
+  platform?: Platform | string | null;
 }): string | null {
+  const name = contact.name?.trim() || contact.inferred_name?.trim() || '';
   const username = contact.username?.trim().replace(/^@+/, '') || '';
   const phone = formatPhoneNumber(contact.phone_number);
-  if (username && phone) return `@${username} · ${phone}`;
-  if (username) return `@${username}`;
-  return phone || null;
+  const visibleName = name && (!isWhatsAppPlatform(contact.platform) || isUsableWhatsAppName(name)) ? name : '';
+  // The title already uses phone first. Show the useful provider identity
+  // beneath it instead of a generic "add context" prompt.
+  if (phone) return visibleName || (username ? `@${username}` : null);
+  if (visibleName && username) return `@${username}`;
+  if (visibleName) return null;
+  return username ? `@${username}` : null;
 }

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -28,9 +28,10 @@ interface PeoplePage {
   nextOffset: number | null;
 }
 
-async function request<T>(path: string): Promise<T> {
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const { data: { session } } = await supabase.auth.getSession();
   const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
     headers: session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : undefined,
   });
   const body = await response.json().catch(() => ({})) as { data?: T; error?: string };
@@ -54,5 +55,8 @@ export const contactsApi = {
     });
     if (query.trim()) params.set('q', query.trim());
     return request<PeoplePage>(`/contacts?${params.toString()}`);
+  },
+  startIdentitySync() {
+    return request<{ status: 'started' }>('/contacts/identity-backfill', { method: 'POST' });
   },
 };

--- a/apps/client/services/phone-numbers.ts
+++ b/apps/client/services/phone-numbers.ts
@@ -31,8 +31,12 @@ export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
 
 /** WhatsApp's bridge fallback is a privacy mask, not a usable phone number. */
 export function isRedactedPhoneFallback(value: string | null | undefined): boolean {
-  const source = sourcePhone(value || '');
-  return Boolean(source) && /^[+0-9\s().•*-]+$/.test(source) && /[•*]/.test(source);
+  // A bridge privacy mask is never a profile name. Treat any mask glyph as
+  // redacted even when a provider adds an unknown suffix or invisible
+  // formatting character; otherwise it can leak back into a visible row.
+  // mautrix currently uses U+2219 (bullet operator); other providers use
+  // U+2022 (bullet) or an asterisk. All are privacy masks.
+  return /[•∙*]/.test(sourcePhone(value || ''));
 }
 
 /** A bridge display-name fallback containing only a phone number (optionally suffixed with `(WA)`). */

--- a/apps/client/tests/contact-display.test.ts
+++ b/apps/client/tests/contact-display.test.ts
@@ -14,17 +14,17 @@ describe('contact display', () => {
     expect(displayContactName('Lucas', Platform.WHATSAPP, '192204836479059')).toBe('Lucas');
   });
 
-  it('uses a public username before falling back to a phone number in People', () => {
+  it('uses a formatted phone number before the profile name or username in People', () => {
     expect(
       displayPersonName({
         platform: Platform.INSTAGRAM,
         username: 'lucas',
         phone_number: '+14155552671',
       })
-    ).toBe('@lucas');
+    ).toBe('+1 415 555 2671');
     expect(
-      displayPersonDetails({ username: 'lucas', phone_number: '+14155552671' })
-    ).toBe('@lucas · +1 415 555 2671');
+      displayPersonDetails({ platform: Platform.INSTAGRAM, name: 'Lucas', username: 'lucas', phone_number: '+14155552671' })
+    ).toBe('Lucas');
   });
 
   it('does not expose an opaque WhatsApp LID in People', () => {
@@ -43,6 +43,24 @@ describe('contact display', () => {
         name: '+1••••••04',
       })
     ).toBe('WhatsApp contact');
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '+1••••••00 (WA)',
+      })
+    ).toBe('WhatsApp contact');
+    expect(
+      displayPersonName({
+        platform: 'WhatsApp',
+        name: '+1••••••00 bridge fallback',
+      })
+    ).toBe('WhatsApp contact');
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '+1∙∙∙∙∙∙∙∙00',
+      })
+    ).toBe('WhatsApp contact');
   });
 
   it('does not use a WhatsApp phone fallback as a People name', () => {
@@ -52,5 +70,23 @@ describe('contact display', () => {
         name: '+1 415 555 2671 (WA)',
       })
     ).toBe('WhatsApp contact');
+  });
+
+  it('does not show a bridge punctuation placeholder as a People name', () => {
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '.',
+      })
+    ).toBe('WhatsApp contact');
+  });
+
+  it('keeps an emoji-only WhatsApp profile name', () => {
+    expect(
+      displayPersonName({
+        platform: Platform.WHATSAPP,
+        name: '🌹',
+      })
+    ).toBe('🌹');
   });
 });

--- a/apps/server/src/adapters/matrix/bridge-http-client.test.ts
+++ b/apps/server/src/adapters/matrix/bridge-http-client.test.ts
@@ -85,3 +85,38 @@ describe('BridgeHttpClient identifier resolution', () => {
     }
   });
 });
+
+describe('BridgeHttpClient contacts', () => {
+  it('reads contacts through the exact linked account', async () => {
+    const originalFetch = globalThis.fetch;
+    let request: Request | undefined;
+
+    globalThis.fetch = async (input, init) => {
+      request = new Request(input, init);
+      return new Response(JSON.stringify({
+        contacts: [{
+          id: 'lid-192204836479059',
+          name: 'A profile name',
+          identifiers: ['@whatsapp_lid-192204836479059:claire.local'],
+        }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+
+    try {
+      const client = new BridgeHttpClient(
+        'https://bridge.example',
+        'shared-secret',
+        '@claire:claire.local'
+      );
+      const contacts = await client.getContacts('linked-whatsapp-account');
+
+      expect(contacts).toHaveLength(1);
+      expect(contacts[0]?.name).toBe('A profile name');
+      expect(new URL(request!.url).pathname).toBe('/_matrix/provision/v3/contacts');
+      expect(new URL(request!.url).searchParams.get('login_id')).toBe('linked-whatsapp-account');
+      expect(new URL(request!.url).searchParams.get('user_id')).toBe('@claire:claire.local');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/server/src/adapters/matrix/bridge-http-client.ts
+++ b/apps/server/src/adapters/matrix/bridge-http-client.ts
@@ -38,6 +38,20 @@ export interface ResolvedBridgeIdentifier {
   mxid?: string;
 }
 
+/**
+ * A contact profile returned by mautrix's authenticated provisioning API.
+ * These values are scoped to a single linked bridge login; they must never be
+ * copied into a shared Matrix ghost profile.
+ */
+export interface BridgeContact {
+  id: string;
+  name?: string;
+  avatar_url?: string;
+  identifiers?: string[];
+  dm_room_mxid?: string;
+  mxid?: string;
+}
+
 export class BridgeHttpClient {
   private readonly provisioningBase: string;
   private static readonly REQUEST_TIMEOUT_MS = 12_000;
@@ -117,6 +131,22 @@ export class BridgeHttpClient {
       undefined,
       { login_id: loginId }
     );
+  }
+
+  /**
+   * Read the authenticated account's own contact directory. mautrix v3
+   * exposes this separately from Matrix room-member profiles, which lets
+   * Claire enrich its per-user contacts table without turning another
+   * person's local address-book label into global bridge metadata.
+   */
+  async getContacts(loginId: string): Promise<BridgeContact[]> {
+    const response = await this.request<{ contacts?: BridgeContact[] }>(
+      'GET',
+      '/v3/contacts',
+      undefined,
+      { login_id: loginId }
+    );
+    return Array.isArray(response.contacts) ? response.contacts : [];
   }
 
   async startLogin(flowId: string): Promise<LoginStepResponse> {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -372,7 +372,7 @@ async function initializePlatforms() {
           const resolved = await bridge.resolveIdentifier(platformUserId, platformUserId);
           return resolved.mxid ? [resolved.mxid] : [];
         },
-        resolveContactIdentity: async (platform, platformContactId, platformUserId) => {
+        resolveContactIdentity: async (platform, platformContactId) => {
           if (platform !== Platform.WHATSAPP || !process.env.WHATSAPP_BRIDGE_SECRET) {
             return null;
           }
@@ -381,10 +381,15 @@ async function initializePlatforms() {
             process.env.WHATSAPP_BRIDGE_SECRET,
             process.env.WHATSAPP_BRIDGE_USER_ID || '@claire_bot:claire.local'
           );
-          const resolved = await bridge.resolveIdentifier(platformContactId, platformUserId);
+          // mautrix resolves an already-known contact profile through the
+          // authenticated bridge user. `platformUserId` is a WhatsApp phone
+          // or LID, not a provisioning login ID, so passing it here prevents
+          // profile enrichment on some bridge versions.
+          const resolved = await bridge.resolveIdentifier(platformContactId);
           return {
             displayName: resolved.name,
             phoneNumber: phoneNumberFromBridgeIdentifiers([
+              resolved.name,
               ...(resolved.identifiers || []),
               resolved.id,
             ]) || undefined,

--- a/apps/server/src/routes/contacts.ts
+++ b/apps/server/src/routes/contacts.ts
@@ -2,6 +2,9 @@ import { Router, Request, Response } from 'express';
 import { supabase, type DbRow } from '../services/supabase';
 import { requireAuth } from '../middleware/auth';
 import { logger } from '../utils/logger';
+import { queueWhatsAppContactIdentitySync } from '../services/whatsapp-contact-backfill';
+import { phoneNumberFromPlatformContactId } from '../services/contact-identity';
+import { Platform } from '../adapters/types';
 
 const router = Router();
 
@@ -16,10 +19,37 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
     const platform = typeof req.query.platform === 'string' ? req.query.platform : 'all';
     const filter = typeof req.query.filter === 'string' ? req.query.filter : 'all';
 
+    // People is a conversation workspace, not a raw bridge directory. Older
+    // mautrix syncs could leave thousands of historical/LID-only directory
+    // records behind with no Claire chat. Showing those records made the list
+    // both slow and impossible to identify. Start from actual conversations,
+    // then load only their linked contacts.
+    let chatQuery = supabase
+      .from('chats')
+      .select('id, contact_id, name, platform, is_group, last_message_at')
+      .eq('user_id', userId)
+      .not('contact_id', 'is', null)
+      .order('last_message_at', { ascending: false, nullsFirst: false });
+    if (platform !== 'all') chatQuery = chatQuery.eq('platform', platform);
+    const { data: linkedChats, error: linkedChatsError } = await chatQuery;
+    if (linkedChatsError) throw linkedChatsError;
+
+    const chatsByContact = new Map<string, DbRow>();
+    for (const chat of linkedChats || []) {
+      if (chat.contact_id && !chatsByContact.has(chat.contact_id)) {
+        chatsByContact.set(chat.contact_id, chat);
+      }
+    }
+    const linkedContactIds = [...chatsByContact.keys()];
+    if (!linkedContactIds.length) {
+      return res.json({ success: true, data: { contacts: [], nextOffset: null } });
+    }
+
     let query = supabase
       .from('contacts')
-      .select('id, name, phone_number, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
+      .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
       .eq('user_id', userId)
+      .in('id', linkedContactIds)
       .order('name', { ascending: true, nullsFirst: false })
       .order('id', { ascending: true })
       .range(offset, offset + limit);
@@ -48,31 +78,52 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
 
     const rows = data || [];
     const page = rows.slice(0, limit);
-    const contactIds = page.map((contact: DbRow) => contact.id as string);
-    const chatsByContact = new Map<string, DbRow>();
-    if (contactIds.length) {
-      const { data: chats, error: chatsError } = await supabase
-        .from('chats')
-        .select('id, contact_id, name, platform, is_group, last_message_at')
-        .eq('user_id', userId)
-        .in('contact_id', contactIds)
-        .order('last_message_at', { ascending: false, nullsFirst: false });
-      if (chatsError) throw chatsError;
-      for (const chat of chats || []) {
-        if (chat.contact_id && !chatsByContact.has(chat.contact_id)) chatsByContact.set(chat.contact_id, chat);
-      }
-    }
-
     return res.json({
       success: true,
       data: {
-        contacts: page.map((contact: DbRow) => ({ ...contact, chat: chatsByContact.get(contact.id as string) || null })),
+        contacts: page.map((contact: DbRow) => {
+          const platform = contact.platform as Platform;
+          // Some older WhatsApp imports predate phone_number but do retain a
+          // real phone JID as their platform contact ID. Expose that as a
+          // canonical display fallback; LIDs remain deliberately hidden.
+          const phoneNumber = contact.phone_number || phoneNumberFromPlatformContactId(platform, contact.platform_contact_id as string | null | undefined);
+          return { ...contact, phone_number: phoneNumber, chat: chatsByContact.get(contact.id as string) || null };
+        }),
         nextOffset: rows.length > limit ? offset + limit : null,
       },
     });
   } catch (error) {
     logger.error('Error fetching contacts:', error);
     return res.status(500).json({ success: false, error: 'Failed to fetch contacts' });
+  }
+});
+
+/**
+ * Start a user-scoped WhatsApp contact identity sync. This is asynchronous on
+ * purpose: a large address book must never keep a mobile request open. The
+ * People query polls while the deduplicated server task enriches existing
+ * contacts, and the task reads no message bodies.
+ */
+router.post('/identity-backfill', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ success: false, error: 'Unauthorized' });
+
+  try {
+    void queueWhatsAppContactIdentitySync(userId, Number(req.body?.limit))
+      .then((result) => logger.info('WhatsApp contact identity sync completed', {
+        scanned: result.scanned,
+        matched: result.matched,
+        updated: result.updated,
+        unresolved: result.unresolved,
+        hasMore: result.hasMore,
+      }))
+      .catch((error) => logger.warn('WhatsApp contact identity sync did not complete', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }));
+    return res.status(202).json({ success: true, data: { status: 'started' } });
+  } catch (error) {
+    logger.error('WhatsApp contact identity backfill failed', { error, userId });
+    return res.status(500).json({ success: false, error: 'Could not refresh WhatsApp identities' });
   }
 });
 

--- a/apps/server/src/routes/platforms.ts
+++ b/apps/server/src/routes/platforms.ts
@@ -20,6 +20,7 @@ import { loginWithCredentials, submitTwoFactorCode } from '../services/instagram
 import { platformCatalog, platformCatalogVersion } from '../platform-catalog';
 import { supabase, type DbRow } from '../services/supabase';
 import { operationsTelemetry } from '../services/operations-telemetry';
+import { queueWhatsAppContactIdentitySync } from '../services/whatsapp-contact-backfill';
 
 // Railway services cannot reach each other through localhost. Railway does not
 // inject NODE_ENV by default, so its public-domain marker is also used to
@@ -634,6 +635,16 @@ router.post('/:platform/connect', async (req: Request, res: Response) => {
                 session.id,
                 result.complete?.user_login_id
               );
+              void queueWhatsAppContactIdentitySync(session.userId)
+                .then((sync) => logger.info('WhatsApp contact identity sync completed after login', {
+                  scanned: sync.scanned,
+                  matched: sync.matched,
+                  updated: sync.updated,
+                  unresolved: sync.unresolved,
+                }))
+                .catch((error) => logger.warn('WhatsApp contact identity sync failed after login', {
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                }));
               logger.info(`WhatsApp login complete for session ${session.id}`);
               return;
             }

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -3,11 +3,13 @@ import { Platform } from '../adapters/types';
 import {
   displayNameFromBridge,
   incomingContactId,
+  isMeaningfulContactName,
   isOpaqueWhatsAppLid,
   isRedactedPhoneFallback,
   phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from './contact-identity';
+import { whatsappContactKeys } from './whatsapp-contact-backfill';
 
 describe('incoming contact identity', () => {
   test('keeps a direct Mac iMessage phone handle', () => {
@@ -30,9 +32,26 @@ describe('incoming contact identity', () => {
 
   test('does not turn WhatsApp privacy-masked numbers into names', () => {
     expect(isRedactedPhoneFallback('+1••••••04')).toBe(true);
+    expect(isRedactedPhoneFallback('+1∙∙∙∙∙∙∙∙04')).toBe(true);
     expect(
       displayNameFromBridge('+1••••••04', Platform.WHATSAPP, 'lid-192204836479059')
     ).toBeNull();
+    expect(
+      displayNameFromBridge('+1••••••04 (WA)', Platform.WHATSAPP, 'lid-192204836479059')
+    ).toBeNull();
+  });
+
+  test('moves mautrix phone display fallbacks into contact detail, not a name', () => {
+    expect(
+      displayNameFromBridge('+1 516 555 1212 (WA)', Platform.WHATSAPP, 'lid-192204836479059')
+    ).toBeNull();
+    expect(phoneNumberFromBridgeIdentifiers(['+1 516 555 1212 (WA)'])).toBe('+15165551212');
+  });
+
+  test('does not treat bridge punctuation as a person name', () => {
+    expect(isMeaningfulContactName('.')).toBe(false);
+    expect(displayNameFromBridge('.', Platform.WHATSAPP, 'lid-192204836479059')).toBeNull();
+    expect(displayNameFromBridge('🌹', Platform.WHATSAPP, 'lid-192204836479059')).toBe('🌹');
   });
 
   test('keeps a genuine bridge profile name and phone-number contact ID', () => {
@@ -48,5 +67,17 @@ describe('incoming contact identity', () => {
       ])
     ).toBe('+15165551212');
     expect(phoneNumberFromBridgeIdentifiers(['lid-192204836479059'])).toBeNull();
+  });
+});
+
+describe('WhatsApp directory identity matching', () => {
+  test('matches Matrix ghost, LID, and bare identifiers without treating LIDs as numbers', () => {
+    expect(whatsappContactKeys('@whatsapp_lid-192204836479059:claire.local')).toContain('lid-192204836479059');
+    expect(whatsappContactKeys('15165551212@s.whatsapp.net')).toEqual(expect.arrayContaining([
+      '15165551212',
+      '+15165551212',
+    ]));
+    expect(whatsappContactKeys('lid-192204836479059')).not.toContain('+192204836479059');
+    expect(whatsappContactKeys('192204836479059')).toContain('lid-192204836479059');
   });
 });

--- a/apps/server/src/services/contact-identity.ts
+++ b/apps/server/src/services/contact-identity.ts
@@ -17,8 +17,21 @@ export function isOpaqueWhatsAppLid(value: string | null | undefined): boolean {
  * name nor a phone number Claire can display or search as an identity.
  */
 export function isRedactedPhoneFallback(value: string | null | undefined): boolean {
-  const source = value?.trim() || '';
-  return Boolean(source) && /^[+0-9\s().•*-]+$/.test(source) && /[•*]/.test(source);
+  // Provider masks must never become a persisted display name. The bridge may
+  // append arbitrary suffixes, so the mask glyph itself is the reliable signal.
+  // mautrix currently uses U+2219 (bullet operator); other providers use
+  // U+2022 (bullet) or an asterisk. All are privacy masks.
+  return /[•∙*]/.test(value?.trim() || '');
+}
+
+/**
+ * A bridge can occasionally report punctuation (for example `.`) as a
+ * WhatsApp push name. It is not a useful identity and should be treated the
+ * same way as an absent profile name. Emoji-only names remain valid: many
+ * people intentionally use one as their WhatsApp profile name.
+ */
+export function isMeaningfulContactName(value: string | null | undefined): boolean {
+  return /[\p{L}\p{N}\p{Extended_Pictographic}]/u.test(value?.trim() || '');
 }
 
 /** Return a real phone-shaped platform identifier, never a WhatsApp LID. */
@@ -43,9 +56,13 @@ export function phoneNumberFromBridgeIdentifiers(
 ): string | null {
   for (const identifier of identifiers) {
     if (!identifier) continue;
-    const source = identifier.trim().replace(/^tel:/i, '').split('@')[0];
+    const source = identifier
+      .trim()
+      .replace(/^tel:/i, '')
+      .replace(/\s*\(WA\)\s*$/i, '')
+      .split('@')[0];
     if (isOpaqueWhatsAppLid(source)) continue;
-    const digits = source.replace(/^\+/, '');
+    const digits = source.replace(/^\+/, '').replace(/[().\s-]/g, '');
     if (/^\d{7,15}$/.test(digits)) return `+${digits}`;
   }
   return null;
@@ -61,9 +78,10 @@ export function displayNameFromBridge(
   platform: Platform,
   platformContactId: string | null | undefined
 ): string | null {
-  const name = candidate?.trim() || '';
+  const name = candidate?.trim().replace(/\s*\(WA\)\s*$/i, '') || '';
   if (
     !name ||
+    !isMeaningfulContactName(name) ||
     (platform === Platform.WHATSAPP &&
       (isOpaqueWhatsAppLid(name) || isRedactedPhoneFallback(name)))
   ) {

--- a/apps/server/src/services/whatsapp-contact-backfill.ts
+++ b/apps/server/src/services/whatsapp-contact-backfill.ts
@@ -1,0 +1,250 @@
+import { BridgeContact, BridgeHttpClient } from '../adapters/matrix/bridge-http-client';
+import { Platform } from '../adapters/types';
+import {
+  displayNameFromBridge,
+  phoneNumberFromBridgeIdentifiers,
+} from './contact-identity';
+import { supabase, type DbRow } from './supabase';
+
+const MAX_CONTACTS_PER_SYNC = 10_000;
+const DATABASE_PAGE_SIZE = 1_000;
+const WRITE_BATCH_SIZE = 250;
+const inFlightSyncs = new Map<string, Promise<ContactIdentityBackfillResult>>();
+
+export interface ContactIdentityBackfillResult {
+  scanned: number;
+  matched: number;
+  updated: number;
+  unresolved: number;
+  skipped: number;
+  hasMore: boolean;
+}
+
+function bridgeClient(): BridgeHttpClient | null {
+  const secret = process.env.WHATSAPP_BRIDGE_SECRET;
+  if (!secret) return null;
+  return new BridgeHttpClient(
+    process.env.WHATSAPP_BRIDGE_URL || 'http://mautrixwhatsapp.railway.internal:29318',
+    secret,
+    process.env.WHATSAPP_BRIDGE_USER_ID || '@claire_bot:claire.local'
+  );
+}
+
+/**
+ * mautrix and our Matrix mapper can represent the same WhatsApp contact as a
+ * JID, a Matrix ghost ID, a bare phone number, or an opaque LID. Compare only
+ * normalized bridge-owned identifiers; we never infer a phone number from a
+ * LID.
+ */
+export function whatsappContactKeys(value: string | null | undefined): string[] {
+  if (!value) return [];
+  const source = value.trim().toLowerCase();
+  if (!source) return [];
+
+  const keys = new Set<string>([source]);
+  const withoutMxid = source.replace(/^@/, '').split(':')[0] || source;
+  keys.add(withoutMxid);
+  const withoutPrefix = withoutMxid.replace(/^whatsapp_/, '');
+  keys.add(withoutPrefix);
+  const bareJid = withoutPrefix.split('@')[0] || withoutPrefix;
+  keys.add(bareJid);
+
+  if (/^\+?\d{7,15}$/.test(bareJid)) {
+    keys.add(bareJid.replace(/^\+/, ''));
+    keys.add(`+${bareJid.replace(/^\+/, '')}`);
+  }
+  if (/^lid[-:]?\d+$/.test(bareJid)) {
+    keys.add(`lid-${bareJid.replace(/\D/g, '')}`);
+  }
+  // Older Claire imports persisted an LID as bare digits, before the mapper
+  // consistently preserved its `lid-` prefix. A WhatsApp phone number is at
+  // most 15 digits; nevertheless include the LID alias for an ambiguous
+  // 15-digit legacy value as a final fallback. Direct phone/JID keys are
+  // inserted first and therefore always win when both identities exist.
+  if (/^\d{15,20}$/.test(bareJid)) {
+    keys.add(`lid-${bareJid}`);
+  }
+
+  return [...keys];
+}
+
+function buildBridgeContactIndex(contacts: BridgeContact[]): Map<string, BridgeContact> {
+  const index = new Map<string, BridgeContact>();
+  for (const contact of contacts) {
+    for (const identity of [contact.id, ...(contact.identifiers || []), contact.mxid]) {
+      for (const key of whatsappContactKeys(identity)) {
+        // Contact IDs themselves are authoritative. Only use an alias when no
+        // direct key has already been seen.
+        if (!index.has(key) || identity === contact.id) index.set(key, contact);
+      }
+    }
+  }
+  return index;
+}
+
+async function linkedWhatsAppLoginId(userId: string): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('platform_sessions')
+    .select('platform_user_id, last_connected_at')
+    .eq('user_id', userId)
+    .eq('platform', Platform.WHATSAPP)
+    .not('platform_user_id', 'is', null)
+    .order('last_connected_at', { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return typeof data?.platform_user_id === 'string' && data.platform_user_id.trim()
+    ? data.platform_user_id
+    : null;
+}
+
+async function loadExistingWhatsAppContacts(userId: string, maxContacts: number): Promise<DbRow[]> {
+  const contacts: DbRow[] = [];
+  for (let offset = 0; contacts.length < maxContacts; offset += DATABASE_PAGE_SIZE) {
+    const remaining = maxContacts - contacts.length;
+    const { data, error } = await supabase
+      .from('contacts')
+      .select('id, user_id, whatsapp_id, platform, platform_contact_id, name, phone_number, avatar_url')
+      .eq('user_id', userId)
+      .eq('platform', Platform.WHATSAPP)
+      .order('id', { ascending: true })
+      .range(offset, offset + Math.min(DATABASE_PAGE_SIZE, remaining) - 1);
+    if (error) throw error;
+    const page = (data || []) as DbRow[];
+    contacts.push(...page);
+    if (page.length < Math.min(DATABASE_PAGE_SIZE, remaining)) break;
+  }
+  return contacts;
+}
+
+function bridgeContactForStoredContact(
+  contact: DbRow,
+  bridgeContacts: Map<string, BridgeContact>
+): BridgeContact | null {
+  const candidates = [
+    contact.platform_contact_id as string | null | undefined,
+    contact.whatsapp_id as string | null | undefined,
+  ];
+  for (const candidate of candidates) {
+    for (const key of whatsappContactKeys(candidate)) {
+      const resolved = bridgeContacts.get(key);
+      if (resolved) return resolved;
+    }
+  }
+  return null;
+}
+
+function updatePayload(contact: DbRow, bridgeContact: BridgeContact): DbRow | null {
+  const platformContactId = String(contact.platform_contact_id || contact.whatsapp_id || '');
+  const name = displayNameFromBridge(bridgeContact.name, Platform.WHATSAPP, platformContactId);
+  const phoneNumber = phoneNumberFromBridgeIdentifiers([
+    bridgeContact.id,
+    ...(bridgeContact.identifiers || []),
+  ]);
+  const avatarUrl = typeof bridgeContact.avatar_url === 'string' && bridgeContact.avatar_url.trim()
+    ? bridgeContact.avatar_url
+    : null;
+
+  const nextName = name || contact.name || null;
+  const nextPhone = phoneNumber || contact.phone_number || null;
+  const nextAvatar = avatarUrl || contact.avatar_url || null;
+  if (
+    nextName === (contact.name || null)
+    && nextPhone === (contact.phone_number || null)
+    && nextAvatar === (contact.avatar_url || null)
+  ) {
+    return null;
+  }
+
+  return {
+    id: contact.id,
+    user_id: contact.user_id,
+    platform: contact.platform,
+    platform_contact_id: platformContactId,
+    // The legacy column remains NOT NULL in deployed databases. Keep it in
+    // sync until that historical constraint is removed in a dedicated schema
+    // migration.
+    whatsapp_id: String(contact.whatsapp_id || platformContactId),
+    name: nextName,
+    phone_number: nextPhone,
+    avatar_url: nextAvatar,
+  };
+}
+
+/**
+ * Copy an authenticated WhatsApp account's contact identities into Claire's
+ * existing, user-scoped contact records. The bridge request is explicitly
+ * scoped by login_id; never use the bridge bot's whole contact directory as a
+ * fallback, because that could mix identities between Claire users.
+ *
+ * A single run is capped at 10k existing contacts and uses paged reads plus
+ * batch upserts so it can repair a large People list without touching message
+ * content or operational telemetry.
+ */
+export async function backfillWhatsAppContactIdentities(
+  userId: string,
+  requestedLimit?: number
+): Promise<ContactIdentityBackfillResult> {
+  const bridge = bridgeClient();
+  if (!bridge) throw new Error('WhatsApp identity resolver is not configured');
+
+  const limit = Math.min(Math.max(requestedLimit || MAX_CONTACTS_PER_SYNC, 1), MAX_CONTACTS_PER_SYNC);
+  const loginId = await linkedWhatsAppLoginId(userId);
+  if (!loginId) throw new Error('WhatsApp needs to be reconnected before contact identities can sync');
+
+  const [rows, bridgeDirectory] = await Promise.all([
+    loadExistingWhatsAppContacts(userId, limit + 1),
+    bridge.getContacts(loginId),
+  ]);
+  const targets = rows.slice(0, limit);
+  const bridgeContacts = buildBridgeContactIndex(bridgeDirectory);
+  const updates: DbRow[] = [];
+  let matched = 0;
+  let unresolved = 0;
+
+  for (const contact of targets) {
+    const bridgeContact = bridgeContactForStoredContact(contact, bridgeContacts);
+    if (!bridgeContact) {
+      unresolved++;
+      continue;
+    }
+    matched++;
+    const payload = updatePayload(contact, bridgeContact);
+    if (payload) updates.push(payload);
+  }
+
+  for (let index = 0; index < updates.length; index += WRITE_BATCH_SIZE) {
+    const batch = updates.slice(index, index + WRITE_BATCH_SIZE);
+    const { error } = await supabase
+      .from('contacts')
+      .upsert(batch, { onConflict: 'user_id,platform,platform_contact_id' });
+    if (error) throw error;
+  }
+
+  return {
+    scanned: targets.length,
+    matched,
+    updated: updates.length,
+    unresolved,
+    skipped: matched - updates.length,
+    hasMore: rows.length > limit,
+  };
+}
+
+/**
+ * De-duplicate a foreground refresh and an after-login sync for the same
+ * Claire user. The caller deliberately receives the same promise so a second
+ * tap never starts a competing 10k-row import.
+ */
+export function queueWhatsAppContactIdentitySync(
+  userId: string,
+  requestedLimit?: number
+): Promise<ContactIdentityBackfillResult> {
+  const existing = inFlightSyncs.get(userId);
+  if (existing) return existing;
+
+  const task = backfillWhatsAppContactIdentities(userId, requestedLimit)
+    .finally(() => inFlightSyncs.delete(userId));
+  inFlightSyncs.set(userId, task);
+  return task;
+}

--- a/apps/website/src/components/site/HomePage.tsx
+++ b/apps/website/src/components/site/HomePage.tsx
@@ -657,23 +657,18 @@ export function HomePage() {
               <div className="phone-tabs">
                 <span>
                   <HeroIcon name="home" />
-                  <small>Home</small>
                 </span>
                 <span>
                   <HeroIcon name="inbox" />
-                  <small>Inbox</small>
                 </span>
                 <span className="phone-tab-ask">
                   <HeroIcon name="sparkles" />
-                  <small>Ask</small>
                 </span>
                 <span>
                   <HeroIcon name="promises" />
-                  <small>Promises</small>
                 </span>
                 <span>
                   <HeroIcon name="search" />
-                  <small>Search</small>
                 </span>
               </div>
             </div>

--- a/supabase/migrations/20260820000003_move_whatsapp_phone_display_fallbacks.sql
+++ b/supabase/migrations/20260820000003_move_whatsapp_phone_display_fallbacks.sql
@@ -1,0 +1,15 @@
+-- mautrix may use the sender's full phone number as its profile display-name
+-- fallback. It is useful contact detail, but it must never occupy `name`:
+-- client identity rules deliberately hide phone-shaped names. Preserve the
+-- canonical E.164 value in phone_number and leave the person name unknown.
+UPDATE contacts
+SET
+  phone_number = COALESCE(
+    phone_number,
+    '+' || regexp_replace(regexp_replace(name, '\s*\(WA\)\s*$', '', 'i'), '[^0-9]', '', 'g')
+  ),
+  name = NULL
+WHERE platform = 'whatsapp'
+  AND name IS NOT NULL
+  AND name !~ '[•*]'
+  AND regexp_replace(regexp_replace(name, '\s*\(WA\)\s*$', '', 'i'), '[^0-9]', '', 'g') ~ '^[0-9]{7,15}$';


### PR DESCRIPTION
## What changed

- Make People a conversation-derived view so historical, unlinked WhatsApp LID directory rows no longer crowd out real contacts.
- Safely pull identities from the authenticated, per-user mautrix contact directory, capped at 10k existing contacts, without message content or cross-user Matrix-profile propagation.
- Refresh People while an identity sync runs, preserve tab navigation, and hide opaque LID or masked-phone fallbacks.
- Remove labels from the website home-page phone navigation.

## Verification

- Server test suite: 402 passing tests.
- Server, client, and website type checks pass.

## Production read-only validation

- The current account has 10,000 historical WhatsApp contact records, but only 62 are linked to conversations; 60 of those have usable names. The new query shows conversation-linked people instead of stale directory rows.
- The authenticated mautrix v3 contact endpoint is available and reports 1,499 directory contacts. No contact data was written to logs during validation.