### PR TITLE
Add a production-store submit profile to eas.json

### DIFF
--- a/apps/client/eas.json
+++ b/apps/client/eas.json
@@ -49,6 +49,9 @@
       "ios": {
         "ascAppId": "6803265140"
       }
+    },
+    "production-store": {
+      "extends": "production"
     }
   }
 }


### PR DESCRIPTION
## Why

`eas build --profile production-store --platform ios --auto-submit` fails with:

```
Missing submit profile in eas.json: production-store
```

EAS looks up the submit profile by the **build** profile's name. `eas.json` defined `submit.production`, but the store-distribution build profile is `production-store`, so auto-submit had nothing to match. The build itself still queued and ran — it just had to be submitted manually afterwards.

## What

Adds `submit.production-store` extending `submit.production`, so it inherits the same `ascAppId` (`6803265140`) rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)