### PR TITLE
Add Open loops spec, per-chat mute, and search/loops fixes

### DIFF
--- a/apps/client/app/chat/settings/[chatId].tsx
+++ b/apps/client/app/chat/settings/[chatId].tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, router } from 'expo-router';
-import { Check, ChevronLeft, Mail, MapPin, Phone, RefreshCw, Sparkles } from 'lucide-react-native';
+import { BellOff, Check, ChevronLeft, Mail, MapPin, Phone, RefreshCw, Sparkles } from 'lucide-react-native';
 import { colors, mobileType, radius, space } from '@claire/design-system';
 import { useAuthStore } from '../../../stores/authStore';
 import { useConversationSettingsStore } from '../../../stores/conversationSettingsStore';
@@ -14,6 +14,7 @@ import { Platform } from '../../../types/platform';
 import type { ChatCategory } from '../../../types/conversationSettings';
 import { formatPhoneNumber, formatPhoneNumberInput, normalizePhoneNumber } from '../../../services/phone-numbers';
 import { displayContactName } from '../../../services/contact-display';
+import { API_BASE_URL } from '../../../services/platforms';
 
 const TONES = [
   { key: 'warm', title: 'Warm + direct', description: 'Clear, human, confident' },
@@ -43,6 +44,7 @@ function Field({ icon, label, value, onChangeText, placeholder, keyboardType = '
 export default function ConversationSettingsScreen() {
   const { chatId, platform, contact_name, chat_name, is_group } = useLocalSearchParams<{ chatId: string; platform?: string; contact_name?: string; chat_name?: string; is_group?: string }>();
   const user = useAuthStore((state) => state.user);
+  const accessToken = useAuthStore((state) => state.token);
   const insets = useSafeAreaInsets();
   const { settings, fetchSettings, setCategory, updateProfile, refreshInsights } = useConversationSettingsStore();
   const chatSettings = settings[chatId];
@@ -53,6 +55,8 @@ export default function ConversationSettingsScreen() {
   const [instruction, setInstruction] = useState('');
   const [tone, setTone] = useState<ToneKey | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [isSavingMute, setIsSavingMute] = useState(false);
   const displayName =
     is_group === '1'
       ? chat_name || contact_name || 'Group'
@@ -67,7 +71,8 @@ export default function ConversationSettingsScreen() {
       // Contacts own the canonical phone number. A Matrix sender identifier can
       // instead be a WhatsApp LID, so only fall back to message metadata when
       // the contact record has not been populated yet.
-      const { data: chat } = await supabase.from('chats').select('contact_id').eq('id', chatId).maybeSingle();
+      const { data: chat } = await supabase.from('chats').select('contact_id,is_muted').eq('id', chatId).maybeSingle();
+      if (active) setIsMuted(chat?.is_muted === true);
       let phone = '';
       if (chat?.contact_id) {
         const { data: contact } = await supabase.from('contacts').select('phone_number').eq('id', chat.contact_id).maybeSingle();
@@ -96,6 +101,25 @@ export default function ConversationSettingsScreen() {
   }, [details.email, details.phone, platform, sourcePhone]);
 
   const handleCategorySelect = (category: ChatCategory) => { if (user?.id) void setCategory(chatId, user.id, category); };
+  const updateMute = async (muted: boolean) => {
+    if (!accessToken || isSavingMute) return;
+    const previous = isMuted;
+    setIsMuted(muted);
+    setIsSavingMute(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/messages/chats/${encodeURIComponent(chatId)}/mute`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ muted }),
+      });
+      if (!response.ok) throw new Error(`Mute update failed (${response.status})`);
+    } catch (error) {
+      setIsMuted(previous);
+      Alert.alert('Could not update notifications', 'Please check your connection and try again.');
+    } finally {
+      setIsSavingMute(false);
+    }
+  };
   const selectTone = (nextTone: ToneKey) => {
     setTone(nextTone);
     if (!instruction.trim()) {
@@ -124,11 +148,19 @@ export default function ConversationSettingsScreen() {
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.cream }} edges={['top']}>
       <View style={{ minHeight: 64, paddingHorizontal: space[4], flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: colors.neutral[200] }}>
         <MobileIconButton label="Back to chat" onPress={() => router.back()}><ChevronLeft size={21} color={colors.ink} /></MobileIconButton>
-        <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, flex: 1, paddingHorizontal: space[3], color: colors.ink }}>Relationship memory</Text>
-        <View style={{ width: 40 }} />
+        <View style={{ flex: 1 }} />
       </View>
       {isLoading && !chatSettings ? <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}><ActivityIndicator size="large" color={colors.ink} /></View> : (
         <ScrollView contentContainerStyle={{ padding: space[4], paddingBottom: 132 + insets.bottom, gap: space[5] }} keyboardShouldPersistTaps="handled">
+          <View style={{ gap: space[2] }}>
+            <SectionLabel title="Chat settings" />
+            <View testID="conversation-notification-settings" style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingHorizontal: space[3], borderRadius: radius.card, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}>
+              <View style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center', borderRadius: radius.control, backgroundColor: isMuted ? colors.neutral[100] : colors.sky }}><BellOff size={19} color={colors.ink} /></View>
+              <View style={{ flex: 1, gap: 2 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>Mute notifications</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{isMuted ? 'Notifications are muted for this chat.' : `Receive alerts for this ${is_group === '1' ? 'group' : 'conversation'}.`}</Text></View>
+              <Switch testID="conversation-mute-notifications" accessibilityLabel={`Mute notifications for ${displayName}`} value={isMuted} disabled={isSavingMute || !accessToken} onValueChange={(value) => void updateMute(value)} trackColor={{ false: colors.neutral[200], true: colors.ink }} thumbColor={isMuted ? colors.lime : colors.paper} />
+            </View>
+          </View>
+
           <View style={{ alignItems: 'center', gap: space[2], paddingVertical: space[2] }}>
             <MobileAvatar name={displayName} size={72} isGroup={is_group === '1'} />
             <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, color: colors.ink }}>{displayName}</Text>

--- a/apps/client/components/claire/skeleton.tsx
+++ b/apps/client/components/claire/skeleton.tsx
@@ -173,6 +173,24 @@ export function ChatSkeleton({ testID }: { testID?: string }) {
   );
 }
 
+export function SearchResultsSkeleton() {
+  return (
+    <View style={{ paddingHorizontal: space[4] }}>
+      <Bone width={110} height={10} style={{ marginBottom: space[3] }} />
+      {Array.from({ length: 6 }, (_, index) => (
+        <View key={index} style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[4] }}>
+          <Bone width={40} height={40} radius={13} delay={index * 70} />
+          <View style={{ flex: 1, gap: 8 }}>
+            <Bone width="64%" height={14} delay={index * 70 + 30} />
+            <Bone width="84%" height={11} delay={index * 70 + 70} />
+          </View>
+          <Bone width={44} height={10} delay={index * 70 + 50} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
 export function PeopleSkeleton() {
   return (
     <View>

--- a/apps/client/features/loops/loops-screen.tsx
+++ b/apps/client/features/loops/loops-screen.tsx
@@ -56,6 +56,10 @@ export function LoopsScreen() {
   const [filter, setFilter] = useState<LoopFilter>('open');
   const [showCreate, setShowCreate] = useState(false);
   const [newLoop, setNewLoop] = useState('');
+  // Pressable's ({ pressed }) => style callback is dropped by NativeWind's
+  // react-native-css-interop wrapper, so the button renders with no style at
+  // all. Track pressed state manually instead. See CLAUDE.md "Mobile gotchas".
+  const [addLoopPressed, setAddLoopPressed] = useState(false);
   const query = useQuery({ queryKey: ['mobile-loops', user?.id], enabled: !!user?.id, queryFn: () => request<LoopItem[]>('/loops?limit=200'), staleTime: 60_000 });
   const patch = useMutation({
     mutationFn: ({ id, status }: { id: string; status: LoopItem['status'] }) => request<LoopItem>(`/loops/${id}`, { method: 'PATCH', body: JSON.stringify({ status }) }),
@@ -137,7 +141,22 @@ export function LoopsScreen() {
             <View style={{ flexDirection: 'row', alignItems: 'center' }}><Text style={{ ...mobileType.sectionTitle, flex: 1, color: colors.ink }}>Add a loop</Text><MobileIconButton label="Close" onPress={() => setShowCreate(false)}><X size={19} color={colors.ink} /></MobileIconButton></View>
             <TextInput autoFocus multiline value={newLoop} onChangeText={setNewLoop} placeholder="What do you want to remember?" placeholderTextColor={colors.neutral[400]} style={{ minHeight: 110, textAlignVertical: 'top', padding: space[4], borderRadius: radius.card, borderWidth: 1, borderColor: colors.neutral[200], backgroundColor: colors.cream, ...mobileType.body, color: colors.ink }} />
             {create.error ? <Text selectable style={{ ...mobileType.bodySmall, color: colors.danger }}>{create.error.message}</Text> : null}
-            <Pressable disabled={!newLoop.trim() || create.isPending} onPress={() => create.mutate(newLoop.trim())} style={({ pressed }) => ({ minHeight: 50, borderRadius: radius.control, backgroundColor: colors.ink, alignItems: 'center', justifyContent: 'center', opacity: !newLoop.trim() || create.isPending ? 0.42 : pressed ? 0.78 : 1 })}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.paper }}>{create.isPending ? 'Adding…' : 'Add loop'}</Text></Pressable>
+            <Pressable
+              disabled={!newLoop.trim() || create.isPending}
+              onPress={() => create.mutate(newLoop.trim())}
+              onPressIn={() => setAddLoopPressed(true)}
+              onPressOut={() => setAddLoopPressed(false)}
+              style={{
+                minHeight: 50,
+                borderRadius: radius.control,
+                backgroundColor: colors.ink,
+                alignItems: 'center',
+                justifyContent: 'center',
+                opacity: !newLoop.trim() || create.isPending ? 0.42 : addLoopPressed ? 0.78 : 1,
+              }}
+            >
+              <Text style={{ ...mobileType.body, fontWeight: '700', color: colors.paper }}>{create.isPending ? 'Adding…' : 'Add loop'}</Text>
+            </Pressable>
           </View>
         </View>
       </Modal>

--- a/apps/client/features/search/search-screen.tsx
+++ b/apps/client/features/search/search-screen.tsx
@@ -6,8 +6,95 @@ import { router } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { colors, mobileType, radius, space } from '@claire/design-system';
 import { MobileChip, MobileHeader, MobileSearchField, MobileState, SectionLabel } from '../../components/mobile/claire-mobile';
+import { PlatformBadge } from '../../components/PlatformIcon';
+import { SearchResultsSkeleton } from '../../components/claire/skeleton';
 import { useAuthStore } from '../../stores/authStore';
 import { searchApi, type SearchScope } from '../../services/search';
+import type { AssistantCitation } from '../../services/conversationAssistant';
+import { resolvePlatform } from '../../types/platform';
+
+const KIND_TINT: Record<string, string> = { message: colors.sky, person: colors.blush, loop: colors.lime, file: colors.lavender };
+
+function ResultIcon({ kind, platform }: { kind: 'message' | 'person' | 'loop' | 'file'; platform?: string | null }) {
+  const resolved = resolvePlatform(platform);
+  return (
+    <View style={{ width: 40, height: 40 }}>
+      <View style={{ width: 40, height: 40, borderRadius: 13, backgroundColor: KIND_TINT[kind], alignItems: 'center', justifyContent: 'center' }}>
+        {kind === 'message' ? <MessageCircle size={18} color={colors.ink} /> : kind === 'person' ? <UserRound size={18} color={colors.ink} /> : kind === 'loop' ? <CheckCircle2 size={18} color={colors.ink} /> : <FileText size={18} color={colors.ink} />}
+      </View>
+      {resolved ? (
+        <View style={{ position: 'absolute', right: -3, bottom: -3, padding: 1, borderRadius: 11, borderWidth: 2, borderColor: colors.cream, backgroundColor: colors.paper }}>
+          <PlatformBadge platform={resolved} size={16} />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function CitationCard({ citation, onPress }: { citation: AssistantCitation; onPress: () => void }) {
+  const [pressed, setPressed] = useState(false);
+  const resolved = resolvePlatform(citation.platform);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      style={{ padding: space[3], borderRadius: radius.control, borderWidth: 1, borderColor: colors.neutral[200], backgroundColor: colors.paper, opacity: pressed ? 0.68 : 1 }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}>
+        {resolved ? <PlatformBadge platform={resolved} size={14} /> : null}
+        <Text numberOfLines={1} style={{ ...mobileType.label, color: colors.ink, flexShrink: 1 }}>{citation.chatName || citation.senderName}</Text>
+      </View>
+      <Text numberOfLines={2} style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginTop: 4 }}>{citation.excerpt}</Text>
+    </Pressable>
+  );
+}
+
+type SearchResultItem = {
+  kind: 'message' | 'person' | 'loop' | 'file';
+  id: string;
+  title: string;
+  subtitle?: string;
+  platform?: string | null;
+  meta?: string;
+  onPress: () => void;
+};
+
+function RecentSearchRow({ term, onPress, onRemove }: { term: string; onPress: () => void; onRemove: () => void }) {
+  const [pressed, setPressed] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      style={{ minHeight: 48, flexDirection: 'row', alignItems: 'center', gap: space[3], borderBottomWidth: 1, borderBottomColor: colors.neutral[200], opacity: pressed ? 0.64 : 1 }}
+    >
+      <Clock3 size={17} color={colors.neutral[600]} />
+      <Text numberOfLines={1} style={{ ...mobileType.body, flex: 1, color: colors.ink }}>{term}</Text>
+      <Pressable accessibilityLabel={`Remove ${term}`} onPress={onRemove} style={{ width: 44, height: 44, alignItems: 'center', justifyContent: 'center' }}><X size={16} color={colors.neutral[400]} /></Pressable>
+    </Pressable>
+  );
+}
+
+function SearchResultRow({ item }: { item: SearchResultItem }) {
+  const [pressed, setPressed] = useState(false);
+  return (
+    <Pressable
+      testID={`search-result-${item.kind}-${item.id}`}
+      onPress={item.onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[4], opacity: pressed ? 0.65 : 1 }}
+    >
+      <ResultIcon kind={item.kind} platform={item.platform} />
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text selectable numberOfLines={1} style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{item.title}</Text>
+        {item.subtitle ? <Text selectable numberOfLines={2} style={{ ...mobileType.bodySmall, color: colors.neutral[600], marginTop: 2 }}>{item.subtitle}</Text> : null}
+      </View>
+      {item.meta ? <Text style={{ ...mobileType.monoLabel, color: colors.neutral[400], maxWidth: 76 }} numberOfLines={2}>{item.meta}</Text> : null}
+    </Pressable>
+  );
+}
 
 const scopes: Array<{ value: SearchScope; label: string }> = [
   { value: 'everything', label: 'Everything' }, { value: 'messages', label: 'Messages' }, { value: 'people', label: 'People' }, { value: 'files', label: 'Files' }, { value: 'loops', label: 'Loops' },
@@ -37,10 +124,10 @@ export function SearchScreen() {
   const rows = useMemo(() => {
     if (!exact.data) return [];
     return [
-      ...exact.data.messages.map(item => ({ kind: 'message' as const, id: item.id, title: item.chat?.name || item.contact?.name || item.contact?.inferred_name || item.contact_name || 'Conversation', subtitle: item.content, meta: `${item.platform || 'message'} · ${new Date(item.timestamp).toLocaleDateString()}`, onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', contact_name: item.contact_name || '', platform: item.platform || '', is_group: item.chat?.is_group ? '1' : '0', highlightMessageId: item.id } }) })),
-      ...exact.data.people.map(item => ({ kind: 'person' as const, id: item.id, title: item.name || item.inferred_name || item.phone_number || 'Contact', subtitle: item.phone_number || 'Known contact', meta: item.platform || 'person', onPress: () => router.push({ pathname: '/(tabs)/contacts', params: { query: item.name || item.inferred_name || item.phone_number || '' } }) })),
-      ...exact.data.loops.map(item => ({ kind: 'loop' as const, id: item.id, title: item.content, subtitle: item.chat?.name || 'Personal reminder', meta: item.deadline ? new Date(item.deadline).toLocaleDateString() : item.status, onPress: () => item.chat_id ? router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', platform: item.chat?.platform || '', is_group: item.chat?.is_group ? '1' : '0' } }) : router.push('/(tabs)/loops') })),
-      ...exact.data.files.map(item => ({ kind: 'file' as const, id: item.id, title: item.content || item.content_type || 'Attachment', subtitle: item.chat?.name || item.contact_name || 'Conversation', meta: item.media_mime_type || item.platform || 'file', onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', contact_name: item.contact_name || '', platform: item.platform || '', is_group: item.chat?.is_group ? '1' : '0', highlightMessageId: item.id } }) })),
+      ...exact.data.messages.map(item => ({ kind: 'message' as const, id: item.id, title: item.chat?.name || item.contact?.name || item.contact?.inferred_name || item.contact_name || 'Conversation', subtitle: item.content, platform: item.platform, meta: new Date(item.timestamp).toLocaleDateString(), onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', contact_name: item.contact_name || '', platform: item.platform || '', is_group: item.chat?.is_group ? '1' : '0', highlightMessageId: item.id } }) })),
+      ...exact.data.people.map(item => ({ kind: 'person' as const, id: item.id, title: item.name || item.inferred_name || item.phone_number || 'Contact', subtitle: item.phone_number || 'Known contact', platform: item.platform, meta: undefined as string | undefined, onPress: () => router.push({ pathname: '/(tabs)/contacts', params: { query: item.name || item.inferred_name || item.phone_number || '' } }) })),
+      ...exact.data.loops.map(item => ({ kind: 'loop' as const, id: item.id, title: item.content, subtitle: item.chat?.name || 'Personal reminder', platform: item.chat?.platform, meta: item.deadline ? new Date(item.deadline).toLocaleDateString() : item.status, onPress: () => item.chat_id ? router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', platform: item.chat?.platform || '', is_group: item.chat?.is_group ? '1' : '0' } }) : router.push('/(tabs)/loops') })),
+      ...exact.data.files.map(item => ({ kind: 'file' as const, id: item.id, title: item.content || item.content_type || 'Attachment', subtitle: item.chat?.name || item.contact_name || 'Conversation', platform: item.platform, meta: item.media_mime_type || undefined, onPress: () => router.push({ pathname: '/chat/[chatId]', params: { chatId: item.chat_id, chat_name: item.chat?.name || '', contact_name: item.contact_name || '', platform: item.platform || '', is_group: item.chat?.is_group ? '1' : '0', highlightMessageId: item.id } }) })),
     ];
   }, [exact.data]);
 
@@ -48,30 +135,29 @@ export function SearchScreen() {
     return (
       <View testID="search-results-screen" style={{ flex: 1, backgroundColor: colors.cream }}>
         <MobileHeader title="Search" subtitle={`${resultCount} result${resultCount === 1 ? '' : 's'} for “${submitted}”`} actions={<Pressable accessibilityRole="button" accessibilityLabel="Clear search" onPress={() => { setSubmitted(''); setQuery(''); }} style={{ width: 44, height: 44, alignItems: 'center', justifyContent: 'center' }}><X size={21} color={colors.ink} /></Pressable>} />
+        {exact.isLoading ? <SearchResultsSkeleton /> : (
         <FlatList
           data={rows}
           keyExtractor={item => `${item.kind}-${item.id}`}
           contentInsetAdjustmentBehavior="automatic"
-          contentContainerStyle={{ paddingHorizontal: space[4], paddingBottom: 112, gap: space[2] }}
-          ListHeaderComponent={<View style={{ gap: space[4], paddingBottom: space[3] }}>
+          contentContainerStyle={{ paddingHorizontal: space[4], paddingBottom: 112 }}
+          ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.neutral[200] }} />}
+          ListHeaderComponent={<View style={{ gap: space[4], paddingBottom: space[4] }}>
             {semantic.isLoading ? <View style={{ minHeight: 100, borderRadius: radius.card, backgroundColor: colors.lavender, alignItems: 'center', justifyContent: 'center' }}><ActivityIndicator color={colors.ink} /></View> : semantic.data ? (
-              <View style={{ padding: space[4], gap: space[2], borderRadius: radius.card, borderCurve: 'continuous', borderWidth: 1, borderColor: colors.ink, backgroundColor: colors.lavender }}>
+              <View style={{ padding: space[4], gap: space[3], borderRadius: radius.card, borderCurve: 'continuous', borderWidth: 1, borderColor: colors.ink, backgroundColor: colors.lavender }}>
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}><Sparkles size={17} color={colors.ink} /><Text style={{ ...mobileType.monoLabel, color: colors.ink }}>CLAIRE'S ANSWER</Text></View>
                 <Text selectable style={{ ...mobileType.body, color: colors.ink }}>{semantic.data.answer}</Text>
                 <Text style={{ ...mobileType.label, color: colors.neutral[600] }}>{semantic.data.citations.length} source message{semantic.data.citations.length === 1 ? '' : 's'}</Text>
-                <View style={{ gap: space[2] }}>{semantic.data.citations.slice(0, 3).map(citation => <Pressable key={citation.messageId} onPress={() => router.push({ pathname: '/chat/[chatId]', params: { chatId: citation.chatId, chat_name: citation.chatName || '', platform: citation.platform, is_group: citation.isGroup ? '1' : '0', highlightMessageId: citation.messageId } })} style={({ pressed }) => ({ padding: space[3], borderRadius: radius.control, backgroundColor: colors.paper, opacity: pressed ? 0.68 : 1 })}><Text style={{ ...mobileType.label, color: colors.ink }}>{citation.chatName || citation.senderName} · {citation.platform}</Text><Text numberOfLines={2} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{citation.excerpt}</Text></Pressable>)}</View>
+                <View style={{ gap: space[3] }}>{semantic.data.citations.slice(0, 3).map(citation => <CitationCard key={citation.messageId} citation={citation} onPress={() => router.push({ pathname: '/chat/[chatId]', params: { chatId: citation.chatId, chat_name: citation.chatName || '', platform: citation.platform, is_group: citation.isGroup ? '1' : '0', highlightMessageId: citation.messageId } })} />)}</View>
                 <Pressable onPress={() => router.push('/assistant')} style={{ minHeight: 42, alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: space[2] }}><Brain size={16} color={colors.ink} /><Text style={{ ...mobileType.label, color: colors.ink }}>Continue with Ask Claire</Text></Pressable>
               </View>
             ) : null}
             <SectionLabel title="Best matches" detail={`${resultCount}`} />
           </View>}
-          renderItem={({ item }) => <Pressable testID={`search-result-${item.kind}-${item.id}`} onPress={item.onPress} style={({ pressed }) => ({ minHeight: 70, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[3], borderBottomWidth: 1, borderBottomColor: colors.neutral[200], opacity: pressed ? 0.65 : 1 })}>
-            <View style={{ width: 38, height: 38, borderRadius: 12, backgroundColor: item.kind === 'message' ? colors.sky : item.kind === 'person' ? colors.blush : item.kind === 'loop' ? colors.lime : colors.lavender, alignItems: 'center', justifyContent: 'center' }}>{item.kind === 'message' ? <MessageCircle size={18} color={colors.ink} /> : item.kind === 'person' ? <UserRound size={18} color={colors.ink} /> : item.kind === 'loop' ? <CheckCircle2 size={18} color={colors.ink} /> : <FileText size={18} color={colors.ink} />}</View>
-            <View style={{ flex: 1, minWidth: 0 }}><Text selectable numberOfLines={1} style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{item.title}</Text><Text selectable numberOfLines={2} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{item.subtitle}</Text></View>
-            <Text style={{ ...mobileType.monoLabel, color: colors.neutral[400], maxWidth: 76 }} numberOfLines={2}>{item.meta}</Text>
-          </Pressable>}
-          ListEmptyComponent={exact.isLoading ? <ActivityIndicator color={colors.ink} /> : <MobileState error={!!exact.error} title={exact.error ? 'Search is unavailable' : 'No matches'} message={exact.error ? exact.error.message : 'Try a different phrase or search Everything for a semantic answer.'} />}
+          renderItem={({ item }) => <SearchResultRow item={item} />}
+          ListEmptyComponent={<MobileState error={!!exact.error} title={exact.error ? 'Search is unavailable' : 'No matches'} message={exact.error ? exact.error.message : 'Try a different phrase or search Everything for a semantic answer.'} />}
         />
+        )}
       </View>
     );
   }
@@ -82,7 +168,7 @@ export function SearchScreen() {
       <View style={{ paddingHorizontal: space[4], gap: space[4] }}>
         <MobileSearchField icon={<Search size={20} color={colors.ink} />} value={query} onChangeText={setQuery} onSubmitEditing={runSearch} placeholder="Messages, people, loops…" returnKeyType="search" style={{ minHeight: 52, backgroundColor: colors.paper, borderWidth: 2, borderColor: colors.ink }} testID="global-search-input" />
         <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: space[2] }}>{scopes.map(item => <MobileChip key={item.value} label={item.label} active={scope === item.value} onPress={() => setScope(item.value)} />)}</ScrollView>
-        {recent.length ? <><SectionLabel title="Recent searches" detail="Clear" />{recent.map(item => <Pressable key={item} onPress={() => { setQuery(item); setSubmitted(item); }} style={({ pressed }) => ({ minHeight: 48, flexDirection: 'row', alignItems: 'center', gap: space[3], borderBottomWidth: 1, borderBottomColor: colors.neutral[200], opacity: pressed ? 0.64 : 1 })}><Clock3 size={17} color={colors.neutral[600]} /><Text numberOfLines={1} style={{ ...mobileType.body, flex: 1, color: colors.ink }}>{item}</Text><Pressable accessibilityLabel={`Remove ${item}`} onPress={() => { const next = recent.filter(value => value !== item); setRecent(next); void AsyncStorage.setItem(storageKey, JSON.stringify(next)); }} style={{ width: 44, height: 44, alignItems: 'center', justifyContent: 'center' }}><X size={16} color={colors.neutral[400]} /></Pressable></Pressable>)}</> : null}
+        {recent.length ? <><SectionLabel title="Recent searches" detail="Clear" />{recent.map(item => <RecentSearchRow key={item} term={item} onPress={() => { setQuery(item); setSubmitted(item); }} onRemove={() => { const next = recent.filter(value => value !== item); setRecent(next); void AsyncStorage.setItem(storageKey, JSON.stringify(next)); }} />)}</> : null}
         <View style={{ padding: space[4], gap: space[2], borderRadius: radius.card, backgroundColor: colors.lavender }}><Sparkles size={21} color={colors.ink} /><Text style={{ ...mobileType.sectionTitle, color: colors.ink }}>Ask naturally.</Text><Text selectable style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>Try “Who recommended the Oaxaca hotel?” or “What did Maya say about launch timing?”</Text></View>
       </View>
     </ScrollView>

--- a/apps/server/src/routes/desktop-sync.ts
+++ b/apps/server/src/routes/desktop-sync.ts
@@ -23,7 +23,7 @@ router.get('/bootstrap', requireAuth, async (req: Request, res: Response) => {
     const userId = req.user?.id as string;
     const [chatsResult, loopsResult, preferencesResult, cursorResult] = await Promise.all([
       supabase.from('chats').select('*, contact:contacts(*)').eq('user_id', userId).order('last_message_at', { ascending: false, nullsFirst: false }),
-      supabase.from('loops').select('*, contact:contacts(*), chat:chats(*)').eq('user_id', userId).in('status', ['open', 'waiting', 'snoozed']).order('updated_at', { ascending: false }).limit(200),
+      supabase.from('loops').select('*, contact:contacts!loops_contact_id_fkey(*), chat:chats!loops_chat_id_fkey(*)').eq('user_id', userId).in('status', ['open', 'waiting', 'snoozed']).order('updated_at', { ascending: false }).limit(200),
       supabase.from('user_preferences').select('*').eq('user_id', userId).maybeSingle(),
       supabase.from('desktop_sync_events').select('cursor').eq('user_id', userId).order('cursor', { ascending: false }).limit(1).maybeSingle(),
     ]);

--- a/apps/server/src/routes/loops.ts
+++ b/apps/server/src/routes/loops.ts
@@ -180,7 +180,18 @@ router.get(
 
       const { status, platform, contact_id, limit, offset } = req.query as any;
 
-      let query = supabase
+      // Count and data are fetched as two separate requests, not combined via
+      // { count: 'exact' } on the embedded select below. Combining them on this
+      // query (large multi-table embed + count + range) was observed in
+      // production to return the correct count but an empty data array, with
+      // no error surfaced — reproducible only on the long-running server
+      // process, never on a fresh one-shot request. Splitting sidesteps it.
+      let countQuery = supabase
+        .from('loops')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId);
+
+      let dataQuery = supabase
         .from('loops')
         .select(`
           *,
@@ -189,18 +200,21 @@ router.get(
             name, is_group, platform,
             contact:contacts!chats_contact_id_fkey(name, inferred_name, avatar_url)
           )
-        `, { count: 'exact' })
+        `)
         .eq('user_id', userId)
         .order('created_at', { ascending: false });
 
-      if (status) query = query.eq('status', status);
-      if (platform) query = query.eq('platform', platform);
-      if (contact_id) query = query.eq('contact_id', contact_id);
+      if (status) { countQuery = countQuery.eq('status', status); dataQuery = dataQuery.eq('status', status); }
+      if (platform) { countQuery = countQuery.eq('platform', platform); dataQuery = dataQuery.eq('platform', platform); }
+      if (contact_id) { countQuery = countQuery.eq('contact_id', contact_id); dataQuery = dataQuery.eq('contact_id', contact_id); }
 
-      const { data, error, count } = await query.range(offset, offset + limit - 1);
+      const [{ count, error: countError }, { data, error }] = await Promise.all([
+        countQuery,
+        dataQuery.range(offset, offset + limit - 1),
+      ]);
 
-      if (error) {
-        logger.error('Error listing loops:', error);
+      if (error || countError) {
+        logger.error('Error listing loops:', error || countError);
         return res.status(500).json({ success: false, error: 'Failed to fetch loops' });
       }
 

--- a/apps/server/src/routes/messages.ts
+++ b/apps/server/src/routes/messages.ts
@@ -497,6 +497,25 @@ router.patch('/chats/:chatId/pin', requireAuth, async (req: Request, res: Respon
   }
 });
 
+/** Muting is Claire-local notification state and applies to every device. */
+router.patch('/chats/:chatId/mute', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id as string;
+    const muted = req.body?.muted;
+    if (typeof muted !== 'boolean') return res.status(400).json({ error: 'muted must be a boolean' });
+    const { data, error } = await supabase.from('chats')
+      .update({ is_muted: muted })
+      .eq('id', req.params.chatId).eq('user_id', userId)
+      .select('id,is_muted').maybeSingle();
+    if (error) throw error;
+    if (!data) return res.status(404).json({ error: 'Chat not found' });
+    return res.json({ success: true, chat: data });
+  } catch (error) {
+    logger.error('Failed to update chat mute state:', error);
+    return res.status(500).json({ error: 'Failed to update chat mute state' });
+  }
+});
+
 /**
  * POST /messages/typing
  * Send typing indicator

--- a/apps/server/src/services/notification-delivery.test.ts
+++ b/apps/server/src/services/notification-delivery.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'bun:test';
-import { isInQuietHours } from './notification-delivery';
+import { isInQuietHours, shouldNotifyConversation } from './notification-delivery';
 import { ExpoNotificationProvider } from './notification-providers';
 
 describe('notification eligibility', () => {
+  it('blocks a muted conversation while leaving unmuted conversations eligible', () => {
+    expect(shouldNotifyConversation(true, { notify_messages: true }, true)).toBe(false);
+    expect(shouldNotifyConversation(true, { notify_messages: true }, false)).toBe(true);
+    expect(shouldNotifyConversation(true, { notify_messages: true }, null)).toBe(true);
+  });
+
   it('handles quiet hours that cross midnight in the device timezone', () => {
     const options = { quiet_hours_enabled: true, quiet_hours_start: '22:00', quiet_hours_end: '08:00' };
     expect(isInQuietHours(options, 'UTC', new Date('2026-08-15T23:00:00Z'))).toBe(true);

--- a/apps/server/src/services/notification-delivery.ts
+++ b/apps/server/src/services/notification-delivery.ts
@@ -51,6 +51,10 @@ interface NotificationOptions {
   quiet_hours_end?: string;
 }
 
+export function shouldNotifyConversation(notificationEnabled: boolean | null | undefined, options: NotificationOptions, isMuted: boolean | null | undefined): boolean {
+  return notificationEnabled !== false && options.notify_messages !== false && isMuted !== true;
+}
+
 function minutesAtTimezone(date: Date, timezone: string): number {
   try {
     const parts = new Intl.DateTimeFormat('en-GB', { timeZone: timezone, hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }).formatToParts(date);
@@ -95,14 +99,16 @@ export class NotificationDeliveryService {
 
   async enqueueIncomingMessage(event: IncomingNotificationEvent): Promise<number> {
     this.start();
-    const [{ data: preferences, error: preferenceError }, { data: devices, error: deviceError }] = await Promise.all([
+    const [{ data: preferences, error: preferenceError }, { data: devices, error: deviceError }, { data: chat, error: chatError }] = await Promise.all([
       supabase.from('user_preferences').select('notification_enabled,preferences').eq('user_id', event.userId).maybeSingle(),
       supabase.from('notification_devices').select('id,user_id,device_id,platform,provider,token,enabled,timezone').eq('user_id', event.userId).eq('enabled', true),
+      supabase.from('chats').select('is_muted').eq('id', event.chatId).eq('user_id', event.userId).maybeSingle(),
     ]);
     if (preferenceError) throw preferenceError;
     if (deviceError) throw deviceError;
+    if (chatError) throw chatError;
     const options = (preferences?.preferences || {}) as NotificationOptions;
-    if (preferences?.notification_enabled === false || options.notify_messages === false) return 0;
+    if (!shouldNotifyConversation(preferences?.notification_enabled, options, chat?.is_muted)) return 0;
 
     const { data: chats } = await supabase.from('chats').select('unread_count').eq('user_id', event.userId);
     const badge = (chats || []).reduce((sum: number, chat: { unread_count?: number }) => sum + Math.max(0, chat.unread_count || 0), 0);

--- a/docs/OPEN_LOOPS_SPEC.md
+++ b/docs/OPEN_LOOPS_SPEC.md
@@ -1,0 +1,181 @@
+# Open loops
+
+An **open loop** is a conversation-linked item that still needs a next move from you or from someone else. It is the product noun for the tab, Ask Claire Track, in-chat found cards, and reminder copy.
+
+This spec is the user-facing system. Detection internals, relevance scoring, and the evaluation harness live in [How Loops work](../apps/website/src/content/docs/product/loops.tsx) and [Loops: relevance and evaluation](../apps/website/src/content/docs/build-claire/loops.tsx). Plugin export (Calendar, Reminders, Tasks) is specified in the [plugin system](../apps/website/src/content/docs/extensibility/plugin-system.tsx). Claire owns the conversation-linked open item; plugins export it.
+
+Do **not** rename this surface to Reminders or Tasks.
+
+## Why this name
+
+**Open loops** already lives in Ask Claire (`Find open loops` — promises, questions, and plans). It covers:
+
+- Things you said you would do
+- Things you are waiting on
+- Unanswered questions
+- Unconfirmed plans
+- Manual reminders you add yourself
+
+It works for dinner with Dad and a client deck. “Close the loop with Maya” is the same sentence in both worlds. Business landing can keep “Promises become work” as marketing; the app noun is Open loops.
+
+The `promises` table and `/promises` routes are already `loops`. Keep using those IDs. This spec is about what people see and can do.
+
+## What is wrong today
+
+The live tab in [`apps/client/features/loops/loops-screen.tsx`](../apps/client/features/loops/loops-screen.tsx) is a flat list with metric tiles and Open / Waiting / Done chips. It mostly shows stored commitments, even though Ask Claire already talks about questions and plans, and the detector already classifies richer kinds.
+
+Other gaps:
+
+- Detection runs on new messages, but the UI implies a magical full-library scan. Be honest: incremental on ingest, optional backfill, user dismiss trains it.
+- `notify_loops` exists in preferences and is not honored on delivery.
+- Overdue is display-only; reminders only fire in a future window.
+- Mobile has no snooze, no source excerpt, and no “Not a loop.” Desktop already has snooze.
+- Ask Claire **Track** and in-chat **Loop found** are still mockup-only in the lab.
+- The tab home does not match Ask Claire language (no grouped Needs you / Waiting / Later, composer on a modal instead of a lime **New**).
+
+Related visual source of truth: [`docs/DESIGN_TO_APP_SPEC.md`](DESIGN_TO_APP_SPEC.md) (Ask Claire chrome, tab bar, Loops rename).
+
+## Definition
+
+An open loop is a conversation-linked item that still needs a next move from you or from someone else.
+
+It is **not**:
+
+- An unread message
+- A plugin task or reminder in Calendar / Reminders / Tasks
+- Something Claire sends
+
+A loop opens when a conversation creates an obligation, changes as the conversation changes, and closes when the conversation resolves it — as a single item, not a pile of fragments. Early negotiation stays quiet. “How about Tuesday?” is not a plan; “Tuesday at 10 works — see you then” can be.
+
+## Five kinds
+
+| Kind     | Meaning                                  | Example                           |
+| -------- | ---------------------------------------- | --------------------------------- |
+| You owe  | You committed                            | Send Maya the deck by 10          |
+| Waiting  | They committed, or owe you an answer     | Noah said he would confirm Friday |
+| Question | A question aimed at you is still open    | Priya: “Are we still on?”         |
+| Plan     | A time/place was proposed, not confirmed | Launch September 18               |
+| Remember | You added it by hand                     | Pick up the cake                  |
+
+Personal and business use the same objects. Copy stays human: “You owe Maya the deck” and “Waiting on Noah” work in both.
+
+## Surfaces
+
+```mermaid
+flowchart LR
+  ingest[New message] --> detect[Cheap classify]
+  detect --> loop[Open loop]
+  askClaire[Ask Claire Track] --> loop
+  manual[New on the tab] --> loop
+  loop --> tab[Open loops tab]
+  loop --> home[Home brief]
+  loop --> inbox[Inbox mark]
+  loop --> chat[In-chat found card]
+  tab --> source[Open source message]
+  tab --> nudge[Draft a follow-up]
+  tab --> plugins[Calendar or Reminders later]
+```
+
+- **Tab** is the list of what still needs a next move.
+- **Home brief** can surface the ones that need you today.
+- **Inbox** can mark a conversation that has an open loop.
+- **In-chat** shows one ambient **Loop found** card. Do not add a second smart-card tray.
+- **Ask Claire Track** creates or focuses the same object the tab shows.
+
+## Tab IA
+
+Ask Claire language. Not metric tiles. No composer on the home of this tab.
+
+- Title **Open loops**. Subtitle: “What still needs a next move.”
+- Lime **New** in the header.
+- Compact chips: All / You owe / Waiting / Questions / Plans
+- Grouped list: **Needs you** (overdue + today + unanswered), then **Waiting**, then **Later**
+- Rows reuse the Ask Claire thread-row: circle avatar, kind kicker, one-line loop, person + source, due
+- Tap opens a detail sheet: excerpt, source, Done / Snooze / Not a loop / Open chat / Draft a follow-up
+- Empty: “Nothing open. Claire will catch new loops as they appear.”
+
+Tab bar label/icon can stay the existing loops mark. The screen title is **Open loops**.
+
+## Detection policy
+
+Make the “scan everything” idea real without lighting money on fire.
+
+- Default: classify **new** messages only, cheap model, confidence floor before insert
+- Optional one-time backfill, user-started, same as Ask Claire indexing
+- Both inbound and outbound
+- Dedup by similar content + same chat
+- **Not a loop** dismisses and suppresses near-duplicates
+- Honor a per-chat tracking / sensitivity toggle (see product loops docs)
+- Do not extract from every historical message on every launch
+
+Relevance stays deterministic code, not a prompt: a missed loop beats a wrong one; group noise is someone else’s business until a hard pass (1:1, or you committed yourself).
+
+## Actions
+
+- **Done** / reopen
+- **Snooze** until tomorrow 9:00 or a picked time (mobile must gain this; desktop already has it)
+- **Open** the source message
+- **Draft a follow-up** (drops text in the composer; Claire still does not send)
+- **Track** from Ask Claire (creates or focuses the loop)
+- **Not a loop** (dismiss + suppress)
+- Phase 2: Add to Calendar / Reminders via plugins
+
+## Reminders
+
+- Honor `notify_loops`
+- Nudge before a deadline and once when it becomes overdue
+- Different copy for You owe vs Waiting
+- Quiet hours apply
+- Per-chat mute applies (Claire-local; every device)
+- Past-due items stay visible in Needs you even if the reminder already fired
+
+Overdue is derived, never stored: live status (`open` / `waiting` / `snoozed`) and `COALESCE(snoozed_until, deadline) < now()`.
+
+## What we will not do
+
+- Auto-send a follow-up
+- Turn every unread into a loop
+- Replace the Reminders or Tasks plugins
+- Show a second smart-card tray in chat (one ambient **Loop found** card is enough)
+- Silently rescan the full library on every launch
+
+## Ask Claire thread chrome
+
+While chatting, no tab bar. Home keeps the tab bar. The moment you are in New or an active Claire thread — anywhere the composer is on screen — hide the bar (lab: `.screen.no-tab`). Same rule for Open loops → Ask Claire thread screens.
+
+No sparkles in the input. The composer is text + send. Sparkles already live on the tab and in Claire’s answer cards.
+
+A **+** menu replaces a decorative leading icon. Options:
+
+- **Tag a person** — same as `@`; adds a focus chip
+- **Filter by platform** — WhatsApp / Telegram / Instagram / all connected
+- **Focus a chat** — scope this thread to one conversation, not just a person
+- **Find open loops** — run the loops prompt in this thread
+- **Check the tone** — same, as a thread action
+- **Clear this conversation** — wipe turns, keep the thread; destructive, confirm
+- **Delete thread** — remove it from Recent
+
+Do not put Send, Use reply, or plugin exports in this menu. Those stay on the answer cards.
+
+## Lab mockups (after this spec)
+
+Spec first. Then extend the gallery; no app code in that pass.
+
+- Extend `landing/ask-claire-mockups.html` with a **Loops** filter and an Open loops section
+- Update Ask Claire screen 05: Track lands in **Open loops**, not Promises
+- Replace `landing/app-mockups.html` screen 05 (Promises) with the Open loops home
+
+Screens to draw: tab home, You owe, Waiting, loop detail, new loop, in-chat Loop found, Ask Claire Track, all clear, Claire chat + menu.
+
+Decision cards on the gallery: a loop is a next move; Claire never sends; detect on ingest not a silent full-library rescan; Not a loop is a first-class action; plugins are export, not the list.
+
+## Launch sequence
+
+After mockups, not in the spec pass:
+
+1. Rename the tab and copy to **Open loops**. Keep the `loops` API.
+2. Grouped list + kinds + detail sheet + snooze + Not a loop.
+3. Wire Ask Claire Track and in-chat Loop found.
+4. Add question + plan extraction behind the same confidence floor.
+5. Honor `notify_loops`; fix overdue + badge.
+6. Later: backfill, plugins, remaining copy that still says Promise.


### PR DESCRIPTION
## Summary
- Add `docs/OPEN_LOOPS_SPEC.md`: kinds, surfaces, tab IA, detection policy, reminders, and launch sequence for conversation-linked next moves.
- Mute a chat from conversation settings; delivery skips push for muted conversations on every device.
- Split the loops list count from the embedded select so the tab no longer returns an empty array, and disambiguate loop foreign keys in desktop sync.
- Polish search with a loading skeleton, platform badges, and NativeWind-safe pressed styles (including the Add loop button).

## Test plan
- [ ] Toggle mute on a conversation and confirm other devices stop receiving push for it
- [ ] Open the Loops tab and confirm existing loops load instead of an empty list
- [ ] Add a loop from the sheet and confirm the button keeps its layout when pressed
- [ ] Search for a message/person and confirm the skeleton, then results with platform badges
- [ ] Skim `docs/OPEN_LOOPS_SPEC.md` for definition, five kinds, and launch sequence


Made with [Cursor](https://cursor.com)