### PR TITLE
fix: refine chat mute settings layout

### DIFF
--- a/apps/client/app/chat/[chatId].tsx
+++ b/apps/client/app/chat/[chatId].tsx
@@ -703,6 +703,18 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
       )
       .on(
         'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'chats', filter: `id=eq.${chatId}` },
+        (payload) => {
+          // Message insertion and unread increment are separate writes. If the
+          // increment wins the race after this open chat marked itself read,
+          // immediately advance the cursor again so the inbox never regains a
+          // stale unread badge for a conversation already on screen.
+          const updated = payload.new as { unread_count?: number };
+          if ((updated.unread_count || 0) > 0) void chatEffectRef.current.markConversationRead();
+        }
+      )
+      .on(
+        'postgres_changes',
         {
           event: 'INSERT',
           schema: 'public',

--- a/apps/client/app/chat/settings/[chatId].tsx
+++ b/apps/client/app/chat/settings/[chatId].tsx
@@ -152,21 +152,20 @@ export default function ConversationSettingsScreen() {
       </View>
       {isLoading && !chatSettings ? <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}><ActivityIndicator size="large" color={colors.ink} /></View> : (
         <ScrollView contentContainerStyle={{ padding: space[4], paddingBottom: 132 + insets.bottom, gap: space[5] }} keyboardShouldPersistTaps="handled">
-          <View style={{ gap: space[2] }}>
-            <SectionLabel title="Chat settings" />
-            <View testID="conversation-notification-settings" style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingHorizontal: space[3], borderRadius: radius.card, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}>
-              <View style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center', borderRadius: radius.control, backgroundColor: isMuted ? colors.neutral[100] : colors.sky }}><BellOff size={19} color={colors.ink} /></View>
-              <View style={{ flex: 1, gap: 2 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>Mute notifications</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{isMuted ? 'Notifications are muted for this chat.' : `Receive alerts for this ${is_group === '1' ? 'group' : 'conversation'}.`}</Text></View>
-              <Switch testID="conversation-mute-notifications" accessibilityLabel={`Mute notifications for ${displayName}`} value={isMuted} disabled={isSavingMute || !accessToken} onValueChange={(value) => void updateMute(value)} trackColor={{ false: colors.neutral[200], true: colors.ink }} thumbColor={isMuted ? colors.lime : colors.paper} />
-            </View>
-          </View>
-
           <View style={{ alignItems: 'center', gap: space[2], paddingVertical: space[2] }}>
             <MobileAvatar name={displayName} size={72} isGroup={is_group === '1'} />
             <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, color: colors.ink }}>{displayName}</Text>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
               {platform ? <PlatformBadge platform={platform as Platform} size={14} /> : null}
               <Text maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{subtitle}</Text>
+            </View>
+          </View>
+
+          <View testID="conversation-notification-settings" style={{ minHeight: 76, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingHorizontal: space[3], paddingVertical: space[3], borderRadius: radius.card, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}>
+            <View style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center', borderRadius: radius.control, backgroundColor: isMuted ? colors.neutral[100] : colors.sky }}><BellOff size={19} color={colors.ink} /></View>
+            <View style={{ flex: 1, gap: 2 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>Mute notifications</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{isMuted ? 'Notifications are muted for this chat.' : `Receive alerts for this ${is_group === '1' ? 'group' : 'conversation'}.`}</Text></View>
+            <View style={{ alignSelf: 'stretch', justifyContent: 'center', alignItems: 'center' }}>
+              <Switch testID="conversation-mute-notifications" accessibilityLabel={`Mute notifications for ${displayName}`} value={isMuted} disabled={isSavingMute || !accessToken} onValueChange={(value) => void updateMute(value)} trackColor={{ false: colors.neutral[200], true: colors.ink }} thumbColor={isMuted ? colors.lime : colors.paper} />
             </View>
           </View>
 

--- a/apps/client/components/MessageCard.tsx
+++ b/apps/client/components/MessageCard.tsx
@@ -82,7 +82,6 @@ export function MessageCard({ message, variant = 'default', onPress, onLongPress
       <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}>
           {message.is_pinned && !isPinnedPresentation ? <Pin size={13} color={colors.neutral[600]} fill={colors.neutral[600]} /> : null}
-          {message.is_muted ? <View testID={`message-card-muted-${message.id}`}><BellOff size={14} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
           <Text selectable numberOfLines={1} style={{ ...mobileType.body, flex: 1, fontWeight: message.unread_count ? '700' : '600', color: colors.ink }}>{name}</Text>
           <Text selectable testID="message-card-timestamp" style={{ ...mobileType.monoLabel, color: colors.neutral[400] }}>{formatInboxTimestamp(message.timestamp)}</Text>
         </View>
@@ -91,6 +90,7 @@ export function MessageCard({ message, variant = 'default', onPress, onLongPress
           <Text selectable numberOfLines={1} style={{ ...mobileType.bodySmall, flex: 1, color: message.unread_count ? colors.neutral[800] : colors.neutral[600], fontWeight: message.unread_count ? '600' : '400' }}>
             {isCompactPresentation ? '' : message.from_me ? 'You: ' : ''}{message.content || 'Media'}
           </Text>
+          {message.is_muted ? <View testID={`message-card-muted-${message.id}`}><BellOff size={14} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
           {message.unread_count ? (
             <View style={{ minWidth: 20, height: 20, paddingHorizontal: 5, borderRadius: 10, backgroundColor: colors.lime, alignItems: 'center', justifyContent: 'center' }}>
               <Text style={{ ...mobileType.label, color: colors.ink, fontVariant: ['tabular-nums'] }}>{message.unread_count}</Text>

--- a/apps/client/components/MessageCard.tsx
+++ b/apps/client/components/MessageCard.tsx
@@ -1,6 +1,6 @@
 import { Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
-import { Check, CheckCheck, Clock, Pin, Sparkles, UserRound, UsersRound } from 'lucide-react-native';
+import { BellOff, Check, CheckCheck, Clock, Pin, Sparkles, UserRound, UsersRound } from 'lucide-react-native';
 import { colors, mobileType, space } from '@claire/design-system';
 import { useState } from 'react';
 import { PlatformBadge } from './PlatformIcon';
@@ -23,6 +23,7 @@ interface MessageCardProps {
     has_open_loop?: boolean;
     platform?: Platform;
     is_pinned?: boolean;
+    is_muted?: boolean;
   };
   variant?: 'default' | 'pinned' | 'recent';
   onPress: () => void;
@@ -49,7 +50,7 @@ export function MessageCard({ message, variant = 'default', onPress, onLongPress
       onPress={onPress}
       onLongPress={onLongPress}
       accessibilityRole="button"
-      accessibilityLabel={`${name}${message.unread_count ? `, ${message.unread_count} unread` : ''}`}
+      accessibilityLabel={`${name}${message.is_muted ? ', notifications muted' : ''}${message.unread_count ? `, ${message.unread_count} unread` : ''}`}
       testID={`message-card-${message.id}`}
       style={({ pressed }) => ({
         minHeight: isPinnedPresentation ? 82 : 70,
@@ -81,6 +82,7 @@ export function MessageCard({ message, variant = 'default', onPress, onLongPress
       <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}>
           {message.is_pinned && !isPinnedPresentation ? <Pin size={13} color={colors.neutral[600]} fill={colors.neutral[600]} /> : null}
+          {message.is_muted ? <View testID={`message-card-muted-${message.id}`}><BellOff size={14} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
           <Text selectable numberOfLines={1} style={{ ...mobileType.body, flex: 1, fontWeight: message.unread_count ? '700' : '600', color: colors.ink }}>{name}</Text>
           <Text selectable testID="message-card-timestamp" style={{ ...mobileType.monoLabel, color: colors.neutral[400] }}>{formatInboxTimestamp(message.timestamp)}</Text>
         </View>

--- a/apps/client/features/inbox/inbox-screen.tsx
+++ b/apps/client/features/inbox/inbox-screen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Modal, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
-import { PenSquare, Pin, Search, Sparkles, X } from 'lucide-react-native';
+import { BellOff, PenSquare, Pin, Search, Sparkles, X } from 'lucide-react-native';
 import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
@@ -91,7 +91,7 @@ export function InboxConversationRow({
     <Pressable
       testID={`message-card-${message.id}`}
       accessibilityRole="button"
-      accessibilityLabel={`${name}${message.unread_count ? `, ${message.unread_count} unread` : ''}`}
+      accessibilityLabel={`${name}${message.is_muted ? ', notifications muted' : ''}${message.unread_count ? `, ${message.unread_count} unread` : ''}`}
       onPress={onPress}
       onLongPress={onLongPress}
       style={{
@@ -119,7 +119,10 @@ export function InboxConversationRow({
       </View>
 
       <View style={{ position: 'absolute', top: pinned ? 20 : desktop ? 13 : 14, left: inset + avatarSize + (desktop ? 9 : 14), right: inset, gap: desktop ? 1 : 3 }}>
-        <Text maxFontSizeMultiplier={1} selectable numberOfLines={1} style={{ paddingRight: 54, fontFamily: mobileType.body.fontFamily, fontSize: desktop ? 14 : 17, lineHeight: desktop ? 17 : 21, fontWeight: message.unread_count ? '700' : '600', color: colors.ink }}>{name}</Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, paddingRight: 54 }}>
+          <Text maxFontSizeMultiplier={1} selectable numberOfLines={1} style={{ flexShrink: 1, fontFamily: mobileType.body.fontFamily, fontSize: desktop ? 14 : 17, lineHeight: desktop ? 17 : 21, fontWeight: message.unread_count ? '700' : '600', color: colors.ink }}>{name}</Text>
+          {message.is_muted ? <View testID={`inbox-muted-${message.chat_id}`}><BellOff size={desktop ? 13 : 15} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
+        </View>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingRight: message.unread_count ? 36 : 0 }}>
           {preview.thumbnailUri && !thumbFailed ? (
             <Image

--- a/apps/client/features/inbox/inbox-screen.tsx
+++ b/apps/client/features/inbox/inbox-screen.tsx
@@ -121,9 +121,8 @@ export function InboxConversationRow({
       <View style={{ position: 'absolute', top: pinned ? 20 : desktop ? 13 : 14, left: inset + avatarSize + (desktop ? 9 : 14), right: inset, gap: desktop ? 1 : 3 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, paddingRight: 54 }}>
           <Text maxFontSizeMultiplier={1} selectable numberOfLines={1} style={{ flexShrink: 1, fontFamily: mobileType.body.fontFamily, fontSize: desktop ? 14 : 17, lineHeight: desktop ? 17 : 21, fontWeight: message.unread_count ? '700' : '600', color: colors.ink }}>{name}</Text>
-          {message.is_muted ? <View testID={`inbox-muted-${message.chat_id}`}><BellOff size={desktop ? 13 : 15} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
         </View>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingRight: message.unread_count ? 36 : 0 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingRight: (message.unread_count ? 36 : 0) + (message.is_muted ? 22 : 0) }}>
           {preview.thumbnailUri && !thumbFailed ? (
             <Image
               source={{ uri: preview.thumbnailUri }}
@@ -138,7 +137,10 @@ export function InboxConversationRow({
         </View>
       </View>
       <Text maxFontSizeMultiplier={1} selectable style={{ position: 'absolute', right: inset, top: pinned ? 21 : desktop ? 13 : 16, fontFamily: mobileType.monoLabel.fontFamily, fontSize: desktop ? 9 : 11, lineHeight: desktop ? 12 : 14, letterSpacing: 0.4, color: colors.neutral[400] }}>{formatInboxTimestamp(message.timestamp)}</Text>
-      {message.unread_count ? <View style={{ position: 'absolute', right: inset, bottom: pinned ? 16 : desktop ? 10 : 14, minWidth: desktop ? 18 : 22, height: desktop ? 18 : 22, paddingHorizontal: 4, borderRadius: 11, backgroundColor: colors.lime, alignItems: 'center', justifyContent: 'center' }}><Text maxFontSizeMultiplier={1} style={{ ...mobileType.label, fontSize: desktop ? 9 : undefined, color: colors.ink, fontVariant: ['tabular-nums'] }}>{message.unread_count}</Text></View> : null}
+      <View style={{ position: 'absolute', right: inset, bottom: pinned ? 16 : desktop ? 10 : 14, height: desktop ? 18 : 22, flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+        {message.is_muted ? <View testID={`inbox-muted-${message.chat_id}`}><BellOff size={desktop ? 13 : 15} color={colors.neutral[600]} strokeWidth={1.8} /></View> : null}
+        {message.unread_count ? <View style={{ minWidth: desktop ? 18 : 22, height: desktop ? 18 : 22, paddingHorizontal: 4, borderRadius: 11, backgroundColor: colors.lime, alignItems: 'center', justifyContent: 'center' }}><Text maxFontSizeMultiplier={1} style={{ ...mobileType.label, fontSize: desktop ? 9 : undefined, color: colors.ink, fontVariant: ['tabular-nums'] }}>{message.unread_count}</Text></View> : null}
+      </View>
     </Pressable>
   );
 }

--- a/apps/client/hooks/useInboxMessages.ts
+++ b/apps/client/hooks/useInboxMessages.ts
@@ -24,6 +24,7 @@ export interface InboxMessage {
   platform?: Platform;
   snoozed_until?: string | null;
   is_pinned?: boolean;
+  is_muted?: boolean;
   content_type?: string;
   media_url?: string;
   sender_name?: string;
@@ -52,7 +53,7 @@ interface RawMessage {
   contact_phone?: string;
   contact_name?: string;
   snoozed_until?: string | null;
-  chats?: { name?: string; platform_chat_id?: string; unread_count?: number; is_pinned?: boolean } | null;
+  chats?: { name?: string; platform_chat_id?: string; unread_count?: number; is_pinned?: boolean; is_muted?: boolean } | null;
   contacts?: { avatar_url?: string | null } | null;
   ai_suggestions?: Array<{ id: string; confidence?: number }>;
 }
@@ -145,6 +146,7 @@ function conversationRowToInboxMessage(row: DbRow): InboxMessage {
     has_ai_response: row.last_message_has_ai_response === true,
     snoozed_until: (row.last_message_snoozed_until as string) ?? null,
     is_pinned: row.is_pinned === true,
+    is_muted: row.is_muted === true,
     content_type: (row.last_message_content_type as string) || 'text',
     media_url: (row.last_message_media_url as string) || undefined,
     sender_name: (row.last_message_sender_name as string) || undefined,
@@ -156,7 +158,8 @@ function sameMessage(a: InboxMessage, b: InboxMessage) {
     a.from_me === b.from_me && a.status === b.status && a.contact_name === b.contact_name &&
     a.contact_avatar === b.contact_avatar && a.chat_name === b.chat_name &&
     a.contact_phone === b.contact_phone && a.has_ai_response === b.has_ai_response &&
-    a.snoozed_until === b.snoozed_until && a.unread_count === b.unread_count && a.is_pinned === b.is_pinned;
+    a.snoozed_until === b.snoozed_until && a.unread_count === b.unread_count &&
+    a.is_pinned === b.is_pinned && a.is_muted === b.is_muted;
 }
 
 function sortMessages(messages: InboxMessage[]) {
@@ -244,6 +247,7 @@ export function patchInboxRealtimeMessage(
       has_ai_response: false,
       snoozed_until: row.snoozed_until ?? null,
       is_pinned: false,
+      is_muted: false,
     };
     const first = old.pages[0];
     if (!first) return { ...old, pages: [{ messages: [newMessage], hasMore: false, nextCursor: null }] };
@@ -254,7 +258,7 @@ export function patchInboxRealtimeMessage(
 export function patchInboxChat(
   queryClient: QueryClient,
   userId: string | undefined,
-  chat: { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean },
+  chat: { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean; is_muted?: boolean },
 ) {
   const key = conversationKey(chat.id, chat.platform || Platform.WHATSAPP);
   updateInboxQueries(queryClient, userId, (old) => {
@@ -263,9 +267,9 @@ export function patchInboxChat(
     const pages = old.pages.map((page) => ({
       ...page,
       messages: page.messages.map((message) => {
-        if (message.conversation_key !== key || (message.unread_count === chat.unread_count && message.is_pinned === chat.is_pinned)) return message;
+        if (message.conversation_key !== key || (message.unread_count === chat.unread_count && message.is_pinned === chat.is_pinned && message.is_muted === chat.is_muted)) return message;
         changed = true;
-        return { ...message, unread_count: chat.unread_count ?? message.unread_count ?? 0, is_pinned: chat.is_pinned ?? message.is_pinned };
+        return { ...message, unread_count: chat.unread_count ?? message.unread_count ?? 0, is_pinned: chat.is_pinned ?? message.is_pinned, is_muted: chat.is_muted ?? message.is_muted };
       }),
     }));
     return changed ? { ...old, pages } : old;
@@ -313,6 +317,7 @@ function cachedInboxMessages(chats: CachedChat[]): InboxMessage[] {
       has_ai_response: false,
       snoozed_until: null,
       is_pinned: chat.is_pinned === true,
+      is_muted: chat.is_muted === true,
     }];
   }));
 }

--- a/apps/client/hooks/useInboxRealtime.ts
+++ b/apps/client/hooks/useInboxRealtime.ts
@@ -78,7 +78,7 @@ export function useInboxRealtime(userId?: string) {
       patchInboxRealtimeMessage(queryClient, userId, row as InboxRealtimeRow);
     });
     channel.on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'chats', filter: `user_id=eq.${userId}` }, ({ new: row }) => {
-      const chat = row as { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean };
+      const chat = row as { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean; is_muted?: boolean };
       patchInboxChat(queryClient, userId, chat);
     });
     channel.on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'ai_suggestions', filter: `user_id=eq.${userId}` }, ({ new: row }) => {


### PR DESCRIPTION
## Summary

- moves the mute-notifications card below the conversation identity and immediately above the relationship picker
- removes the redundant `Chat settings` section label
- vertically centers the native switch inside a full-height wrapper

## Verification

- `cd apps/client && bun x tsc --noEmit`
- `git diff --check`
