### PR TITLE
feat(people): index and import contact directory

### DIFF
--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { FlatList, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Pressable, ScrollView, SectionList, Text, View } from 'react-native';
 import { Check, ListFilter, Search } from 'lucide-react-native';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
+import { useQuery } from '@tanstack/react-query';
+import { colors, mobileType, space, useIsDesktopLayout } from '@claire/design-system';
 import { useAuthStore } from '../../stores/authStore';
 import { MobileAvatar, MobileChip, MobileHeader, MobileIconButton, MobileSearchField, MobileState } from '../../components/mobile/claire-mobile';
+import { BottomSheet } from '../../components/mobile/bottom-sheet';
 import { PlatformIcon, PlatformName } from '../../components/PlatformIcon';
 import { Platform, platformLabel } from '../../types/platform';
 import { PeopleSkeleton } from '../../components/claire/skeleton';
 import { contactsApi, type PeopleFilter, type PersonContact } from '../../services/contacts';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { displayPersonDetails, displayPersonName } from '../../services/contact-display';
+import { isPhoneNumberFallback } from '../../services/phone-numbers';
 
 type PlatformFilter = 'all' | Platform;
 
@@ -21,12 +23,57 @@ function contactPlatform(contact: PersonContact) {
   return contact.chat?.platform || contact.platform || null;
 }
 
+/**
+ * A contact is the durable platform profile; a chat is the latest
+ * conversation envelope. Older WhatsApp imports occasionally have identity
+ * metadata only on that envelope, so use it as a display-only fallback. This
+ * keeps a person identifiable without ever surfacing the bridge LID.
+ */
+function displayIdentity(contact: PersonContact) {
+  const chatName = contact.chat?.name?.trim() || null;
+  return {
+    ...contact,
+    platform: contactPlatform(contact),
+    name: contact.name || contact.inferred_name || chatName,
+    phone_number: contact.phone_number || (chatName && isPhoneNumberFallback(chatName) ? chatName : null),
+  };
+}
+
 function personName(contact: PersonContact): string {
-  return displayPersonName({ ...contact, platform: contactPlatform(contact) }, 'Unknown person');
+  return displayPersonName(displayIdentity(contact), 'Unknown person');
 }
 
 function personDetails(contact: PersonContact): string | null {
-  return displayPersonDetails(contact);
+  return displayPersonDetails(displayIdentity(contact));
+}
+
+type PeopleSection = { title: string; data: PersonContact[] };
+
+function alphabetLetter(contact: PersonContact): string {
+  const initial = personName(contact)
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .charAt(0)
+    .toUpperCase();
+  return /^[A-Z]$/.test(initial) ? initial : '#';
+}
+
+function alphabetizedSections(contacts: PersonContact[]): PeopleSection[] {
+  const grouped = new Map<string, PersonContact[]>();
+  for (const contact of contacts) {
+    const letter = alphabetLetter(contact);
+    const section = grouped.get(letter) || [];
+    section.push(contact);
+    grouped.set(letter, section);
+  }
+  return [...grouped.entries()]
+    .sort(([left], [right]) => {
+      if (left === '#') return 1;
+      if (right === '#') return -1;
+      return left.localeCompare(right);
+    })
+    .map(([title, data]) => ({ title, data }));
 }
 
 export default function ContactsScreen() {
@@ -39,28 +86,27 @@ export default function ContactsScreen() {
   const [showPlatformFilter, setShowPlatformFilter] = useState(false);
   const user = useAuthStore(state => state.user);
   const requestedIdentitySyncFor = useRef<string | null>(null);
+  const peopleListRef = useRef<SectionList<PersonContact>>(null);
   const debouncedSearchQuery = useDebouncedValue(searchQuery);
 
   useEffect(() => {
     setSearchQuery(params.q || params.query || '');
   }, [params.q, params.query]);
 
-  const peopleQuery = useInfiniteQuery({
+  const peopleQuery = useQuery({
     queryKey: ['people', user?.id, debouncedSearchQuery, platform, filter],
     enabled: !!user?.id,
-    initialPageParam: 0,
-    queryFn: ({ pageParam }) => contactsApi.list({
-      offset: pageParam,
+    // The API and bridge sync share a 10k maximum. Loading that user-scoped
+    // directory as one virtualized list is what makes an A–Z index truthful:
+    // tapping J never jumps only within whichever page happened to be loaded.
+    queryFn: () => contactsApi.list({
+      limit: 10_000,
       query: debouncedSearchQuery,
       platform,
       filter,
     }),
-    getNextPageParam: (page) => page.nextOffset,
-    // Contacts are enriched asynchronously by the connected bridges. A
-    // foreground return should always pick up newly learned names/numbers.
-    // Keep polling briefly while the bounded server-side identity sync runs.
+    // A foreground return should always pick up newly learned names/numbers.
     refetchOnMount: 'always',
-    refetchInterval: 15_000,
   });
 
   useEffect(() => {
@@ -69,12 +115,17 @@ export default function ContactsScreen() {
     // This only starts a per-user, metadata-only bridge sync. It is safe to
     // ignore a missing/disconnected WhatsApp account; People still renders
     // the identities already stored for other platforms.
-    void contactsApi.startIdentitySync()
-      .then(() => peopleQuery.refetch())
-      .catch(() => undefined);
+    // The task is asynchronous. Refresh a few times while a linked account's
+    // bounded directory import runs, instead of repeatedly downloading a
+    // possible 10k-person directory for the entire life of the screen.
+    const refreshTimers = [3_000, 15_000, 45_000].map((delay) => setTimeout(() => {
+      void peopleQuery.refetch();
+    }, delay));
+    void contactsApi.startIdentitySync().catch(() => undefined);
+    return () => refreshTimers.forEach(clearTimeout);
   }, [user?.id, peopleQuery.refetch]);
   const contacts = useMemo(
-    () => (peopleQuery.data?.pages.flatMap((page) => page.contacts) || [])
+    () => (peopleQuery.data?.contacts || [])
       .slice()
       .sort((left, right) => {
         const leftName = personName(left);
@@ -86,6 +137,7 @@ export default function ContactsScreen() {
       }),
     [peopleQuery.data],
   );
+  const sections = useMemo(() => alphabetizedSections(contacts), [contacts]);
 
   // Keep every supported platform visible. A zero-result Instagram filter is
   // useful feedback that the account has no synced Instagram conversations;
@@ -106,8 +158,8 @@ export default function ContactsScreen() {
   const emptyMessage = searchQuery
     ? 'Try another name or number.'
     : platform !== 'all'
-      ? 'Contacts from this account appear here as conversations sync.'
-      : 'Contacts appear here as conversations sync.';
+      ? 'Contacts from this connected account appear here after it syncs.'
+      : 'Contacts from your connected accounts appear here after they sync.';
 
   if (isDesktop) {
     const selected = contacts.find((contact) => contact.id === selectedContactId) || contacts[0];
@@ -157,17 +209,21 @@ export default function ContactsScreen() {
         </ScrollView>
       </View>
         {peopleQuery.isLoading ? <View style={{ paddingHorizontal: space[4] }}><PeopleSkeleton /></View> : (
-        <FlatList
-          data={contacts}
+        <View style={{ flex: 1, minHeight: 0 }}>
+        <SectionList
+          ref={peopleListRef}
+          sections={sections}
           keyExtractor={item => item.id}
           testID="contacts-list"
           style={{ backgroundColor: colors.paper }}
-          contentContainerStyle={{ paddingHorizontal: space[4], paddingBottom: 104 }}
-          onEndReached={() => {
-            if (peopleQuery.hasNextPage && !peopleQuery.isFetchingNextPage) void peopleQuery.fetchNextPage();
-          }}
-          onEndReachedThreshold={0.6}
+          contentContainerStyle={{ paddingLeft: space[4], paddingRight: 30, paddingBottom: 104 }}
+          stickySectionHeadersEnabled={false}
           ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.neutral[200] }} />}
+          renderSectionHeader={({ section }) => (
+            <View style={{ paddingTop: space[3], paddingBottom: space[1] }}>
+              <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600] }}>{section.title}</Text>
+            </View>
+          )}
           renderItem={({ item }) => {
             const name = personName(item);
             const identityDetail = personDetails(item);
@@ -194,19 +250,29 @@ export default function ContactsScreen() {
             );
           }}
           ListEmptyComponent={<MobileState error={!!peopleQuery.error} title={peopleQuery.error ? 'People are unavailable' : emptyTitle} message={peopleQuery.error ? 'Try again in a moment.' : emptyMessage} />}
-          ListFooterComponent={peopleQuery.isFetchingNextPage ? <View style={{ paddingVertical: space[4] }}><PeopleSkeleton /></View> : null}
         />
+        {sections.length ? <View pointerEvents="box-none" style={{ position: 'absolute', right: 2, top: space[2], bottom: 96, justifyContent: 'center' }} testID="people-alphabet-index">
+          {sections.map((section, sectionIndex) => (
+            <Pressable
+              key={section.title}
+              accessibilityRole="button"
+              accessibilityLabel={`Jump to ${section.title}`}
+              hitSlop={4}
+              onPress={() => peopleListRef.current?.scrollToLocation({ sectionIndex, itemIndex: 0, animated: true, viewOffset: 8 })}
+              style={{ minHeight: 15, minWidth: 20, alignItems: 'center', justifyContent: 'center' }}
+            >
+              <Text style={{ fontSize: 10, lineHeight: 12, fontWeight: '800', color: colors.neutral[600] }}>{section.title}</Text>
+            </Pressable>
+          ))}
+        </View> : null}
+        </View>
       )}
 
-      <Modal visible={showPlatformFilter} transparent animationType="slide" onRequestClose={() => setShowPlatformFilter(false)}>
-        <View style={{ flex: 1, backgroundColor: 'rgba(16,18,15,0.35)', justifyContent: 'flex-end' }}>
-          <Pressable accessibilityRole="button" accessibilityLabel="Close platform filter" style={{ flex: 1 }} onPress={() => setShowPlatformFilter(false)} />
-          <View style={{ backgroundColor: colors.paper, borderTopLeftRadius: radius.panel, borderTopRightRadius: radius.panel, paddingHorizontal: space[5], paddingTop: space[4], paddingBottom: 36 }}>
-            <View style={{ width: 36, height: 4, borderRadius: 2, backgroundColor: colors.neutral[300], alignSelf: 'center', marginBottom: space[4] }} />
-            <Text style={{ ...mobileType.sectionTitle, color: colors.ink }}>Filter by platform</Text>
-            <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginTop: 4, marginBottom: space[3] }}>People includes everyone Claire has synced, including Instagram.</Text>
+      <BottomSheet visible={showPlatformFilter} title="Filter people" onClose={() => setShowPlatformFilter(false)} testID="people-platform-sheet">
+        <View style={{ paddingHorizontal: space[4], paddingBottom: space[2] }}>
+            <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginBottom: space[3] }}>Choose the networks you want to see.</Text>
             <Pressable accessibilityRole="button" accessibilityState={{ selected: platform === 'all' }} onPress={() => selectPlatform('all')} testID="people-platform-all">
-              <View style={{ minHeight: 56, flexDirection: 'row', alignItems: 'center', gap: space[3] }}>
+              <View style={{ minHeight: 60, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[2] }}>
                 <View style={{ flex: 1, minWidth: 0 }}>
                   <Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>All platforms</Text>
                   <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>Every synced person</Text>
@@ -223,7 +289,7 @@ export default function ContactsScreen() {
                   onPress={() => selectPlatform(value)}
                   testID={`people-platform-${value}`}
                 >
-                  <View style={{ minHeight: 56, flexDirection: 'row', alignItems: 'center', gap: space[3] }}>
+                  <View style={{ minHeight: 60, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[2] }}>
                     <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
                       <PlatformName platform={value} size={14} />
                       <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>Show {platformLabel(value)} people</Text>
@@ -233,9 +299,8 @@ export default function ContactsScreen() {
                 </Pressable>
               </View>
             ))}
-          </View>
         </View>
-      </Modal>
+      </BottomSheet>
     </View>
   );
 }

--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -17,6 +17,22 @@ import { isPhoneNumberFallback } from '../../services/phone-numbers';
 
 type PlatformFilter = 'all' | Platform;
 
+const CURRENT_FILTERS: Array<{ value: PeopleFilter; label: string; detail: string }> = [
+  { value: 'all', label: 'All people', detail: 'Everyone Claire has synced' },
+  { value: 'contacted', label: 'Contacted', detail: 'People you have messaged' },
+  { value: 'needs_context', label: 'Needs context', detail: 'People without relationship context' },
+  { value: 'groups', label: 'Groups', detail: 'Group conversations' },
+];
+
+const COMING_SOON_FILTERS = [
+  ['Open loops', 'Unresolved promises, questions, and plans'],
+  ['Needs reply', 'Conversations waiting on you'],
+  ['Follow-ups due', 'Commitments and reminders with a next step'],
+  ['Reconnecting', 'People you have not talked to recently'],
+  ['Context gaps', 'Important people Claire knows little about'],
+  ['Important moments', 'Relevant dates and shared context'],
+] as const;
+
 const PLATFORM_ORDER: Platform[] = [Platform.WHATSAPP, Platform.INSTAGRAM, Platform.IMESSAGE, Platform.TELEGRAM];
 
 function contactPlatform(contact: PersonContact) {
@@ -154,7 +170,13 @@ export default function ContactsScreen() {
     setShowPlatformFilter(false);
   };
 
-  const emptyTitle = searchQuery ? 'No people found' : platform !== 'all' ? `No people on ${platformLabel(platform)}` : 'No people yet';
+  const emptyTitle = searchQuery
+    ? 'No people found'
+    : filter === 'contacted'
+      ? 'No people contacted yet'
+      : platform !== 'all'
+        ? `No people on ${platformLabel(platform)}`
+        : 'No people yet';
   const emptyMessage = searchQuery
     ? 'Try another name or number.'
     : platform !== 'all'
@@ -197,6 +219,7 @@ export default function ContactsScreen() {
         <MobileSearchField icon={<Search size={18} color={colors.neutral[600]} />} placeholder="Search people" value={searchQuery} onChangeText={setSearchQuery} testID="contacts-search-input" />
         <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: space[2] }}>
           <MobileChip label="All" active={filter === 'all'} onPress={() => setFilter('all')} />
+          <MobileChip label="Contacted" active={filter === 'contacted'} onPress={() => setFilter('contacted')} />
           <MobileChip label="Needs context" active={filter === 'needs_context'} onPress={() => setFilter('needs_context')} />
           <MobileChip label="Groups" active={filter === 'groups'} onPress={() => setFilter('groups')} />
           <MobileChip
@@ -268,9 +291,25 @@ export default function ContactsScreen() {
         </View>
       )}
 
-      <BottomSheet visible={showPlatformFilter} title="Filter people" onClose={() => setShowPlatformFilter(false)} testID="people-platform-sheet">
+      <BottomSheet visible={showPlatformFilter} title="Filter people" onClose={() => setShowPlatformFilter(false)} testID="people-platform-sheet" snapPoints={['88%']} scrollable>
         <View style={{ paddingHorizontal: space[4], paddingBottom: space[2] }}>
-            <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginBottom: space[3] }}>Choose the networks you want to see.</Text>
+            <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600], marginBottom: space[2] }}>SHOW</Text>
+            {CURRENT_FILTERS.map((option, index) => (
+              <View key={option.value}>
+                {index ? <View style={{ height: 1, backgroundColor: colors.neutral[200] }} /> : null}
+                <Pressable accessibilityRole="button" accessibilityState={{ selected: filter === option.value }} onPress={() => { setFilter(option.value); setShowPlatformFilter(false); }} testID={`people-filter-${option.value}`}>
+                  <View style={{ minHeight: 60, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[2] }}>
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{option.label}</Text>
+                      <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{option.detail}</Text>
+                    </View>
+                    {filter === option.value ? <Check size={18} color={colors.ink} /> : null}
+                  </View>
+                </Pressable>
+              </View>
+            ))}
+            <View style={{ height: 1, backgroundColor: colors.neutral[200], marginVertical: space[2] }} />
+            <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600], marginBottom: space[2] }}>PLATFORM</Text>
             <Pressable accessibilityRole="button" accessibilityState={{ selected: platform === 'all' }} onPress={() => selectPlatform('all')} testID="people-platform-all">
               <View style={{ minHeight: 60, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[2] }}>
                 <View style={{ flex: 1, minWidth: 0 }}>
@@ -297,6 +336,21 @@ export default function ContactsScreen() {
                     {platform === value ? <Check size={18} color={colors.ink} /> : null}
                   </View>
                 </Pressable>
+              </View>
+            ))}
+            <View style={{ height: 1, backgroundColor: colors.neutral[200], marginVertical: space[2] }} />
+            <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600], marginBottom: space[1] }}>CLAIRE INTELLIGENCE</Text>
+            <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginBottom: space[2] }}>Coming soon — these require reliable, explainable signals.</Text>
+            {COMING_SOON_FILTERS.map(([label, detail], index) => (
+              <View key={label}>
+                {index ? <View style={{ height: 1, backgroundColor: colors.neutral[200] }} /> : null}
+                <View accessibilityRole="text" style={{ minHeight: 58, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[2], opacity: 0.58 }}>
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text style={{ ...mobileType.bodySmall, fontWeight: '700', color: colors.ink }}>{label}</Text>
+                    <Text style={{ ...mobileType.label, color: colors.neutral[600] }}>{detail}</Text>
+                  </View>
+                  <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600] }}>SOON</Text>
+                </View>
               </View>
             ))}
         </View>

--- a/apps/client/components/mobile/bottom-sheet.tsx
+++ b/apps/client/components/mobile/bottom-sheet.tsx
@@ -89,7 +89,32 @@ export function BottomSheet({
         borderTopRightRadius: 28,
       }}
     >
-      <BottomSheetView>
+      {scrollable ? (
+        <BottomSheetScrollView contentContainerStyle={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
+          <View
+            testID={testID}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: space[2],
+              paddingHorizontal: space[4],
+              paddingTop: space[3],
+              paddingBottom: space[2],
+            }}
+          >
+            <Text style={{ ...mobileType.sectionTitle, flex: 1, color: colors.ink }}>{title}</Text>
+            <MobileIconButton
+              label="Close"
+              testID={testID ? `${testID}-close` : undefined}
+              onPress={onClose}
+            >
+              <X size={19} color={colors.ink} />
+            </MobileIconButton>
+          </View>
+          {children}
+        </BottomSheetScrollView>
+      ) : (
+      <BottomSheetView style={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
         <View
           testID={testID}
           style={{
@@ -110,15 +135,8 @@ export function BottomSheet({
             <X size={19} color={colors.ink} />
           </MobileIconButton>
         </View>
+        {children}
       </BottomSheetView>
-      {scrollable ? (
-        <BottomSheetScrollView contentContainerStyle={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
-          {children}
-        </BottomSheetScrollView>
-      ) : (
-        <BottomSheetView style={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
-          {children}
-        </BottomSheetView>
       )}
     </GorhomBottomSheet>
   );

--- a/apps/client/components/mobile/bottom-sheet.tsx
+++ b/apps/client/components/mobile/bottom-sheet.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import GorhomBottomSheet, {
   BottomSheetBackdrop,
+  BottomSheetScrollView,
   BottomSheetView,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
@@ -36,12 +37,16 @@ export function BottomSheet({
   onClose,
   children,
   testID,
+  snapPoints = SNAP_POINTS,
+  scrollable = false,
 }: {
   visible: boolean;
   title: string;
   onClose: () => void;
   children: ReactNode;
   testID?: string;
+  snapPoints?: string[];
+  scrollable?: boolean;
 }) {
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<GorhomBottomSheet>(null);
@@ -70,7 +75,7 @@ export function BottomSheet({
     <GorhomBottomSheet
       ref={sheetRef}
       index={-1}
-      snapPoints={SNAP_POINTS}
+      snapPoints={snapPoints}
       enablePanDownToClose
       onClose={onClose}
       backdropComponent={renderBackdrop}
@@ -84,7 +89,7 @@ export function BottomSheet({
         borderTopRightRadius: 28,
       }}
     >
-      <BottomSheetView style={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
+      <BottomSheetView>
         <View
           testID={testID}
           style={{
@@ -105,8 +110,16 @@ export function BottomSheet({
             <X size={19} color={colors.ink} />
           </MobileIconButton>
         </View>
-        {children}
       </BottomSheetView>
+      {scrollable ? (
+        <BottomSheetScrollView contentContainerStyle={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
+          {children}
+        </BottomSheetScrollView>
+      ) : (
+        <BottomSheetView style={{ paddingBottom: bottomSheetInset(insets.bottom) }}>
+          {children}
+        </BottomSheetView>
+      )}
     </GorhomBottomSheet>
   );
 }

--- a/apps/client/services/contact-display.ts
+++ b/apps/client/services/contact-display.ts
@@ -51,10 +51,11 @@ export function displayContactName(
 }
 
 /**
- * Full contact identity used by People. A real formatted phone number is the
- * most reliable way to identify a WhatsApp-only contact, followed by the
- * provider profile name and then a public username. This keeps bridge routing
- * IDs and privacy masks out of the product while still making every row useful.
+ * Primary People label. When the platform gives us both a profile name and a
+ * phone number, people scan much more naturally as "Name" then "Number" than
+ * as a phone directory. A phone remains the primary label only when it is the
+ * only safe identity we have. This keeps bridge routing IDs and privacy masks
+ * out of the product while still making every row useful.
  */
 export function displayPersonName(
   contact: {
@@ -75,13 +76,13 @@ export function displayPersonName(
       ? name
       : '';
   const phone = formatPhoneNumber(contact.phone_number);
-  return phone || visibleName || (username ? `@${username}` : '') ||
+  return visibleName || (username ? `@${username}` : '') || phone ||
     (isWhatsApp
       ? 'WhatsApp contact'
       : fallback);
 }
 
-/** Secondary identity detail for a People row, without duplicating its title. */
+/** Secondary People identity detail, without duplicating its primary label. */
 export function displayPersonDetails(contact: {
   name?: string | null;
   inferred_name?: string | null;
@@ -93,9 +94,9 @@ export function displayPersonDetails(contact: {
   const username = contact.username?.trim().replace(/^@+/, '') || '';
   const phone = formatPhoneNumber(contact.phone_number);
   const visibleName = name && (!isWhatsAppPlatform(contact.platform) || isUsableWhatsAppName(name)) ? name : '';
-  // The title already uses phone first. Show the useful provider identity
-  // beneath it instead of a generic "add context" prompt.
-  if (phone) return visibleName || (username ? `@${username}` : null);
+  // A full name belongs on the first line. Put its formatted phone beneath it;
+  // otherwise use a public username as the supporting identity.
+  if ((visibleName || username) && phone) return phone;
   if (visibleName && username) return `@${username}`;
   if (visibleName) return null;
   return username ? `@${username}` : null;

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -41,15 +41,16 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const contactsApi = {
-  list({ offset = 0, query, platform, filter }: {
+  list({ offset = 0, limit = 80, query, platform, filter }: {
     offset?: number;
+    limit?: number;
     query: string;
     platform: 'all' | Platform;
     filter: PeopleFilter;
   }) {
     const params = new URLSearchParams({
       offset: String(offset),
-      limit: '80',
+      limit: String(limit),
       platform,
       filter,
     });

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -2,7 +2,7 @@ import { supabase } from './supabase';
 import { API_BASE_URL } from './platforms';
 import type { Platform } from '../types/platform';
 
-export type PeopleFilter = 'all' | 'needs_context' | 'groups';
+export type PeopleFilter = 'all' | 'contacted' | 'needs_context' | 'groups';
 
 export interface PersonContact {
   id: string;

--- a/apps/client/tests/contact-display.test.ts
+++ b/apps/client/tests/contact-display.test.ts
@@ -14,17 +14,28 @@ describe('contact display', () => {
     expect(displayContactName('Lucas', Platform.WHATSAPP, '192204836479059')).toBe('Lucas');
   });
 
-  it('uses a formatted phone number before the profile name or username in People', () => {
+  it('puts a profile name first and a formatted phone below it in People', () => {
+    expect(
+      displayPersonName({
+        platform: Platform.INSTAGRAM,
+        name: 'Lucas',
+        username: 'lucas',
+        phone_number: '+14155552671',
+      })
+    ).toBe('Lucas');
+    expect(
+      displayPersonDetails({ platform: Platform.INSTAGRAM, name: 'Lucas', username: 'lucas', phone_number: '+14155552671' })
+    ).toBe('+1 415 555 2671');
     expect(
       displayPersonName({
         platform: Platform.INSTAGRAM,
         username: 'lucas',
         phone_number: '+14155552671',
       })
-    ).toBe('+1 415 555 2671');
+    ).toBe('@lucas');
     expect(
-      displayPersonDetails({ platform: Platform.INSTAGRAM, name: 'Lucas', username: 'lucas', phone_number: '+14155552671' })
-    ).toBe('Lucas');
+      displayPersonDetails({ platform: Platform.INSTAGRAM, username: 'lucas', phone_number: '+14155552671' })
+    ).toBe('+1 415 555 2671');
   });
 
   it('does not expose an opaque WhatsApp LID in People', () => {

--- a/apps/server/src/routes/contacts.ts
+++ b/apps/server/src/routes/contacts.ts
@@ -13,71 +13,73 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
   if (!userId) return res.status(401).json({ success: false, error: 'Unauthorized' });
 
   try {
-    const limit = Math.min(Math.max(Number.parseInt(String(req.query.limit ?? ''), 10) || 80, 1), 100);
+    // People is an address book as well as a conversation workspace. The
+    // mobile client asks for the bounded full directory so its A–Z index can
+    // jump reliably; keep the server-side cap aligned with the bridge sync.
+    const limit = Math.min(Math.max(Number.parseInt(String(req.query.limit ?? ''), 10) || 80, 1), 10_000);
     const offset = Math.max(Number.parseInt(String(req.query.offset ?? ''), 10) || 0, 0);
     const search = typeof req.query.q === 'string' ? req.query.q.trim() : '';
     const platform = typeof req.query.platform === 'string' ? req.query.platform : 'all';
     const filter = typeof req.query.filter === 'string' ? req.query.filter : 'all';
 
-    // People is a conversation workspace, not a raw bridge directory. Older
-    // mautrix syncs could leave thousands of historical/LID-only directory
-    // records behind with no Claire chat. Showing those records made the list
-    // both slow and impossible to identify. Start from actual conversations,
-    // then load only their linked contacts.
-    let chatQuery = supabase
-      .from('chats')
-      .select('id, contact_id, name, platform, is_group, last_message_at')
-      .eq('user_id', userId)
-      .not('contact_id', 'is', null)
-      .order('last_message_at', { ascending: false, nullsFirst: false });
-    if (platform !== 'all') chatQuery = chatQuery.eq('platform', platform);
-    const { data: linkedChats, error: linkedChatsError } = await chatQuery;
-    if (linkedChatsError) throw linkedChatsError;
+    const contactsQuery = () => {
+      let query = supabase
+        .from('contacts')
+        .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
+        .eq('user_id', userId)
+        .order('name', { ascending: true, nullsFirst: false })
+        .order('id', { ascending: true });
 
+      if (platform !== 'all') query = query.eq('platform', platform);
+      if (filter === 'needs_context') query = query.eq('is_group', false).is('inferred_relationship', null);
+      if (filter === 'groups') query = query.eq('is_group', true);
+      if (search) {
+        // PostgREST's OR grammar treats commas and parentheses as syntax. They
+        // aren't useful for People search, so make them literal-free first.
+        const pattern = `%${search.replace(/[%,()]/g, ' ')}%`;
+        query = query.or(
+          `name.ilike.${pattern},` +
+          `inferred_name.ilike.${pattern},` +
+          `phone_number.ilike.${pattern},` +
+          `username.ilike.${pattern}`,
+        );
+      }
+      return query;
+    };
+
+    // Supabase deployments often cap one PostgREST response at 1,000 rows.
+    // Fetch in internal chunks so a 10k directory still reaches the mobile
+    // A–Z list as one complete, correctly sorted data set.
+    const rows: DbRow[] = [];
+    const desiredRows = limit + 1;
+    for (let pageOffset = offset; rows.length < desiredRows; ) {
+      const chunkSize = Math.min(1_000, desiredRows - rows.length);
+      const { data, error } = await contactsQuery().range(pageOffset, pageOffset + chunkSize - 1);
+      if (error) throw error;
+      const chunk = (data || []) as DbRow[];
+      rows.push(...chunk);
+      if (chunk.length < chunkSize) break;
+      pageOffset += chunk.length;
+    }
+    const page = rows.slice(0, limit);
+    const contactIds = page.map((contact: DbRow) => contact.id as string);
     const chatsByContact = new Map<string, DbRow>();
-    for (const chat of linkedChats || []) {
-      if (chat.contact_id && !chatsByContact.has(chat.contact_id)) {
-        chatsByContact.set(chat.contact_id, chat);
+    if (contactIds.length) {
+      let chatQuery = supabase
+        .from('chats')
+        .select('id, contact_id, name, platform, is_group, last_message_at')
+        .eq('user_id', userId)
+        .in('contact_id', contactIds)
+        .order('last_message_at', { ascending: false, nullsFirst: false });
+      if (platform !== 'all') chatQuery = chatQuery.eq('platform', platform);
+      const { data: linkedChats, error: linkedChatsError } = await chatQuery;
+      if (linkedChatsError) throw linkedChatsError;
+      for (const chat of linkedChats || []) {
+        if (chat.contact_id && !chatsByContact.has(chat.contact_id)) {
+          chatsByContact.set(chat.contact_id, chat);
+        }
       }
     }
-    const linkedContactIds = [...chatsByContact.keys()];
-    if (!linkedContactIds.length) {
-      return res.json({ success: true, data: { contacts: [], nextOffset: null } });
-    }
-
-    let query = supabase
-      .from('contacts')
-      .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
-      .eq('user_id', userId)
-      .in('id', linkedContactIds)
-      .order('name', { ascending: true, nullsFirst: false })
-      .order('id', { ascending: true })
-      .range(offset, offset + limit);
-
-    if (platform !== 'all') query = query.eq('platform', platform);
-    if (filter === 'needs_context') query = query.eq('is_group', false).is('inferred_relationship', null);
-    if (filter === 'groups') query = query.eq('is_group', true);
-    if (search) {
-      // PostgREST's OR grammar treats commas and parentheses as syntax. They
-      // aren't useful for People search, so make them literal-free first.
-      const pattern = `%${search.replace(/[%,()]/g, ' ')}%`;
-      query = query.or(
-        `name.ilike.${pattern},` +
-        `inferred_name.ilike.${pattern},` +
-        `phone_number.ilike.${pattern},` +
-        `username.ilike.${pattern}`,
-      );
-    }
-
-    // Fetch one extra row rather than an exact count. Exact counts become an
-    // unnecessary full-table scan when a user has a large imported address
-    // book, and the UI only needs to know whether another page exists.
-    const { data, error } = await query;
-
-    if (error) throw error;
-
-    const rows = data || [];
-    const page = rows.slice(0, limit);
     return res.json({
       success: true,
       data: {
@@ -101,8 +103,9 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
 /**
  * Start a user-scoped WhatsApp contact identity sync. This is asynchronous on
  * purpose: a large address book must never keep a mobile request open. The
- * People query polls while the deduplicated server task enriches existing
- * contacts, and the task reads no message bodies.
+ * People query polls while the deduplicated server task enriches and imports
+ * the linked account's contact directory, and the task reads no message
+ * bodies.
  */
 router.post('/identity-backfill', requireAuth, async (req: Request, res: Response) => {
   const userId = req.user?.id;
@@ -113,6 +116,7 @@ router.post('/identity-backfill', requireAuth, async (req: Request, res: Respons
       .then((result) => logger.info('WhatsApp contact identity sync completed', {
         scanned: result.scanned,
         matched: result.matched,
+        created: result.created,
         updated: result.updated,
         unresolved: result.unresolved,
         hasMore: result.hasMore,

--- a/apps/server/src/routes/contacts.ts
+++ b/apps/server/src/routes/contacts.ts
@@ -31,6 +31,9 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
         .order('id', { ascending: true });
 
       if (platform !== 'all') query = query.eq('platform', platform);
+      // "Contacted" is maintained by a database trigger, rather than passing
+      // a potentially huge message-derived ID list through a URL query.
+      if (filter === 'contacted') query = query.eq('is_group', false).gt('outbound_message_count', 0);
       if (filter === 'needs_context') query = query.eq('is_group', false).is('inferred_relationship', null);
       if (filter === 'groups') query = query.eq('is_group', true);
       if (search) {

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -9,7 +9,7 @@ import {
   phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
 } from './contact-identity';
-import { whatsappContactKeys } from './whatsapp-contact-backfill';
+import { directoryInsertPayload, whatsappContactKeys } from './whatsapp-contact-backfill';
 
 describe('incoming contact identity', () => {
   test('keeps a direct Mac iMessage phone handle', () => {
@@ -79,5 +79,26 @@ describe('WhatsApp directory identity matching', () => {
     ]));
     expect(whatsappContactKeys('lid-192204836479059')).not.toContain('+192204836479059');
     expect(whatsappContactKeys('192204836479059')).toContain('lid-192204836479059');
+  });
+
+  test('creates a user-scoped directory person from a named LID profile', () => {
+    const payload = directoryInsertPayload('user-1', {
+      id: 'lid-192204836479059',
+      name: 'Ezra',
+      identifiers: ['12409945910@s.whatsapp.net'],
+    });
+    expect(payload).toMatchObject({
+      user_id: 'user-1',
+      platform: Platform.WHATSAPP,
+      platform_contact_id: 'lid-192204836479059',
+      whatsapp_id: 'lid-192204836479059',
+      name: 'Ezra',
+      phone_number: '+12409945910',
+      is_group: false,
+    });
+  });
+
+  test('does not persist a directory entry that has only an opaque LID', () => {
+    expect(directoryInsertPayload('user-1', { id: 'lid-192204836479059' })).toBeNull();
   });
 });

--- a/apps/server/src/services/whatsapp-contact-backfill.ts
+++ b/apps/server/src/services/whatsapp-contact-backfill.ts
@@ -15,6 +15,7 @@ export interface ContactIdentityBackfillResult {
   scanned: number;
   matched: number;
   updated: number;
+  created: number;
   unresolved: number;
   skipped: number;
   hasMore: boolean;
@@ -134,6 +135,34 @@ function bridgeContactForStoredContact(
   return null;
 }
 
+function storedContactIndex(contacts: DbRow[]): Map<string, DbRow> {
+  const index = new Map<string, DbRow>();
+  for (const contact of contacts) {
+    for (const identity of [
+      contact.platform_contact_id as string | null | undefined,
+      contact.whatsapp_id as string | null | undefined,
+    ]) {
+      for (const key of whatsappContactKeys(identity)) {
+        if (!index.has(key)) index.set(key, contact);
+      }
+    }
+  }
+  return index;
+}
+
+function storedContactForBridgeContact(
+  bridgeContact: BridgeContact,
+  contacts: Map<string, DbRow>
+): DbRow | null {
+  for (const identity of [bridgeContact.id, ...(bridgeContact.identifiers || []), bridgeContact.mxid]) {
+    for (const key of whatsappContactKeys(identity)) {
+      const matched = contacts.get(key);
+      if (matched) return matched;
+    }
+  }
+  return null;
+}
+
 function updatePayload(contact: DbRow, bridgeContact: BridgeContact): DbRow | null {
   const platformContactId = String(contact.platform_contact_id || contact.whatsapp_id || '');
   const name = displayNameFromBridge(bridgeContact.name, Platform.WHATSAPP, platformContactId);
@@ -172,14 +201,47 @@ function updatePayload(contact: DbRow, bridgeContact: BridgeContact): DbRow | nu
 }
 
 /**
- * Copy an authenticated WhatsApp account's contact identities into Claire's
- * existing, user-scoped contact records. The bridge request is explicitly
- * scoped by login_id; never use the bridge bot's whole contact directory as a
- * fallback, because that could mix identities between Claire users.
+ * A bridge-directory entry is safe to persist only if it carries a usable
+ * provider name or a direct phone identifier. A raw WhatsApp LID alone is a
+ * routing handle, not an identity people should see in Claire.
+ */
+export function directoryInsertPayload(userId: string, bridgeContact: BridgeContact): DbRow | null {
+  const platformContactId = String(bridgeContact.id || bridgeContact.identifiers?.[0] || '').trim();
+  if (!platformContactId) return null;
+
+  const name = displayNameFromBridge(bridgeContact.name, Platform.WHATSAPP, platformContactId);
+  const phoneNumber = phoneNumberFromBridgeIdentifiers([
+    bridgeContact.id,
+    ...(bridgeContact.identifiers || []),
+  ]);
+  if (!name && !phoneNumber) return null;
+
+  return {
+    user_id: userId,
+    platform: Platform.WHATSAPP,
+    platform_contact_id: platformContactId,
+    // The legacy field is still NOT NULL. Keeping the same authenticated
+    // bridge-owned identifier in both fields preserves its database contract.
+    whatsapp_id: platformContactId,
+    name,
+    phone_number: phoneNumber,
+    avatar_url: typeof bridgeContact.avatar_url === 'string' && bridgeContact.avatar_url.trim()
+      ? bridgeContact.avatar_url
+      : null,
+    is_group: false,
+  };
+}
+
+/**
+ * Copy an authenticated WhatsApp account's contact directory into Claire's
+ * user-scoped contact records. Existing contacts are enriched in place and
+ * contacts that have not yet messaged the user are added as standalone People
+ * entries. The bridge request is explicitly scoped by login_id; never use the
+ * bridge bot's whole contact directory as a fallback, because that could mix
+ * identities between Claire users.
  *
- * A single run is capped at 10k existing contacts and uses paged reads plus
- * batch upserts so it can repair a large People list without touching message
- * content or operational telemetry.
+ * A single run is capped at 10k bridge-directory entries and uses paged reads
+ * plus batch upserts. It touches no message bodies or operational telemetry.
  */
 export async function backfillWhatsAppContactIdentities(
   userId: string,
@@ -196,25 +258,45 @@ export async function backfillWhatsAppContactIdentities(
     loadExistingWhatsAppContacts(userId, limit + 1),
     bridge.getContacts(loginId),
   ]);
-  const targets = rows.slice(0, limit);
-  const bridgeContacts = buildBridgeContactIndex(bridgeDirectory);
-  const updates: DbRow[] = [];
+  const directory = bridgeDirectory.slice(0, limit);
+  const bridgeContacts = buildBridgeContactIndex(directory);
+  const contactsByIdentity = storedContactIndex(rows.slice(0, limit));
+  const upserts: DbRow[] = [];
   let matched = 0;
+  let created = 0;
   let unresolved = 0;
+  const matchedStoredContactIds = new Set<string>();
+  const insertedDirectoryIds = new Set<string>();
 
-  for (const contact of targets) {
+  // First preserve the existing reconciliation behavior for contacts created
+  // from conversations, including old aliases the bridge may no longer emit.
+  for (const contact of rows.slice(0, limit)) {
     const bridgeContact = bridgeContactForStoredContact(contact, bridgeContacts);
-    if (!bridgeContact) {
+    if (!bridgeContact || matchedStoredContactIds.has(String(contact.id))) continue;
+    matchedStoredContactIds.add(String(contact.id));
+    matched++;
+    const payload = updatePayload(contact, bridgeContact);
+    if (payload) upserts.push(payload);
+  }
+
+  // Then add the rest of the authenticated WhatsApp directory. This is what
+  // lets People include someone the user has saved but never messaged.
+  for (const bridgeContact of directory) {
+    if (storedContactForBridgeContact(bridgeContact, contactsByIdentity)) continue;
+    const payload = directoryInsertPayload(userId, bridgeContact);
+    if (!payload) {
       unresolved++;
       continue;
     }
-    matched++;
-    const payload = updatePayload(contact, bridgeContact);
-    if (payload) updates.push(payload);
+    const contactId = String(payload.platform_contact_id);
+    if (insertedDirectoryIds.has(contactId)) continue;
+    insertedDirectoryIds.add(contactId);
+    upserts.push(payload);
+    created++;
   }
 
-  for (let index = 0; index < updates.length; index += WRITE_BATCH_SIZE) {
-    const batch = updates.slice(index, index + WRITE_BATCH_SIZE);
+  for (let index = 0; index < upserts.length; index += WRITE_BATCH_SIZE) {
+    const batch = upserts.slice(index, index + WRITE_BATCH_SIZE);
     const { error } = await supabase
       .from('contacts')
       .upsert(batch, { onConflict: 'user_id,platform,platform_contact_id' });
@@ -222,12 +304,13 @@ export async function backfillWhatsAppContactIdentities(
   }
 
   return {
-    scanned: targets.length,
+    scanned: directory.length,
     matched,
-    updated: updates.length,
+    updated: upserts.length - created,
+    created,
     unresolved,
-    skipped: matched - updates.length,
-    hasMore: rows.length > limit,
+    skipped: matched - (upserts.length - created),
+    hasMore: bridgeDirectory.length > limit,
   };
 }
 

--- a/apps/website/public/mockups/app-mockups.html
+++ b/apps/website/public/mockups/app-mockups.html
@@ -38,6 +38,7 @@
         ><a href="/mockups/mobile/components" target="_top">Components</a
         ><a class="active" href="/mockups/mobile" target="_top">Concepts</a
         ><a href="/mockups/mobile/app" target="_top">App preview</a
+        ><a href="/mockups/people-filters-spec.html" target="_top">People filters</a
         ><a href="/mockups/desktop" target="_top">Desktop</a
         ><a href="/mockups/plugins" target="_top">Plugins</a>
       </nav>

--- a/apps/website/public/mockups/people-filters-spec.html
+++ b/apps/website/public/mockups/people-filters-spec.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Claire — People filters</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <style>
+      :root { --ink:#10120f; --paper:#fffdf8; --cream:#f4f1ea; --line:#dedbd2; --muted:#6d6d67; --lime:#ddff4a; --sky:#b8d9f7; --green:#1fc66a; }
+      * { box-sizing:border-box; }
+      body { margin:0; background:var(--cream); color:var(--ink); font-family:"Public Sans",sans-serif; }
+      .top { max-width:1180px; margin:auto; padding:26px 28px; display:flex; justify-content:space-between; align-items:center; border-bottom:1px solid var(--line); }
+      .brand,.eyebrow,.tag,.mono { font:500 12px "DM Mono",monospace; letter-spacing:.1em; }
+      .brand b { font-family:"Public Sans",sans-serif; letter-spacing:-.04em; font-size:18px; }
+      .tag { border:1px solid var(--ink); border-radius:999px; padding:8px 12px; background:var(--lime); }
+      main { max-width:1180px; margin:auto; padding:54px 28px 90px; }
+      h1 { margin:10px 0 16px; max-width:770px; font-size:clamp(42px,6vw,78px); line-height:.9; letter-spacing:-.075em; }
+      .lede { margin:0; max-width:660px; color:var(--muted); font-size:18px; line-height:1.5; }
+      .hero { display:grid; grid-template-columns:1fr 390px; align-items:start; gap:64px; margin-bottom:76px; }
+      .phone { position:relative; width:390px; height:790px; overflow:hidden; background:var(--paper); border:15px solid var(--ink); border-radius:48px; box-shadow:0 18px 45px rgba(16,18,15,.16); }
+      .island { width:122px; height:32px; background:var(--ink); border-radius:22px; position:absolute; left:50%; transform:translateX(-50%); top:10px; }
+      .status { height:78px; padding:22px 24px 0; display:flex; justify-content:space-between; font-weight:700; font-size:14px; }
+      .phone-body { padding:14px 20px; }
+      .phone-title { display:flex; align-items:flex-start; justify-content:space-between; }
+      .phone-title h2 { font-size:39px; letter-spacing:-.065em; margin:0; }
+      .phone-title p { margin:7px 0 20px; color:var(--muted); font-size:14px; }
+      .filter-trigger,.icon-button { border:1px solid var(--line); background:var(--paper); width:48px; height:48px; border-radius:16px; font-size:22px; cursor:pointer; }
+      .search { background:#f0eee8; border-radius:16px; height:52px; padding:0 16px; display:flex; align-items:center; gap:10px; color:#989891; font-size:15px; }
+      .chips { display:flex; gap:7px; overflow:hidden; padding:16px 0 14px; }
+      .chip { white-space:nowrap; border:1px solid var(--line); border-radius:999px; padding:8px 11px; font-size:12px; font-weight:700; background:var(--paper); }
+      .chip.active { background:var(--ink); color:white; border-color:var(--ink); }
+      .letter { color:var(--muted); font:500 11px "DM Mono",monospace; margin:10px 0 3px; }
+      .person { min-height:70px; display:flex; gap:11px; align-items:center; border-bottom:1px solid var(--line); }
+      .avatar { width:40px; height:40px; border-radius:50%; background:#f3d5e5; display:grid; place-items:center; font-size:12px; font-weight:800; }
+      .person b { display:block; font-size:15px; }.person span { display:block; color:var(--muted); font-size:12px; margin-top:2px; }.platform { color:var(--green)!important; }
+      .index { position:absolute; right:10px; top:275px; display:grid; gap:5px; color:var(--muted); font-weight:800; font-size:10px; text-align:center; }
+      .tabs { position:absolute; left:16px; right:16px; bottom:16px; height:56px; border:1px solid var(--line); background:rgba(255,253,248,.96); border-radius:28px; display:flex; align-items:center; justify-content:space-around; color:#a2a19a; font-size:11px; }
+      .tabs b { background:var(--lime); border:1px solid var(--ink); color:var(--ink); padding:11px; border-radius:16px; }
+      .scrim { display:none; position:absolute; inset:0; background:rgba(16,18,15,.42); z-index:4; }
+      .sheet { position:absolute; z-index:5; left:0; right:0; bottom:-760px; max-height:715px; overflow:auto; background:var(--paper); border-radius:28px 28px 0 0; padding:12px 20px 40px; transition:bottom .26s ease; box-shadow:0 -16px 35px rgba(16,18,15,.16); }
+      .phone.sheet-open .scrim { display:block; }.phone.sheet-open .sheet { bottom:0; }
+      .handle { width:40px; height:4px; background:#c8c5bd; border-radius:4px; margin:0 auto 14px; }.sheet-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:11px; }.sheet-head h3 { margin:0; font-size:20px; letter-spacing:-.04em; }.sheet-head button { border:0; background:none; font-size:22px; cursor:pointer; }
+      .sheet-label { color:var(--muted); margin:16px 0 4px; font:500 10px "DM Mono",monospace; letter-spacing:.1em; }.sheet-copy { color:var(--muted); margin:5px 0 7px; font-size:12px; }
+      .sheet-row { width:100%; min-height:57px; display:flex; align-items:center; gap:9px; border:0; border-top:1px solid var(--line); background:transparent; color:var(--ink); text-align:left; font:inherit; }.sheet-row strong { display:block; font-size:13px; }.sheet-row small { display:block; color:var(--muted); margin-top:2px; font-size:11px; }.check { margin-left:auto; font-size:16px; }.soon { opacity:.58; }.soon em { margin-left:auto; font:500 9px "DM Mono",monospace; letter-spacing:.08em; color:var(--muted); font-style:normal; }
+      .spec-grid { display:grid; grid-template-columns:1fr 1fr; gap:22px; }.block { background:var(--paper); border:1px solid var(--line); padding:24px; border-radius:18px; }.block h2 { font-size:23px; letter-spacing:-.045em; margin:0 0 12px; }.block p,.block li { color:var(--muted); font-size:14px; line-height:1.5; }.block ul { padding-left:18px; margin:10px 0 0; }.block li+li { margin-top:7px; }.flow { display:grid; gap:8px; }.step { border-left:3px solid var(--lime); padding:9px 11px; background:#fbfaf5; }.step b { display:block; font-size:13px; }.step span { color:var(--muted); font-size:12px; }.full { grid-column:1/-1; }.status-now { color:#28804a; }.status-soon { color:#996300; }
+      @media(max-width:820px){ .top{padding:18px}.top .tag{display:none} main{padding:34px 18px 60px}.hero{grid-template-columns:1fr;gap:36px}.phone{margin:auto;width:min(390px,100%)}.spec-grid{grid-template-columns:1fr}.full{grid-column:auto} }
+    </style>
+  </head>
+  <body>
+    <header class="top"><div class="brand"><b>claire</b> / PEOPLE</div><div class="tag">PRODUCT SPEC · DRAFT</div></header>
+    <main>
+      <section class="hero">
+        <div>
+          <div class="eyebrow">PEOPLE DIRECTORY · FILTER SYSTEM</div>
+          <h1>Find the people who need your attention.</h1>
+          <p class="lede">People begins as a private, cross-platform directory. Deterministic filters are available now; Claire&apos;s intelligence filters stay visibly separate until each one has a trustworthy, explainable signal.</p>
+        </div>
+        <div class="phone" id="phone" aria-label="Interactive People filter mockup">
+          <div class="island"></div><div class="status"><span>9:41</span><span>▮◒</span></div>
+          <div class="phone-body"><div class="phone-title"><div><h2>People</h2><p>The people behind your conversations</p></div><button class="filter-trigger" id="open-sheet" aria-label="Open filters">☷</button></div><div class="search">⌕ &nbsp; Search people</div><div class="chips"><span class="chip active">All</span><span class="chip">Contacted</span><span class="chip">Open loops</span></div><div class="letter">A</div><div class="person"><span class="avatar">AC</span><div><b>Amber C Edwards</b><span>+1 945 352 8908</span><span class="platform">◉ WhatsApp</span></div></div><div class="person"><span class="avatar">AM</span><div><b>Amazon México</b><span class="platform">◉ WhatsApp</span></div></div><div class="letter">J</div><div class="person"><span class="avatar">JO</span><div><b>Jare Ola</b><span>+1 313 917 7555</span><span class="platform">◉ WhatsApp</span></div></div></div>
+          <div class="index">A<br>B<br>C<br>D<br>F<br>G<br>J<br>M<br>R<br>S<br>W<br>#</div><div class="tabs"><span>Home</span><span>Inbox</span><b>People</b><span>Promises</span><span>•••</span></div>
+          <div class="scrim" id="close-scrim"></div>
+          <section class="sheet" aria-label="Filter people"><div class="handle"></div><div class="sheet-head"><h3>Filter people</h3><button id="close-sheet" aria-label="Close filters">×</button></div><div class="sheet-label">SHOW NOW</div><button class="sheet-row" type="button"><span><strong>All people</strong><small>Everyone Claire has synced</small></span><span class="check">✓</span></button><button class="sheet-row" type="button"><span><strong>Contacted</strong><small>People you have messaged</small></span></button><button class="sheet-row" type="button"><span><strong>Needs context</strong><small>People without relationship context</small></span></button><button class="sheet-row" type="button"><span><strong>Groups</strong><small>Group conversations</small></span></button><div class="sheet-label">PLATFORM</div><button class="sheet-row" type="button"><span><strong>All platforms</strong><small>WhatsApp, Instagram, Telegram, and more</small></span><span class="check">✓</span></button><div class="sheet-label">CLAIRE INTELLIGENCE</div><p class="sheet-copy">Coming soon — every result will explain why it appears.</p><div class="sheet-row soon"><span><strong>Open loops</strong><small>Unresolved promises, questions, and plans</small></span><em>SOON</em></div><div class="sheet-row soon"><span><strong>Needs reply</strong><small>Conversations waiting on you</small></span><em>SOON</em></div><div class="sheet-row soon"><span><strong>Follow-ups due</strong><small>Commitments and reminders with a next step</small></span><em>SOON</em></div><div class="sheet-row soon"><span><strong>Reconnecting</strong><small>People you have not talked to recently</small></span><em>SOON</em></div><div class="sheet-row soon"><span><strong>Context gaps</strong><small>Important people Claire knows little about</small></span><em>SOON</em></div><div class="sheet-row soon"><span><strong>Important moments</strong><small>Relevant dates and shared context</small></span><em>SOON</em></div></section>
+        </div>
+      </section>
+      <section class="spec-grid">
+        <article class="block"><h2>How the menu works</h2><div class="flow"><div class="step"><b>1. Pick one People state</b><span>All, Contacted, Needs context, or Groups are mutually exclusive.</span></div><div class="step"><b>2. Narrow by platform</b><span>The platform choice composes with the People state.</span></div><div class="step"><b>3. Keep intelligence honest</b><span>Future filters are visible but disabled until their data has a reliable source, a reason, and a resolution state.</span></div></div></article>
+        <article class="block"><h2>Available now</h2><ul><li><b>All people</b> — the linked account&apos;s synced contacts.</li><li><b>Contacted</b> — direct people with at least one message sent by the account owner.</li><li><b>Needs context</b> — non-group people without saved relationship context.</li><li><b>Groups</b> — group conversations.</li><li><b>Platform</b> — the People state above, limited to one network.</li></ul></article>
+        <article class="block"><h2>Open loops: required contract</h2><p>A future open-loop entry must include a type, status, last activity, optional due date, source message reference, and a resolution action. It is not an unread count and it never silently guesses that a relationship is unhealthy.</p><p><span class="status-soon mono">COMING SOON</span> until Claire can produce an explainable result and let the person mark it resolved.</p></article>
+        <article class="block"><h2>Claire-specific follow-ons</h2><ul><li>Cross-network identity linking with confidence and manual correction.</li><li>Relationship preferences for tone, AI context, reminders, and notifications.</li><li>“Who should I talk to?” — an explainable shortlist based on open loops and chosen priorities.</li><li>Private recency and follow-up cues, never opaque relationship scores.</li></ul></article>
+        <article class="block full"><h2>Implementation boundary</h2><p><span class="status-now mono">NOW</span> Contacted is deterministic server-side metadata: a user-scoped contact appears only when there is an outbound direct message linked to that contact. The client receives people and message-presence only—never message text—to render this filter. <span class="status-soon mono">LATER</span> Open loops, Needs reply, Follow-ups due, Reconnecting, Context gaps, and Important moments require their own source-of-truth records, explicit lifecycle states, and user-visible evidence before they become active filters.</p></article>
+      </section>
+    </main>
+    <script>
+      const phone = document.getElementById('phone');
+      const open = document.getElementById('open-sheet');
+      const close = () => phone.classList.remove('sheet-open');
+      open.addEventListener('click', () => phone.classList.add('sheet-open'));
+      document.getElementById('close-sheet').addEventListener('click', close);
+      document.getElementById('close-scrim').addEventListener('click', close);
+    </script>
+  </body>
+</html>

--- a/supabase/migrations/20260820000004_add_contacted_people_filter.sql
+++ b/supabase/migrations/20260820000004_add_contacted_people_filter.sql
@@ -1,0 +1,57 @@
+-- "Contacted" is intentionally deterministic: it includes a person only when
+-- the Claire account owner has sent them at least one direct message. Store a
+-- user-scoped counter on Contacts so People never has to pass thousands of
+-- message-derived UUIDs through the API or read message content.
+ALTER TABLE public.contacts
+  ADD COLUMN IF NOT EXISTS outbound_message_count INTEGER NOT NULL DEFAULT 0;
+
+UPDATE public.contacts AS contact
+SET outbound_message_count = source.count
+FROM (
+  SELECT contact_id, COUNT(*)::INTEGER AS count
+  FROM public.messages
+  WHERE from_me = TRUE AND contact_id IS NOT NULL
+  GROUP BY contact_id
+) AS source
+WHERE contact.id = source.contact_id
+  AND contact.outbound_message_count IS DISTINCT FROM source.count;
+
+CREATE INDEX IF NOT EXISTS idx_contacts_user_outbound_messages
+  ON public.contacts (user_id, name, id)
+  WHERE outbound_message_count > 0 AND is_group = FALSE;
+
+CREATE OR REPLACE FUNCTION public.maintain_contact_outbound_message_count()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND OLD.from_me IS NOT DISTINCT FROM NEW.from_me
+    AND OLD.contact_id IS NOT DISTINCT FROM NEW.contact_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP IN ('UPDATE', 'DELETE') AND OLD.from_me = TRUE AND OLD.contact_id IS NOT NULL THEN
+    UPDATE public.contacts
+    SET outbound_message_count = GREATEST(outbound_message_count - 1, 0)
+    WHERE id = OLD.contact_id AND user_id = OLD.user_id;
+  END IF;
+
+  IF TG_OP IN ('INSERT', 'UPDATE') AND NEW.from_me = TRUE AND NEW.contact_id IS NOT NULL THEN
+    UPDATE public.contacts
+    SET outbound_message_count = outbound_message_count + 1
+    WHERE id = NEW.contact_id AND user_id = NEW.user_id;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS maintain_contact_outbound_message_count ON public.messages;
+CREATE TRIGGER maintain_contact_outbound_message_count
+AFTER INSERT OR UPDATE OF from_me, contact_id OR DELETE ON public.messages
+FOR EACH ROW EXECUTE FUNCTION public.maintain_contact_outbound_message_count();
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

- Adds a scalable People directory with iOS-style A–Z navigation and support for up to 10,000 contacts.
- Shows the most useful identity first: profile name, then a formatted phone number or platform username; keeps opaque WhatsApp LIDs out of customer-facing fields.
- Imports eligible contacts from the authenticated WhatsApp bridge directory, including people without an existing Claire conversation.
- Adds **Contacted** alongside All, Needs context, Groups, and platform filters.
- Adds the full People filter sheet, including clearly labelled future Claire-intelligence filters (Open loops, Needs reply, Follow-ups due, Reconnecting, Context gaps, and Important moments).
- Fixes the native filter sheet so its title and filter rows share one scroll layout and cannot overlap.

## Data / migration

- Adds `contacts.outbound_message_count`, a backfill, index, and trigger so the **Contacted** filter remains accurate as messages are sent.
- Apply `supabase/migrations/20260820000004_add_contacted_people_filter.sql` with this deployment.

## Scope

- WhatsApp is the only connector in this change that currently provides a safe source for a full address-book-style directory.
- Instagram/Telegram people continue to appear as their connectors provide usable profile information or conversations. We do not infer a complete non-DM-directory where the provider does not expose one.

## Privacy

- Contacts remain user- and platform-scoped.
- LID-only WhatsApp identities are not stored as phone numbers or displayed as names.

## Verification

- `bun --filter @claire/server test -- services/contact-identity.test.ts`
- `bun --filter @claire/server typecheck`
- `bun --filter @claire/client typecheck`
- iOS Simulator: verified the A–Z People directory and alphabet jump rail.

