### PR TITLE
Update the inbox preview as soon as a message is sent

### DIFF
--- a/apps/client/app/chat/[chatId].tsx
+++ b/apps/client/app/chat/[chatId].tsx
@@ -58,7 +58,11 @@ import { DesktopInboxWorkspace } from '../../features/desktop/desktop-inbox-work
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { MobileAvatar, MobileIconButton } from '../../components/mobile/claire-mobile';
 import { cacheTimeline } from '../../services/mobile-cache';
-import { inboxQueryPrefix, patchInboxChat } from '../../hooks/useInboxMessages';
+import {
+  inboxQueryPrefix,
+  patchInboxChat,
+  patchInboxRealtimeMessage,
+} from '../../hooks/useInboxMessages';
 import {
   chatTimelineKey,
   updateChatTimeline,
@@ -493,6 +497,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
       updateChatTimeline(queryClient, user?.id, chatId, updater, options),
     [queryClient, user?.id, chatId]
   );
+
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const [inputText, setInputText] = useState('');
@@ -520,6 +525,31 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
   }, [draft]);
 
   const resolvedPlatform = platform || chatMetadata?.platform || undefined;
+
+  // Sending does not write a messages row: POST /platforms/:platform/send hands
+  // the message to the bridge and returns, and the row only lands when the
+  // platform echoes it back through Matrix. The inbox preview is driven purely
+  // by that row's realtime INSERT, so until the round trip completes the
+  // conversation still lists the previous message. The transcript hides this
+  // behind its optimistic bubble; the inbox had no equivalent, which is why the
+  // subtitle lagged by however long the bridge took. Patch it here too, and let
+  // the realtime row reconcile the ids when it arrives.
+  const syncInboxPreview = useCallback(
+    (message: ChatMessage) => {
+      if (!chatId) return;
+      patchInboxRealtimeMessage(queryClient, user?.id, {
+        id: message.id,
+        chat_id: chatId,
+        content: message.content,
+        timestamp: message.timestamp,
+        from_me: true,
+        is_group: is_group === '1',
+        platform: resolvedPlatform as Platform,
+        contact_name: contact_name || chat_name || undefined,
+      });
+    },
+    [queryClient, user?.id, chatId, is_group, resolvedPlatform, contact_name, chat_name]
+  );
   const isGroup = is_group === '1' || (!is_group && chatMetadata?.isGroup === true);
   const resolvedName = chat_name || contact_name || chatMetadata?.name || undefined;
   const platformCapabilities = availablePlatforms.find(
@@ -885,6 +915,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
       (previous) => ({ ...previous, messages: [...previous.messages, optimistic] }),
       { createIfMissing: true }
     );
+    syncInboxPreview(optimistic);
     if (user?.id && chatId) {
       void cacheTimeline(user.id, chatId, [{ ...optimistic, chat_id: chatId }]).catch(
         () => undefined
@@ -921,6 +952,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
         }),
         { createIfMissing: true }
       );
+      syncInboxPreview(confirmed);
       if (user?.id && chatId) {
         void cacheTimeline(user.id, chatId, [{ ...confirmed, chat_id: chatId }]).catch(
           () => undefined
@@ -995,6 +1027,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
       (previous) => ({ ...previous, messages: [...previous.messages, optimistic] }),
       { createIfMissing: true }
     );
+    syncInboxPreview(optimistic);
     if (user?.id && chatId) {
       void cacheTimeline(user.id, chatId, [{ ...optimistic, chat_id: chatId }]).catch(() => undefined);
     }
@@ -1016,6 +1049,7 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
         }),
         { createIfMissing: true }
       );
+      syncInboxPreview(confirmed);
       if (user?.id && chatId) {
         void cacheTimeline(user.id, chatId, [{ ...confirmed, chat_id: chatId }]).catch(() => undefined);
       }

--- a/apps/client/tests/inboxSentPreview.test.ts
+++ b/apps/client/tests/inboxSentPreview.test.ts
@@ -1,0 +1,122 @@
+import { QueryClient, type InfiniteData } from '@tanstack/react-query';
+import {
+  inboxQueryKey,
+  patchInboxRealtimeMessage,
+  type InboxMessage,
+} from '../hooks/useInboxMessages';
+import { Platform } from '../types/platform';
+
+jest.mock('../services/mobile-cache', () => ({
+  usesNativeMobileCache: () => false,
+  cacheTimeline: jest.fn(async () => undefined),
+  cachedTimeline: jest.fn(async () => []),
+}));
+
+const USER = 'user-1';
+const CHAT = 'chat-1';
+
+type Page = { messages: InboxMessage[]; hasMore: boolean; nextCursor: null };
+
+const row = (over: Partial<InboxMessage> = {}): InboxMessage => ({
+  id: 'server-1',
+  conversation_key: `${Platform.WHATSAPP}:${CHAT}`,
+  chat_id: CHAT,
+  chat_name: 'Lucas',
+  contact_name: 'Lucas',
+  content: 'their older message',
+  timestamp: '2026-08-26T10:00:00.000Z',
+  from_me: false,
+  is_group: false,
+  platform: Platform.WHATSAPP,
+  unread_count: 0,
+  ...over,
+});
+
+function seed(qc: QueryClient, messages: InboxMessage[]) {
+  qc.setQueryData<InfiniteData<Page>>(inboxQueryKey(USER, '', 'all', 'all'), {
+    pages: [{ messages, hasMore: false, nextCursor: null }],
+    pageParams: [null],
+  });
+}
+
+const feed = (qc: QueryClient) =>
+  qc.getQueryData<InfiniteData<Page>>(inboxQueryKey(USER, '', 'all', 'all'))!.pages[0].messages;
+
+describe('inbox preview after sending', () => {
+  it('shows the sent message immediately, without waiting for the bridge round trip', () => {
+    // The send endpoint never writes a messages row — it lands only when the
+    // platform echoes back through Matrix. Without this patch the subtitle
+    // keeps showing the previous message for as long as that takes.
+    const qc = new QueryClient();
+    seed(qc, [row()]);
+
+    patchInboxRealtimeMessage(qc, USER, {
+      id: 'optimistic-1',
+      chat_id: CHAT,
+      content: 'what I just sent',
+      timestamp: '2026-08-26T10:05:00.000Z',
+      from_me: true,
+      is_group: false,
+      platform: Platform.WHATSAPP,
+      contact_name: 'Lucas',
+    });
+
+    expect(feed(qc)[0].content).toBe('what I just sent');
+    expect(feed(qc)[0].from_me).toBe(true);
+  });
+
+  it('reconciles to the real row without duplicating the conversation', () => {
+    const qc = new QueryClient();
+    seed(qc, [row()]);
+    const sent = {
+      chat_id: CHAT,
+      content: 'what I just sent',
+      from_me: true,
+      is_group: false,
+      platform: Platform.WHATSAPP,
+      contact_name: 'Lucas',
+    };
+    patchInboxRealtimeMessage(qc, USER, { ...sent, id: 'optimistic-1', timestamp: '2026-08-26T10:05:00.000Z' });
+    // The bridge echo arrives with the durable id.
+    patchInboxRealtimeMessage(qc, USER, { ...sent, id: 'server-9', timestamp: '2026-08-26T10:05:01.000Z' });
+
+    expect(feed(qc)).toHaveLength(1);
+    expect(feed(qc)[0].id).toBe('server-9');
+    expect(feed(qc)[0].content).toBe('what I just sent');
+  });
+
+  it('does not inflate the unread count for a message the user sent', () => {
+    const qc = new QueryClient();
+    seed(qc, [row({ unread_count: 3 })]);
+    patchInboxRealtimeMessage(qc, USER, {
+      id: 'optimistic-1',
+      chat_id: CHAT,
+      content: 'mine',
+      timestamp: '2026-08-26T10:05:00.000Z',
+      from_me: true,
+      platform: Platform.WHATSAPP,
+    });
+    expect(feed(qc)[0].unread_count).toBe(3);
+  });
+
+  it('moves the conversation to the top of the feed', () => {
+    const qc = new QueryClient();
+    const other = row({
+      id: 'other-1',
+      chat_id: 'chat-2',
+      conversation_key: `${Platform.WHATSAPP}:chat-2`,
+      chat_name: 'Someone else',
+      timestamp: '2026-08-26T10:04:00.000Z',
+    });
+    seed(qc, [other, row()]);
+    patchInboxRealtimeMessage(qc, USER, {
+      id: 'optimistic-1',
+      chat_id: CHAT,
+      content: 'mine',
+      timestamp: '2026-08-26T10:05:00.000Z',
+      from_me: true,
+      platform: Platform.WHATSAPP,
+    });
+    expect(feed(qc)[0].chat_id).toBe(CHAT);
+  });
+});


### PR DESCRIPTION
## Why

Sending a message and going back to the inbox often left the conversation still showing the *previous* message.

The cause is server-side, not in the client. `POST /platforms/:platform/send` (`apps/server/src/routes/platforms.ts:1184`) hands the message to the adapter and returns — **it never writes a `messages` row**. The row is only created when the platform echoes the message back through Matrix into the bridge handler in `apps/server/src/index.ts`.

The inbox subtitle is driven entirely by that row's realtime INSERT, so the chain is:

```
send → Matrix → WhatsApp → echo back → mautrix → Synapse → server → row insert → realtime → inbox patch
```

The subtitle cannot update until that full round trip completes, and its latency varies — which is why it looked correct sometimes and stale other times.

The transcript never showed the problem because it has an optimistic bubble. The inbox had no equivalent.

## What

Patch the cached inbox preview on send, the same way the timeline already does, and let the realtime row reconcile the id when it lands. Matching is by *conversation*, not by message, so the echo updates the same row rather than adding a second one.

Wired into both send paths (text and media/voice), on the optimistic write and again on confirmation.

## Tests

Four cases in `apps/client/tests/inboxSentPreview.test.ts`: the preview updates immediately, the bridge echo reconciles to the durable id without duplicating the conversation, a sent message does not inflate the unread count, and the conversation moves to the top of the feed.

## Not verified end to end

The cache logic is unit-tested and the wiring typechecks, but this has **not** been exercised on a device — doing so means sending a real message from a real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)