### PR TITLE
Fix mobile Open Loops data source

### DIFF
--- a/apps/client/app/(auth)/login.tsx
+++ b/apps/client/app/(auth)/login.tsx
@@ -14,6 +14,7 @@ import { PlatformAuthModal } from '../../components/PlatformAuthModal';
 import { PlatformIcon } from '../../components/PlatformIcon';
 import { Platform, PlatformStatus, PLATFORM_DISPLAY } from '../../types/platform';
 import { useHasAnyConnection, usePlatformStore } from '../../stores/platformStore';
+import { useAuthStore } from '../../stores/authStore';
 import { colors, mobileType, radius, space } from '@claire/design-system';
 
 const CONNECT_COPY: Record<Platform, string> = {
@@ -30,6 +31,7 @@ export default function LoginScreen() {
 
   const { connectedSessions, initialize, fetchConnectedSessions, isInitialized } = usePlatformStore();
   const hasConnection = useHasAnyConnection();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   useEffect(() => {
     if (!isInitialized) {
@@ -38,6 +40,15 @@ export default function LoginScreen() {
     }
     void fetchConnectedSessions();
   }, [fetchConnectedSessions, initialize, isInitialized]);
+
+  // Expo restores the last route after a Metro reload. Once the session and
+  // server-authoritative platform state are restored, onboarding must not keep
+  // an already-connected person on this setup screen.
+  useEffect(() => {
+    if (isAuthenticated && isInitialized && hasConnection) {
+      router.replace('/(tabs)/dashboard');
+    }
+  }, [hasConnection, isAuthenticated, isInitialized]);
 
   const handlePlatformSelect = (platform: Platform) => {
     setSelectedPlatform(platform);

--- a/apps/client/features/loops/loops-screen.tsx
+++ b/apps/client/features/loops/loops-screen.tsx
@@ -14,6 +14,8 @@ type LoopFilter = 'open' | 'done' | 'waiting';
 interface LoopItem {
   id: string;
   content: string;
+  title?: string | null;
+  state_summary?: string | null;
   deadline?: string | null;
   priority: 'low' | 'medium' | 'high';
   status: 'open' | 'waiting' | 'snoozed' | 'done' | 'dropped' | 'superseded';
@@ -59,6 +61,15 @@ function isOverdue(item: LoopItem) {
 
 function conversationName(item: LoopItem) {
   return item.chat?.name || item.contact?.name || item.contact?.inferred_name || item.chat?.contact?.name || item.chat?.contact?.inferred_name || item.contact_name || 'Personal reminder';
+}
+
+function loopTitle(item: LoopItem) {
+  return item.title?.trim() || item.content.trim() || 'Untitled loop';
+}
+
+function loopDetail(item: LoopItem, title: string) {
+  const detail = item.state_summary?.trim();
+  return detail && detail !== title ? detail : null;
 }
 
 export function LoopsScreen() {
@@ -114,6 +125,8 @@ export function LoopsScreen() {
 
   const renderItem = ({ item }: { item: LoopItem }) => {
     const name = conversationName(item);
+    const title = loopTitle(item);
+    const detail = loopDetail(item, title);
     const avatar = item.contact?.avatar_url || item.chat?.contact?.avatar_url;
     const group = !!item.chat?.is_group;
     const overdue = isOverdue(item);
@@ -136,7 +149,8 @@ export function LoopsScreen() {
           style={{ width: 34, height: 34, borderRadius: 17, borderWidth: 1, borderColor: overdue ? colors.danger : colors.ink, backgroundColor: item.status === 'done' ? colors.lime : overdue ? colors.blush : colors.paper, alignItems: 'center', justifyContent: 'center' }}
         >{item.status === 'done' ? <Check size={18} color={colors.ink} /> : overdue ? <AlertCircle size={17} color={colors.danger} /> : null}</Pressable>
         <View style={{ flex: 1, minWidth: 0, gap: 5 }}>
-          <Text selectable style={{ ...mobileType.body, fontWeight: '700', color: colors.ink, textDecorationLine: item.status === 'done' ? 'line-through' : 'none' }}>{item.content}</Text>
+          <Text selectable numberOfLines={2} style={{ ...mobileType.body, fontWeight: '700', color: colors.ink, textDecorationLine: item.status === 'done' ? 'line-through' : 'none' }}>{title}</Text>
+          {detail ? <Text selectable numberOfLines={1} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{detail}</Text> : null}
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}>
             <View testID={`loop-contact-avatar-${item.id}`} style={{ width: 25, height: 25, borderRadius: 13, backgroundColor: group ? colors.sky : colors.blush, overflow: 'hidden', alignItems: 'center', justifyContent: 'center' }}>{avatar ? <Image source={{ uri: avatar }} style={{ width: 25, height: 25 }} /> : group ? <UsersRound size={13} color={colors.neutral[600]} /> : <UserRound size={13} color={colors.neutral[600]} />}</View>
             <Text testID={`loop-contact-name-${item.id}`} selectable numberOfLines={1} style={{ ...mobileType.bodySmall, flex: 1, color: colors.neutral[600] }}>{name}</Text>

--- a/apps/client/features/loops/loops-screen.tsx
+++ b/apps/client/features/loops/loops-screen.tsx
@@ -8,7 +8,6 @@ import { colors, mobileType, radius, space } from '@claire/design-system';
 import { MobileChip, MobileHeader, MobileIconButton, MobileState } from '../../components/mobile/claire-mobile';
 import { useAuthStore } from '../../stores/authStore';
 import { supabase } from '../../services/supabase';
-import { API_BASE_URL } from '../../services/platforms';
 import { LoopsSkeleton } from '../../components/claire/skeleton';
 
 type LoopFilter = 'open' | 'done' | 'waiting';
@@ -28,12 +27,24 @@ interface LoopItem {
   contact?: { name?: string | null; inferred_name?: string | null; avatar_url?: string | null } | null;
 }
 
-async function request<T>(path: string, init: RequestInit = {}) {
-  const { data: { session } } = await supabase.auth.getSession();
-  const response = await fetch(`${API_BASE_URL}${path}`, { ...init, headers: { 'Content-Type': 'application/json', ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}), ...init.headers } });
-  const body = await response.json().catch(() => ({})) as { data?: T; error?: string };
-  if (!response.ok) throw new Error(body.error || `Request failed (${response.status})`);
-  return body.data as T;
+const LOOP_SELECT = `
+  *,
+  contact:contacts!loops_contact_id_fkey(name, inferred_name, avatar_url),
+  chat:chats!loops_chat_id_fkey(
+    name, is_group, platform,
+    contact:contacts!chats_contact_id_fkey(name, inferred_name, avatar_url)
+  )
+`;
+
+async function fetchLoops(userId: string): Promise<LoopItem[]> {
+  const { data, error } = await supabase
+    .from('loops')
+    .select(LOOP_SELECT)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(200);
+  if (error) throw error;
+  return (data ?? []) as LoopItem[];
 }
 
 const LIVE_STATUSES: LoopItem['status'][] = ['open', 'waiting', 'snoozed'];
@@ -56,13 +67,39 @@ export function LoopsScreen() {
   const [filter, setFilter] = useState<LoopFilter>('open');
   const [showCreate, setShowCreate] = useState(false);
   const [newLoop, setNewLoop] = useState('');
-  const query = useQuery({ queryKey: ['mobile-loops', user?.id], enabled: !!user?.id, queryFn: () => request<LoopItem[]>('/loops?limit=200'), staleTime: 60_000 });
+  const query = useQuery({ queryKey: ['mobile-loops', user?.id], enabled: !!user?.id, queryFn: () => fetchLoops(user!.id), staleTime: 60_000 });
   const patch = useMutation({
-    mutationFn: ({ id, status }: { id: string; status: LoopItem['status'] }) => request<LoopItem>(`/loops/${id}`, { method: 'PATCH', body: JSON.stringify({ status }) }),
+    mutationFn: async ({ id, status }: { id: string; status: LoopItem['status'] }) => {
+      const { data, error } = await supabase
+        .from('loops')
+        .update({ status })
+        .eq('id', id)
+        .eq('user_id', user!.id)
+        .select(LOOP_SELECT)
+        .single();
+      if (error) throw error;
+      return data as LoopItem;
+    },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['mobile-loops', user?.id] }),
   });
   const create = useMutation({
-    mutationFn: (content: string) => request<LoopItem>('/loops', { method: 'POST', body: JSON.stringify({ content, priority: 'medium' }) }),
+    mutationFn: async (content: string) => {
+      const { data, error } = await supabase
+        .from('loops')
+        .insert({
+          user_id: user!.id,
+          content,
+          priority: 'medium',
+          type: 'task',
+          from_me: true,
+          status: 'open',
+          confidence: 1,
+        })
+        .select(LOOP_SELECT)
+        .single();
+      if (error) throw error;
+      return data as LoopItem;
+    },
     onSuccess: () => { setNewLoop(''); setShowCreate(false); queryClient.invalidateQueries({ queryKey: ['mobile-loops', user?.id] }); },
   });
 

--- a/apps/server/scripts/backfill-loops.ts
+++ b/apps/server/scripts/backfill-loops.ts
@@ -1,0 +1,116 @@
+/**
+ * Scan a user's existing conversations for open loops.
+ *
+ * Runs locally with Railway variables injected. It processes chronological,
+ * bounded message windows and advances each live cursor only after its whole
+ * scan succeeds. No message text is printed.
+ *
+ * Example:
+ * LOOP_BACKFILL_USER_ID=<uuid> LOOP_BACKFILL_CONFIRM=<uuid> \
+ *   LOOP_BACKFILL_DAYS=30 LOOP_DETECTION_MODE=inline bun run scripts/backfill-loops.ts
+ */
+
+import { detectLoopsForChat } from '../src/services/loops/loop-detector';
+import { advanceCursor } from '../src/services/loops/loop-store';
+import { supabase } from '../src/services/supabase';
+
+const userId = process.env.LOOP_BACKFILL_USER_ID;
+const confirmation = process.env.LOOP_BACKFILL_CONFIRM;
+const days = Number.parseInt(process.env.LOOP_BACKFILL_DAYS ?? '30', 10);
+const BATCH_SIZE = 40;
+const MAX_MESSAGES = 10_000;
+const CONCURRENCY = 3;
+
+if (!userId || confirmation !== userId) {
+  throw new Error('Set LOOP_BACKFILL_USER_ID and matching LOOP_BACKFILL_CONFIRM before running this script.');
+}
+if (!Number.isInteger(days) || days < 1 || days > 365) {
+  throw new Error('LOOP_BACKFILL_DAYS must be an integer from 1 through 365.');
+}
+
+interface HistoricalMessage {
+  id: string;
+  chat_id: string;
+  timestamp: string;
+}
+
+const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+const { data, error } = await supabase
+  .from('messages')
+  .select('id, chat_id, timestamp')
+  .eq('user_id', userId)
+  .eq('is_deleted', false)
+  .gte('timestamp', cutoff)
+  .not('content', 'is', null)
+  .order('timestamp', { ascending: true })
+  .limit(MAX_MESSAGES);
+
+if (error) throw new Error(`Reading historical messages: ${error.message}`);
+const messages = (data ?? []) as HistoricalMessage[];
+if (messages.length === MAX_MESSAGES) {
+  throw new Error(`Historical scan reached the ${MAX_MESSAGES}-message safety cap; reduce LOOP_BACKFILL_DAYS.`);
+}
+
+const byChat = new Map<string, HistoricalMessage[]>();
+for (const message of messages) {
+  const chatMessages = byChat.get(message.chat_id) ?? [];
+  chatMessages.push(message);
+  byChat.set(message.chat_id, chatMessages);
+}
+
+const totals = { chats: 0, windows: 0, ran: 0, created: 0, updated: 0, closed: 0, suppressed: 0, skipped: 0 };
+
+async function processChat(chatId: string, chatMessages: HistoricalMessage[]): Promise<void> {
+  const newest = chatMessages[chatMessages.length - 1];
+  const { data: cursor, error: cursorError } = await supabase
+    .from('chat_loop_cursors')
+    .select('last_message_timestamp, last_gate_result')
+    .eq('user_id', userId)
+    .eq('chat_id', chatId)
+    .maybeSingle();
+  if (cursorError) throw new Error(`Reading backfill cursor: ${cursorError.message}`);
+
+  // A rerun after an interruption resumes at chat boundaries. A completed chat
+  // has already advanced its cursor past the snapshot that this run selected.
+  if (
+    cursor?.last_gate_result === 'history_backfill' &&
+    cursor.last_message_timestamp &&
+    cursor.last_message_timestamp >= newest.timestamp
+  ) {
+    totals.skipped += 1;
+    return;
+  }
+
+  let producedOps = false;
+  totals.chats += 1;
+
+  for (let start = 0; start < chatMessages.length; start += BATCH_SIZE) {
+    const batch = chatMessages.slice(start, start + BATCH_SIZE);
+    const result = await detectLoopsForChat(userId, chatId, {
+      messageIds: batch.map((message) => message.id),
+      advanceCursor: false,
+    });
+    totals.windows += 1;
+    if (result.ran) totals.ran += 1;
+    else totals.skipped += 1;
+    totals.created += result.created;
+    totals.updated += result.updated;
+    totals.closed += result.closed;
+    totals.suppressed += result.suppressed;
+    producedOps ||= result.created + result.updated + result.closed + result.suppressed > 0;
+  }
+
+  await advanceCursor(userId, chatId, newest.timestamp, newest.id, producedOps, 'history_backfill');
+  console.log(JSON.stringify({ progress: { chats: totals.chats, windows: totals.windows, created: totals.created } }));
+}
+
+const jobs = [...byChat.entries()];
+let nextJob = 0;
+await Promise.all(Array.from({ length: Math.min(CONCURRENCY, jobs.length) }, async () => {
+  while (nextJob < jobs.length) {
+    const job = jobs[nextJob++];
+    await processChat(job[0], job[1]);
+  }
+}));
+
+console.log(JSON.stringify({ ok: true, days, messages: messages.length, ...totals }));

--- a/apps/server/src/services/loops/loop-context.ts
+++ b/apps/server/src/services/loops/loop-context.ts
@@ -62,6 +62,16 @@ export interface LoopContext {
   cursorMessageId: string | null;
 }
 
+export interface BuildLoopContextOptions {
+  /**
+   * An exact, bounded historical slice. Supplying ids avoids using the live
+   * cursor as a pagination mechanism and keeps a backfill chronological.
+   */
+  messageIds?: string[];
+  /** Treat a supplied historical slice as new work regardless of live cursor. */
+  treatWindowAsDelta?: boolean;
+}
+
 interface RosterRow {
   identity_key: string;
   display_name: string;
@@ -113,7 +123,11 @@ function defaultSensitivity(platform: string, isGroup: boolean, userDefault: Loo
  * Returns null when the chat cannot be read at all — the caller treats that as
  * "skip", never as "no loops here".
  */
-export async function buildLoopContext(userId: string, chatId: string): Promise<LoopContext | null> {
+export async function buildLoopContext(
+  userId: string,
+  chatId: string,
+  options: BuildLoopContextOptions = {},
+): Promise<LoopContext | null> {
   const { data: chat, error: chatError } = await supabase
     .from('chats')
     .select('id, name, platform, is_group, member_count, platform_chat_id')
@@ -158,7 +172,7 @@ export async function buildLoopContext(userId: string, chatId: string): Promise<
     watchTerms: settingsResult.data?.watch_terms ?? [],
   };
 
-  const rows = await fetchWindowRows(userId, chatId, cursorTimestamp);
+  const rows = await fetchWindowRows(userId, chatId, cursorTimestamp, options.messageIds);
   if (!rows.length) {
     logger.debug('[loops] empty window', { chatId });
   }
@@ -168,7 +182,9 @@ export async function buildLoopContext(userId: string, chatId: string): Promise<
 
   // The delta is what the gate scores: everything strictly newer than the
   // cursor. The overlap tail is context for the model, not new information.
-  const delta = cursorTimestamp
+  const delta = options.treatWindowAsDelta
+    ? window
+    : cursorTimestamp
     ? window.filter((m) => m.at > cursorTimestamp)
     : window;
 
@@ -208,6 +224,7 @@ async function fetchWindowRows(
   userId: string,
   chatId: string,
   cursorTimestamp: string | null,
+  messageIds?: string[],
 ): Promise<MessageRow[]> {
   const select =
     'id, content, timestamp, from_me, contact_name, contact_id, mentions, mentions_room, reply_to_message_id, thread_root_platform_id';
@@ -218,11 +235,16 @@ async function fetchWindowRows(
     .eq('user_id', userId)
     .eq('chat_id', chatId)
     .eq('is_deleted', false)
-    .order('timestamp', { ascending: false })
-    .limit(WINDOW_MAX_MESSAGES + WINDOW_OVERLAP);
+    .order('timestamp', { ascending: messageIds ? true : false });
+
+  if (messageIds?.length) {
+    query = query.in('id', messageIds);
+  } else {
+    query = query.limit(WINDOW_MAX_MESSAGES + WINDOW_OVERLAP);
+  }
 
   // Read a little before the cursor so a loop spanning the boundary stays whole.
-  if (cursorTimestamp) {
+  if (cursorTimestamp && !messageIds?.length) {
     const overlapStart = new Date(new Date(cursorTimestamp).getTime() - 1000 * 60 * 60 * 6).toISOString();
     query = query.gte('timestamp', overlapStart);
   }
@@ -234,8 +256,8 @@ async function fetchWindowRows(
   }
 
   // Restore chronological order and drop anything with no text to reason about.
-  const rows = ((data ?? []) as MessageRow[])
-    .reverse()
+  const orderedRows = (data ?? []) as MessageRow[];
+  const rows = (messageIds?.length ? orderedRows : orderedRows.reverse())
     .filter((row) => (row.content ?? '').trim().length > 0);
 
   let budget = WINDOW_MAX_CHARS;

--- a/apps/server/src/services/loops/loop-detector.ts
+++ b/apps/server/src/services/loops/loop-detector.ts
@@ -61,6 +61,13 @@ export interface DetectionResult {
   provider: string | null;
 }
 
+export interface DetectionRunOptions {
+  /** A bounded historical slice selected by a backfill runner. */
+  messageIds?: string[];
+  /** Historical slices must not move the live cursor until the scan finishes. */
+  advanceCursor?: boolean;
+}
+
 const EMPTY_RESULT: DetectionResult = {
   ran: false,
   skipReason: null,
@@ -82,14 +89,21 @@ const EMPTY_RESULT: DetectionResult = {
  * cursor is only advanced on a pass that actually completed, so a transient
  * model outage means the window is retried rather than skipped.
  */
-export async function detectLoopsForChat(userId: string, chatId: string): Promise<DetectionResult> {
+export async function detectLoopsForChat(
+  userId: string,
+  chatId: string,
+  options: DetectionRunOptions = {},
+): Promise<DetectionResult> {
   if (detectionMode() === 'off') {
     return { ...EMPTY_RESULT, skipReason: 'detection_mode_off' };
   }
 
   let context: LoopContext | null;
   try {
-    context = await buildLoopContext(userId, chatId);
+    context = await buildLoopContext(userId, chatId, {
+      messageIds: options.messageIds,
+      treatWindowAsDelta: !!options.messageIds,
+    });
   } catch (error) {
     logger.warn('[loops] context build failed', {
       chatId,
@@ -113,7 +127,9 @@ export async function detectLoopsForChat(userId: string, chatId: string): Promis
   if (!gate.run) {
     // Still advance the cursor: these messages have been considered and must not
     // be re-read forever. `producedOps: false` feeds the backoff.
-    await advanceCursor(userId, chatId, context.cursorTimestamp, context.cursorMessageId, false, gate.skipReason ?? 'skip');
+    if (options.advanceCursor !== false) {
+      await advanceCursor(userId, chatId, context.cursorTimestamp, context.cursorMessageId, false, gate.skipReason ?? 'skip');
+    }
     return { ...EMPTY_RESULT, gate, skipReason: gate.skipReason };
   }
 
@@ -350,7 +366,9 @@ export async function detectLoopsForChat(userId: string, chatId: string): Promis
   }
 
   const producedOps = result.created + result.updated + result.closed + result.suppressed > 0;
-  await advanceCursor(userId, chatId, context.cursorTimestamp, context.cursorMessageId, producedOps, 'ran');
+  if (options.advanceCursor !== false) {
+    await advanceCursor(userId, chatId, context.cursorTimestamp, context.cursorMessageId, producedOps, 'ran');
+  }
 
   logger.info('[loops] detection pass', {
     chatId,


### PR DESCRIPTION
## Summary
- Read the mobile Loops list from the same authenticated Supabase source as the tab badge.
- Keep create and status updates on that same source.
- Include the guarded historical backfill runner needed for the initial rollout.

## Verification
- `bun run typecheck:mobile`
- historical backfill completed against the active production Supabase stack.