### PR TITLE
feat: add per-conversation notification mute

### DIFF
--- a/apps/client/app/chat/settings/[chatId].tsx
+++ b/apps/client/app/chat/settings/[chatId].tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, router } from 'expo-router';
-import { Check, ChevronLeft, Mail, MapPin, Phone, RefreshCw, Sparkles } from 'lucide-react-native';
+import { BellOff, Check, ChevronLeft, Mail, MapPin, Phone, RefreshCw, Sparkles } from 'lucide-react-native';
 import { colors, mobileType, radius, space } from '@claire/design-system';
 import { useAuthStore } from '../../../stores/authStore';
 import { useConversationSettingsStore } from '../../../stores/conversationSettingsStore';
@@ -14,6 +14,7 @@ import { Platform } from '../../../types/platform';
 import type { ChatCategory } from '../../../types/conversationSettings';
 import { formatPhoneNumber, formatPhoneNumberInput, normalizePhoneNumber } from '../../../services/phone-numbers';
 import { displayContactName } from '../../../services/contact-display';
+import { API_BASE_URL } from '../../../services/platforms';
 
 const TONES = [
   { key: 'warm', title: 'Warm + direct', description: 'Clear, human, confident' },
@@ -43,6 +44,7 @@ function Field({ icon, label, value, onChangeText, placeholder, keyboardType = '
 export default function ConversationSettingsScreen() {
   const { chatId, platform, contact_name, chat_name, is_group } = useLocalSearchParams<{ chatId: string; platform?: string; contact_name?: string; chat_name?: string; is_group?: string }>();
   const user = useAuthStore((state) => state.user);
+  const accessToken = useAuthStore((state) => state.token);
   const insets = useSafeAreaInsets();
   const { settings, fetchSettings, setCategory, updateProfile, refreshInsights } = useConversationSettingsStore();
   const chatSettings = settings[chatId];
@@ -53,6 +55,8 @@ export default function ConversationSettingsScreen() {
   const [instruction, setInstruction] = useState('');
   const [tone, setTone] = useState<ToneKey | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [isSavingMute, setIsSavingMute] = useState(false);
   const displayName =
     is_group === '1'
       ? chat_name || contact_name || 'Group'
@@ -67,7 +71,8 @@ export default function ConversationSettingsScreen() {
       // Contacts own the canonical phone number. A Matrix sender identifier can
       // instead be a WhatsApp LID, so only fall back to message metadata when
       // the contact record has not been populated yet.
-      const { data: chat } = await supabase.from('chats').select('contact_id').eq('id', chatId).maybeSingle();
+      const { data: chat } = await supabase.from('chats').select('contact_id,is_muted').eq('id', chatId).maybeSingle();
+      if (active) setIsMuted(chat?.is_muted === true);
       let phone = '';
       if (chat?.contact_id) {
         const { data: contact } = await supabase.from('contacts').select('phone_number').eq('id', chat.contact_id).maybeSingle();
@@ -96,6 +101,25 @@ export default function ConversationSettingsScreen() {
   }, [details.email, details.phone, platform, sourcePhone]);
 
   const handleCategorySelect = (category: ChatCategory) => { if (user?.id) void setCategory(chatId, user.id, category); };
+  const updateMute = async (muted: boolean) => {
+    if (!accessToken || isSavingMute) return;
+    const previous = isMuted;
+    setIsMuted(muted);
+    setIsSavingMute(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/messages/chats/${encodeURIComponent(chatId)}/mute`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ muted }),
+      });
+      if (!response.ok) throw new Error(`Mute update failed (${response.status})`);
+    } catch {
+      setIsMuted(previous);
+      Alert.alert('Could not update notifications', 'Please check your connection and try again.');
+    } finally {
+      setIsSavingMute(false);
+    }
+  };
   const selectTone = (nextTone: ToneKey) => {
     setTone(nextTone);
     if (!instruction.trim()) {
@@ -124,11 +148,19 @@ export default function ConversationSettingsScreen() {
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.cream }} edges={['top']}>
       <View style={{ minHeight: 64, paddingHorizontal: space[4], flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: colors.neutral[200] }}>
         <MobileIconButton label="Back to chat" onPress={() => router.back()}><ChevronLeft size={21} color={colors.ink} /></MobileIconButton>
-        <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, flex: 1, paddingHorizontal: space[3], color: colors.ink }}>Relationship memory</Text>
-        <View style={{ width: 40 }} />
+        <View style={{ flex: 1 }} />
       </View>
       {isLoading && !chatSettings ? <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}><ActivityIndicator size="large" color={colors.ink} /></View> : (
         <ScrollView contentContainerStyle={{ padding: space[4], paddingBottom: 132 + insets.bottom, gap: space[5] }} keyboardShouldPersistTaps="handled">
+          <View style={{ gap: space[2] }}>
+            <SectionLabel title="Chat settings" />
+            <View testID="conversation-notification-settings" style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingHorizontal: space[3], borderRadius: radius.card, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}>
+              <View style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center', borderRadius: radius.control, backgroundColor: isMuted ? colors.neutral[100] : colors.sky }}><BellOff size={19} color={colors.ink} /></View>
+              <View style={{ flex: 1, gap: 2 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>Mute notifications</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{isMuted ? 'Notifications are muted for this chat.' : `Receive alerts for this ${is_group === '1' ? 'group' : 'conversation'}.`}</Text></View>
+              <Switch testID="conversation-mute-notifications" accessibilityLabel={`Mute notifications for ${displayName}`} value={isMuted} disabled={isSavingMute || !accessToken} onValueChange={(value) => void updateMute(value)} trackColor={{ false: colors.neutral[200], true: colors.ink }} thumbColor={isMuted ? colors.lime : colors.paper} />
+            </View>
+          </View>
+
           <View style={{ alignItems: 'center', gap: space[2], paddingVertical: space[2] }}>
             <MobileAvatar name={displayName} size={72} isGroup={is_group === '1'} />
             <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, color: colors.ink }}>{displayName}</Text>

--- a/apps/server/src/routes/messages.ts
+++ b/apps/server/src/routes/messages.ts
@@ -497,6 +497,25 @@ router.patch('/chats/:chatId/pin', requireAuth, async (req: Request, res: Respon
   }
 });
 
+/** Muting is Claire-local notification state and applies to every device. */
+router.patch('/chats/:chatId/mute', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id as string;
+    const muted = req.body?.muted;
+    if (typeof muted !== 'boolean') return res.status(400).json({ error: 'muted must be a boolean' });
+    const { data, error } = await supabase.from('chats')
+      .update({ is_muted: muted })
+      .eq('id', req.params.chatId).eq('user_id', userId)
+      .select('id,is_muted').maybeSingle();
+    if (error) throw error;
+    if (!data) return res.status(404).json({ error: 'Chat not found' });
+    return res.json({ success: true, chat: data });
+  } catch (error) {
+    logger.error('Failed to update chat mute state:', error);
+    return res.status(500).json({ error: 'Failed to update chat mute state' });
+  }
+});
+
 /**
  * POST /messages/typing
  * Send typing indicator

--- a/apps/server/src/services/notification-delivery.test.ts
+++ b/apps/server/src/services/notification-delivery.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'bun:test';
-import { isInQuietHours } from './notification-delivery';
+import { isInQuietHours, shouldNotifyConversation } from './notification-delivery';
 import { ExpoNotificationProvider } from './notification-providers';
 
 describe('notification eligibility', () => {
+  it('blocks a muted conversation while leaving unmuted conversations eligible', () => {
+    expect(shouldNotifyConversation(true, { notify_messages: true }, true)).toBe(false);
+    expect(shouldNotifyConversation(true, { notify_messages: true }, false)).toBe(true);
+    expect(shouldNotifyConversation(true, { notify_messages: true }, null)).toBe(true);
+  });
+
   it('handles quiet hours that cross midnight in the device timezone', () => {
     const options = { quiet_hours_enabled: true, quiet_hours_start: '22:00', quiet_hours_end: '08:00' };
     expect(isInQuietHours(options, 'UTC', new Date('2026-08-15T23:00:00Z'))).toBe(true);

--- a/apps/server/src/services/notification-delivery.ts
+++ b/apps/server/src/services/notification-delivery.ts
@@ -51,6 +51,10 @@ interface NotificationOptions {
   quiet_hours_end?: string;
 }
 
+export function shouldNotifyConversation(notificationEnabled: boolean | null | undefined, options: NotificationOptions, isMuted: boolean | null | undefined): boolean {
+  return notificationEnabled !== false && options.notify_messages !== false && isMuted !== true;
+}
+
 function minutesAtTimezone(date: Date, timezone: string): number {
   try {
     const parts = new Intl.DateTimeFormat('en-GB', { timeZone: timezone, hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }).formatToParts(date);
@@ -95,14 +99,16 @@ export class NotificationDeliveryService {
 
   async enqueueIncomingMessage(event: IncomingNotificationEvent): Promise<number> {
     this.start();
-    const [{ data: preferences, error: preferenceError }, { data: devices, error: deviceError }] = await Promise.all([
+    const [{ data: preferences, error: preferenceError }, { data: devices, error: deviceError }, { data: chat, error: chatError }] = await Promise.all([
       supabase.from('user_preferences').select('notification_enabled,preferences').eq('user_id', event.userId).maybeSingle(),
       supabase.from('notification_devices').select('id,user_id,device_id,platform,provider,token,enabled,timezone').eq('user_id', event.userId).eq('enabled', true),
+      supabase.from('chats').select('is_muted').eq('id', event.chatId).eq('user_id', event.userId).maybeSingle(),
     ]);
     if (preferenceError) throw preferenceError;
     if (deviceError) throw deviceError;
+    if (chatError) throw chatError;
     const options = (preferences?.preferences || {}) as NotificationOptions;
-    if (preferences?.notification_enabled === false || options.notify_messages === false) return 0;
+    if (!shouldNotifyConversation(preferences?.notification_enabled, options, chat?.is_muted)) return 0;
 
     const { data: chats } = await supabase.from('chats').select('unread_count').eq('user_id', event.userId);
     const badge = (chats || []).reduce((sum: number, chat: { unread_count?: number }) => sum + Math.max(0, chat.unread_count || 0), 0);


### PR DESCRIPTION
## Summary

- adds a prominent **Mute notifications** toggle at the top of chat settings for both direct and group conversations
- removes the misleading `Relationship memory` navigation title and leaves the back control clean
- persists mute state through an authenticated, user-scoped API endpoint
- prevents the notification delivery service from queueing alerts for muted chats across every registered device

## Verification

- `cd apps/client && bun x tsc --noEmit`
- `cd apps/server && bun test src/services/notification-delivery.test.ts` (5 passing)
- `git diff --check`

## Notes

The schema already contains `chats.is_muted`, so no migration is required.

PR #149 is the older notification rollout documentation PR. It is currently conflicting and does not contain this product change, so this focused PR supersedes it for the chat-mute work.
