### PR TITLE
Let the client see that platforms support reactions

### DIFF
--- a/apps/server/src/routes/platform-capabilities.test.ts
+++ b/apps/server/src/routes/platform-capabilities.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+import { clientCapabilities } from './platforms';
+import type { PlatformCapabilities } from '../adapters';
+
+const capabilities = (over: Partial<PlatformCapabilities> = {}): PlatformCapabilities => ({
+  canSendText: true,
+  canSendMedia: true,
+  canSendStickers: true,
+  canSendVoice: true,
+  canSendLocation: true,
+  canCreateGroups: true,
+  canReadReceipts: true,
+  canEditMessages: false,
+  canDeleteMessages: true,
+  canReactToMessages: true,
+  canReplyToMessages: true,
+  maxMessageLength: 4096,
+  supportedMediaTypes: [],
+  ...over,
+});
+
+const adapter = (over: Partial<PlatformCapabilities> = {}) => ({
+  capabilities: capabilities(over),
+  sendReaction: () => undefined,
+});
+
+/** An adapter that declares the capability but never implements the method. */
+const adapterWithoutSendReaction = (over: Partial<PlatformCapabilities> = {}) => ({
+  capabilities: capabilities(over),
+});
+
+describe('clientCapabilities', () => {
+  it('exposes canReactToMessages under the name the clients actually read', () => {
+    // The whole reaction feature was invisible because the adapter shape was
+    // returned verbatim: the client reads capabilities.canSendReactions, which
+    // was always undefined, so the picker treated every platform as incapable.
+    expect(clientCapabilities(adapter({ canReactToMessages: true })).canSendReactions).toBe(true);
+    expect(clientCapabilities(adapter({ canReactToMessages: false })).canSendReactions).toBe(false);
+  });
+
+  it('does not advertise reactions when the adapter cannot actually send one', () => {
+    // The endpoint gates on canReactToMessages AND sendReaction. Advertising
+    // the capability without the method would offer a picker whose every tap
+    // comes back 400.
+    expect(
+      clientCapabilities(adapterWithoutSendReaction({ canReactToMessages: true })).canSendReactions,
+    ).toBe(false);
+  });
+
+  it('does not leak the internal capability names onto the wire', () => {
+    const wire = clientCapabilities(adapter()) as Record<string, unknown>;
+    for (const internalOnly of ['canReactToMessages', 'canCreateGroups', 'canSendLocation', 'maxMessageLength', 'supportedMediaTypes']) {
+      expect(internalOnly in wire).toBe(false);
+    }
+  });
+
+  it('emits exactly the fields the client contract declares', () => {
+    // Guards the drift in both directions: a field added on the client without
+    // a mapping here, or one removed here while the client still reads it.
+    expect(Object.keys(clientCapabilities(adapter())).sort()).toEqual([
+      'canDeleteMessages',
+      'canEditMessages',
+      'canReadReceipts',
+      'canReplyToMessages',
+      'canSendMedia',
+      'canSendReactions',
+      'canSendStickers',
+      'canSendText',
+      'canSendVoice',
+      'supportsBroadcasts',
+      'supportsGroups',
+    ]);
+  });
+
+  it('carries the reply capability through unchanged', () => {
+    // Reply was the control case: it worked only because both sides spell it
+    // the same way. Keep it that way.
+    expect(clientCapabilities(adapter({ canReplyToMessages: false })).canReplyToMessages).toBe(false);
+  });
+});

--- a/apps/server/src/routes/platforms.ts
+++ b/apps/server/src/routes/platforms.ts
@@ -10,6 +10,7 @@ import {
   Platform,
   PlatformStatus,
   MessageContentType,
+  type PlatformCapabilities,
 } from '../adapters';
 import { MatrixBridgeAdapter } from '../adapters/matrix';
 import { platformConfig } from '../config';
@@ -198,6 +199,44 @@ router.post('/:platform/interest', async (req: Request, res: Response) => {
  * GET /platforms
  * List all available platforms and their status
  */
+/**
+ * Translate an adapter's capabilities into the shape the clients consume.
+ *
+ * These are two different vocabularies for the same facts, and returning the
+ * adapter object verbatim silently disabled every feature whose name happened
+ * not to match. `canReactToMessages` is `canSendReactions` on the client, so
+ * the reaction picker read `undefined`, treated every platform as incapable,
+ * and never offered a reaction — even though the adapter, the endpoint and the
+ * persistence behind it were all fully implemented. Reply escaped the bug only
+ * because `canReplyToMessages` is spelled the same on both sides.
+ *
+ * Mapping field by field keeps the contract in one place, so the next rename is
+ * a compile error here rather than a feature that quietly stops appearing.
+ */
+export function clientCapabilities(adapter: { capabilities: PlatformCapabilities; sendReaction?: unknown }) {
+  const capabilities = adapter.capabilities;
+  return {
+    canSendText: capabilities.canSendText,
+    canSendMedia: capabilities.canSendMedia,
+    canSendVoice: capabilities.canSendVoice,
+    canSendStickers: capabilities.canSendStickers,
+    // Both halves, because the reaction endpoint gates on both. Three adapters
+    // advertise canReactToMessages without implementing sendReaction; that is
+    // harmless while PLATFORM_MODE=matrix routes them all through the bridge
+    // adapter, but the moment one is served directly the picker would offer a
+    // reaction the endpoint answers with 400. Advertise only what works.
+    canSendReactions: capabilities.canReactToMessages && typeof adapter.sendReaction === 'function',
+    canReplyToMessages: capabilities.canReplyToMessages,
+    canReadReceipts: capabilities.canReadReceipts,
+    canDeleteMessages: capabilities.canDeleteMessages,
+    canEditMessages: capabilities.canEditMessages,
+    // The adapters track whether a group can be *created*, which is the closest
+    // fact available; neither of these is read by a client today.
+    supportsGroups: capabilities.canCreateGroups,
+    supportsBroadcasts: false,
+  };
+}
+
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const platforms = platformManager.getAvailablePlatforms();
@@ -208,7 +247,7 @@ router.get('/', async (_req: Request, res: Response) => {
         platform,
         enabled: platformConfig[platform as keyof typeof platformConfig]?.enabled ?? false,
         authMethod: adapter?.authMethod,
-        capabilities: adapter?.capabilities,
+        capabilities: adapter ? clientCapabilities(adapter) : undefined,
       };
     });
 
@@ -1049,16 +1088,27 @@ router.post(
 
       const startedAt = Date.now();
       const sent = await adapter.sendReaction(sessionId, chatId, messageId, emoji);
+      // Upsert, not insert. The duplicate check above runs before the bridge
+      // call, so the whole provider round trip sits inside the window — and the
+      // bridge echoes the reaction back through the normal ingest path, which
+      // writes this exact row. When the echo wins that race an insert violates
+      // message_reactions_user_id_message_id_reactor_id_emoji_key and the user
+      // sees a raw Postgres constraint error for a reaction that in fact
+      // succeeded. Landing on the row the echo created is the correct outcome,
+      // and it carries our platform_event_id onto it.
       const { data: reaction, error: reactionError } = await supabase
         .from('message_reactions')
-        .insert({
-          user_id: userId,
-          message_id: target.id,
-          platform_event_id: sent.platformEventId,
-          emoji,
-          from_me: true,
-          reactor_id: 'self',
-        })
+        .upsert(
+          {
+            user_id: userId,
+            message_id: target.id,
+            platform_event_id: sent.platformEventId,
+            emoji,
+            from_me: true,
+            reactor_id: 'self',
+          },
+          { onConflict: 'user_id,message_id,reactor_id,emoji' }
+        )
         .select('*')
         .single();
       if (reactionError) throw reactionError;


### PR DESCRIPTION
## Why

Reactions could not be applied to any message on any platform. Long-pressing a message offered only **Reply** and **Copy**.

The feature was not unfinished — it was unreachable. `MatrixBridgeAdapter.sendReaction`, the `POST /platforms/:platform/reactions` endpoint, its validation, its dedupe and its persistence into `message_reactions` were all already implemented and working.

The break is a contract mismatch. `GET /platforms` returned the adapter's capability object **verbatim**:

```ts
capabilities: adapter?.capabilities,
```

The adapter calls the field `canReactToMessages`. The client's `PlatformCapabilities` declares `canSendReactions`, and both the picker and `handleReact` gate on it. So it was always `undefined`, and every platform looked incapable.

There is a clean control in the same UI: **Reply worked**, because `canReplyToMessages` happens to be spelled identically on both sides.

## What

**Map capabilities field by field** into the client contract instead of leaking the adapter shape, so a rename on either side becomes a compile error here rather than a feature that silently stops appearing.

The mapped flag also requires the adapter to actually implement `sendReaction`, matching the endpoint's own gate. Three adapters (`whatsapp`, `telegram`, `instagram`) declare `canReactToMessages: true` without the method — harmless while `PLATFORM_MODE=matrix` routes them all through the bridge adapter, but otherwise the picker would offer a reaction the endpoint answers with 400.

**Make the reaction write idempotent.** The duplicate check runs *before* the bridge call, so the entire provider round trip sits inside the window — and the bridge echoes the reaction back through the normal ingest path, which writes the same row. When the echo won that race, the insert violated `message_reactions_user_id_message_id_reactor_id_emoji_key` and surfaced a raw Postgres constraint error to the user for a reaction that had actually succeeded. Observed on device during verification.

## Verified on device

With the capability flag forced open locally to simulate this fix, against the deployed server:

- the six quick reactions appeared in the message actions sheet, where before there was only Reply and Copy
- tapping 😂 applied it to the message and it rendered on the bubble
- the duplicate-key error above appeared, which is what led to the second fix

## Coverage

WhatsApp, Telegram and Instagram all route through the Matrix bridge adapter, which implements `sendReaction` — so all three gain reactions. **iMessage does not**: it declares `canReactToMessages: false` and has no `sendReaction`. Tapbacks would need separate adapter work.

## Note

`bun test` in `apps/server` has a pre-existing intermittent failure — roughly 1 run in 10, only with coverage enabled, and not reproducible in 13 targeted runs. Unrelated to this change (this route sits at ~5% coverage), but worth chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)