### PR TITLE
Fix loop ownership display

### DIFF
--- a/apps/client/features/loops/loop-detail-screen.tsx
+++ b/apps/client/features/loops/loop-detail-screen.tsx
@@ -136,9 +136,6 @@ function ParticipantRow({ participant }: { participant: LoopParticipant }) {
       <Text style={{ ...mobileType.bodySmall, flex: 1, color: colors.ink }}>
         {participant.is_self ? 'You' : participant.display_name}
       </Text>
-      {participant.role === 'owner' ? (
-        <Text style={{ ...mobileType.monoLabel, color: colors.neutral[600] }}>OWNER</Text>
-      ) : null}
     </View>
   );
 }

--- a/apps/server/src/services/loops/loop-detector.ts
+++ b/apps/server/src/services/loops/loop-detector.ts
@@ -267,7 +267,7 @@ export async function detectLoopsForChat(
       await upsertLoopParticipants(
         stored.id,
         userId,
-        buildParticipants(op.participants, context, op.owner_name ?? null),
+        buildParticipants(op.participants, context, op.owner, op.owner_name ?? null),
       );
     } else {
       // Lost a race, or the same intent restated: fold it into the live loop.
@@ -405,21 +405,28 @@ function normalizeDeadline(value: string | null | undefined): string | null {
 }
 
 /** Roster entries for the people a loop actually involves. */
-function buildParticipants(
+export function buildParticipants(
   names: string[],
   context: LoopContext,
+  owner: 'me' | 'them' | 'shared' | 'unknown',
   ownerName: string | null,
 ): Array<{ displayName: string; identityKey: string; contactId?: string | null; isSelf?: boolean; role?: 'owner' | 'counterparty' | 'mentioned' | 'observer' }> {
   const byName = new Map(context.roster.map((p) => [p.displayName.toLowerCase(), p]));
 
   return names.slice(0, 25).map((name) => {
     const match = byName.get(name.toLowerCase());
-    const isOwner = !!ownerName && name.toLowerCase() === ownerName.toLowerCase();
+    const isSelf = match?.isSelf ?? false;
+    // The model's optional name must never override the structured owner
+    // direction. In particular, a user cannot be labelled the owner of a loop
+    // whose `owner` is `them` merely because their name appeared in the prompt.
+    const isOwner = owner === 'me'
+      ? isSelf
+      : owner === 'them' && !isSelf && !!ownerName && name.toLowerCase() === ownerName.toLowerCase();
     return {
       displayName: name,
       identityKey: match?.identityKey ?? name.toLowerCase(),
       contactId: match?.contactId ?? null,
-      isSelf: match?.isSelf ?? false,
+      isSelf,
       role: isOwner ? ('owner' as const) : ('counterparty' as const),
     };
   });

--- a/apps/server/tests/services/loops/loop-detector.test.ts
+++ b/apps/server/tests/services/loops/loop-detector.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildParticipants } from '../../../src/services/loops/loop-detector';
+import type { LoopContext } from '../../../src/services/loops/loop-context';
+
+const context = {
+  roster: [
+    { identityKey: 'self', displayName: 'Luc Succes', contactId: null, isSelf: true },
+    { identityKey: 'maya', displayName: 'Maya', contactId: 'maya-id', isSelf: false },
+  ],
+} as LoopContext;
+
+describe('buildParticipants', () => {
+  it('does not label the user as the owner when the counterparty owes the next move', () => {
+    const participants = buildParticipants(['Luc Succes', 'Maya'], context, 'them', 'Luc Succes');
+
+    expect(participants.find((participant) => participant.isSelf)?.role).toBe('counterparty');
+  });
+
+  it('uses the structured owner direction when the user owes the next move', () => {
+    const participants = buildParticipants(['Luc Succes', 'Maya'], context, 'me', null);
+
+    expect(participants.find((participant) => participant.isSelf)?.role).toBe('owner');
+  });
+});


### PR DESCRIPTION
Align persisted participant roles with the structured owner direction and remove the misleading per-person owner label from loop details. Adds focused coverage for self vs counterparty ownership.