### PR TITLE
Stop raw server errors reaching the chat

### DIFF
--- a/apps/client/services/api-errors.ts
+++ b/apps/client/services/api-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * What the user is allowed to read from a failed request.
+ *
+ * Trust is decided by status, not by inspecting the text. A 4xx is the server
+ * deliberately telling the person something — a validation failure, a
+ * disconnected session, an unsupported capability — and that copy is written
+ * for them. A 5xx means something broke, and its message is written for whoever
+ * reads the logs: it has carried a database constraint name into the chat
+ * composer before. Never show that, whatever it says.
+ *
+ * This is the backstop, not the control. The server is responsible for keeping
+ * internal detail out of a response body in the first place; this exists so that
+ * when an endpoint gets it wrong the failure mode is a vague message rather than
+ * a leak.
+ *
+ * Structural rather than typed against AxiosError so it stays free of axios —
+ * which cannot be imported under the test environment.
+ */
+export interface FailedRequest {
+  response?: { status?: number; data?: { error?: string; message?: string } };
+}
+
+export const GENERIC_SERVER_ERROR = 'Something went wrong on our end. Please try again.';
+export const GENERIC_REQUEST_ERROR = 'Something went wrong. Please try again.';
+export const UNREACHABLE_ERROR = 'Could not reach Claire. Check your connection and try again.';
+
+export function clientSafeMessage(error: FailedRequest): string {
+  const status = error.response?.status;
+  const body = error.response?.data?.error || error.response?.data?.message;
+
+  if (status !== undefined && status >= 500) {
+    // Keep the real text reachable while developing, but never render it.
+    if (body) console.warn('[api] server error detail (not shown to user):', body);
+    return GENERIC_SERVER_ERROR;
+  }
+
+  // No response at all: the request never completed.
+  if (status === undefined) return UNREACHABLE_ERROR;
+
+  return body || GENERIC_REQUEST_ERROR;
+}

--- a/apps/client/services/platforms.ts
+++ b/apps/client/services/platforms.ts
@@ -7,6 +7,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { supabase } from './supabase';
+import { clientSafeMessage } from './api-errors';
 import {
   Platform,
   PlatformStatus,
@@ -104,6 +105,7 @@ api.interceptors.request.use(async (config) => {
   return config;
 });
 
+
 // Handle response errors
 api.interceptors.response.use(
   (response) => response,
@@ -118,12 +120,7 @@ api.interceptors.response.use(
       }
     }
 
-    const message = error.response?.data?.error
-      || error.response?.data?.message
-      || error.message
-      || 'An unexpected error occurred';
-
-    return Promise.reject(new Error(message));
+    return Promise.reject(new Error(clientSafeMessage(error)));
   }
 );
 

--- a/apps/client/tests/clientSafeMessage.test.ts
+++ b/apps/client/tests/clientSafeMessage.test.ts
@@ -1,0 +1,45 @@
+import {
+  clientSafeMessage,
+  GENERIC_REQUEST_ERROR,
+  GENERIC_SERVER_ERROR,
+  type FailedRequest,
+} from '../services/api-errors';
+
+const failure = (status: number | undefined, body?: { error?: string; message?: string }): FailedRequest => ({
+  response: status === undefined ? undefined : { status, data: body ?? {} },
+});
+
+describe('clientSafeMessage', () => {
+  it('never surfaces a 5xx body, however specific it looks', () => {
+    // The exact string that reached the chat composer during reaction testing.
+    const leak =
+      'duplicate key value violates unique constraint "message_reactions_user_id_message_id_reactor_id_emoji_key"';
+    const shown = clientSafeMessage(failure(500, { error: leak }));
+    expect(shown).not.toContain('duplicate key');
+    expect(shown).not.toContain('message_reactions');
+    expect(shown).toBe(GENERIC_SERVER_ERROR);
+  });
+
+  it('suppresses 5xx detail even when the server used the message field', () => {
+    expect(clientSafeMessage(failure(503, { message: 'ECONNREFUSED 10.0.0.4:5432' }))).not.toContain(
+      'ECONNREFUSED',
+    );
+  });
+
+  it('relays a 4xx body, which the server wrote for the person', () => {
+    expect(clientSafeMessage(failure(400, { error: 'Session not connected' }))).toBe(
+      'Session not connected',
+    );
+    expect(clientSafeMessage(failure(404, { error: 'Conversation not found' }))).toBe(
+      'Conversation not found',
+    );
+  });
+
+  it('falls back when a 4xx carries no body', () => {
+    expect(clientSafeMessage(failure(400))).toBe(GENERIC_REQUEST_ERROR);
+  });
+
+  it('explains a request that never reached the server', () => {
+    expect(clientSafeMessage(failure(undefined))).toContain('Check your connection');
+  });
+});

--- a/apps/server/src/routes/platform-capabilities.test.ts
+++ b/apps/server/src/routes/platform-capabilities.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+import { clientCapabilities } from './platforms';
+import type { PlatformCapabilities } from '../adapters';
+
+const capabilities = (over: Partial<PlatformCapabilities> = {}): PlatformCapabilities => ({
+  canSendText: true,
+  canSendMedia: true,
+  canSendStickers: true,
+  canSendVoice: true,
+  canSendLocation: true,
+  canCreateGroups: true,
+  canReadReceipts: true,
+  canEditMessages: false,
+  canDeleteMessages: true,
+  canReactToMessages: true,
+  canReplyToMessages: true,
+  maxMessageLength: 4096,
+  supportedMediaTypes: [],
+  ...over,
+});
+
+const adapter = (over: Partial<PlatformCapabilities> = {}) => ({
+  capabilities: capabilities(over),
+  sendReaction: () => undefined,
+});
+
+/** An adapter that declares the capability but never implements the method. */
+const adapterWithoutSendReaction = (over: Partial<PlatformCapabilities> = {}) => ({
+  capabilities: capabilities(over),
+});
+
+describe('clientCapabilities', () => {
+  it('exposes canReactToMessages under the name the clients actually read', () => {
+    // The whole reaction feature was invisible because the adapter shape was
+    // returned verbatim: the client reads capabilities.canSendReactions, which
+    // was always undefined, so the picker treated every platform as incapable.
+    expect(clientCapabilities(adapter({ canReactToMessages: true })).canSendReactions).toBe(true);
+    expect(clientCapabilities(adapter({ canReactToMessages: false })).canSendReactions).toBe(false);
+  });
+
+  it('does not advertise reactions when the adapter cannot actually send one', () => {
+    // The endpoint gates on canReactToMessages AND sendReaction. Advertising
+    // the capability without the method would offer a picker whose every tap
+    // comes back 400.
+    expect(
+      clientCapabilities(adapterWithoutSendReaction({ canReactToMessages: true })).canSendReactions,
+    ).toBe(false);
+  });
+
+  it('does not leak the internal capability names onto the wire', () => {
+    const wire = clientCapabilities(adapter()) as Record<string, unknown>;
+    for (const internalOnly of ['canReactToMessages', 'canCreateGroups', 'canSendLocation', 'maxMessageLength', 'supportedMediaTypes']) {
+      expect(internalOnly in wire).toBe(false);
+    }
+  });
+
+  it('emits exactly the fields the client contract declares', () => {
+    // Guards the drift in both directions: a field added on the client without
+    // a mapping here, or one removed here while the client still reads it.
+    expect(Object.keys(clientCapabilities(adapter())).sort()).toEqual([
+      'canDeleteMessages',
+      'canEditMessages',
+      'canReadReceipts',
+      'canReplyToMessages',
+      'canSendMedia',
+      'canSendReactions',
+      'canSendStickers',
+      'canSendText',
+      'canSendVoice',
+      'supportsBroadcasts',
+      'supportsGroups',
+    ]);
+  });
+
+  it('carries the reply capability through unchanged', () => {
+    // Reply was the control case: it worked only because both sides spell it
+    // the same way. Keep it that way.
+    expect(clientCapabilities(adapter({ canReplyToMessages: false })).canReplyToMessages).toBe(false);
+  });
+});

--- a/apps/server/src/routes/platforms.ts
+++ b/apps/server/src/routes/platforms.ts
@@ -21,6 +21,7 @@ import { loginWithCredentials, submitTwoFactorCode } from '../services/instagram
 import { platformCatalog, platformCatalogVersion } from '../platform-catalog';
 import { supabase, type DbRow } from '../services/supabase';
 import { operationsTelemetry } from '../services/operations-telemetry';
+import { respondWithError } from '../utils/api-error';
 import { queueWhatsAppContactIdentitySync } from '../services/whatsapp-contact-backfill';
 
 // Railway services cannot reach each other through localhost. Railway does not
@@ -1124,10 +1125,9 @@ router.post(
       });
       return res.json({ success: true, reaction });
     } catch (error) {
-      logger.error('Error sending message reaction:', error);
-      return res.status(500).json({
-        success: false,
-        error: (error as Error).message || 'Failed to send reaction',
+      return respondWithError(res, error, {
+        logMessage: 'Error sending message reaction',
+        fallback: 'Could not add that reaction. Try again.',
       });
     }
   }
@@ -1221,8 +1221,10 @@ router.post(
         throw error;
       }
     } catch (error) {
-      logger.error('Error sending voice note:', error);
-      return res.status(500).json({ success: false, error: 'Failed to send voice note' });
+      return respondWithError(res, error, {
+        logMessage: 'Error sending voice note',
+        fallback: 'Could not send that voice note. Try again.',
+      });
     }
   }
 );
@@ -1354,10 +1356,9 @@ router.post('/:platform/send', async (req: Request, res: Response) => {
       throw error;
     }
   } catch (error) {
-    logger.error('Error sending message:', error);
-    return res.status(500).json({
-      success: false,
-      error: (error as Error).message || 'Failed to send message',
+    return respondWithError(res, error, {
+      logMessage: 'Error sending message',
+      fallback: 'Could not send that message. Try again.',
     });
   }
 });

--- a/apps/server/src/routes/platforms.ts
+++ b/apps/server/src/routes/platforms.ts
@@ -10,6 +10,7 @@ import {
   Platform,
   PlatformStatus,
   MessageContentType,
+  type PlatformCapabilities,
 } from '../adapters';
 import { MatrixBridgeAdapter } from '../adapters/matrix';
 import { platformConfig } from '../config';
@@ -198,6 +199,44 @@ router.post('/:platform/interest', async (req: Request, res: Response) => {
  * GET /platforms
  * List all available platforms and their status
  */
+/**
+ * Translate an adapter's capabilities into the shape the clients consume.
+ *
+ * These are two different vocabularies for the same facts, and returning the
+ * adapter object verbatim silently disabled every feature whose name happened
+ * not to match. `canReactToMessages` is `canSendReactions` on the client, so
+ * the reaction picker read `undefined`, treated every platform as incapable,
+ * and never offered a reaction — even though the adapter, the endpoint and the
+ * persistence behind it were all fully implemented. Reply escaped the bug only
+ * because `canReplyToMessages` is spelled the same on both sides.
+ *
+ * Mapping field by field keeps the contract in one place, so the next rename is
+ * a compile error here rather than a feature that quietly stops appearing.
+ */
+export function clientCapabilities(adapter: { capabilities: PlatformCapabilities; sendReaction?: unknown }) {
+  const capabilities = adapter.capabilities;
+  return {
+    canSendText: capabilities.canSendText,
+    canSendMedia: capabilities.canSendMedia,
+    canSendVoice: capabilities.canSendVoice,
+    canSendStickers: capabilities.canSendStickers,
+    // Both halves, because the reaction endpoint gates on both. Three adapters
+    // advertise canReactToMessages without implementing sendReaction; that is
+    // harmless while PLATFORM_MODE=matrix routes them all through the bridge
+    // adapter, but the moment one is served directly the picker would offer a
+    // reaction the endpoint answers with 400. Advertise only what works.
+    canSendReactions: capabilities.canReactToMessages && typeof adapter.sendReaction === 'function',
+    canReplyToMessages: capabilities.canReplyToMessages,
+    canReadReceipts: capabilities.canReadReceipts,
+    canDeleteMessages: capabilities.canDeleteMessages,
+    canEditMessages: capabilities.canEditMessages,
+    // The adapters track whether a group can be *created*, which is the closest
+    // fact available; neither of these is read by a client today.
+    supportsGroups: capabilities.canCreateGroups,
+    supportsBroadcasts: false,
+  };
+}
+
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const platforms = platformManager.getAvailablePlatforms();
@@ -208,7 +247,7 @@ router.get('/', async (_req: Request, res: Response) => {
         platform,
         enabled: platformConfig[platform as keyof typeof platformConfig]?.enabled ?? false,
         authMethod: adapter?.authMethod,
-        capabilities: adapter?.capabilities,
+        capabilities: adapter ? clientCapabilities(adapter) : undefined,
       };
     });
 
@@ -1049,16 +1088,27 @@ router.post(
 
       const startedAt = Date.now();
       const sent = await adapter.sendReaction(sessionId, chatId, messageId, emoji);
+      // Upsert, not insert. The duplicate check above runs before the bridge
+      // call, so the whole provider round trip sits inside the window — and the
+      // bridge echoes the reaction back through the normal ingest path, which
+      // writes this exact row. When the echo wins that race an insert violates
+      // message_reactions_user_id_message_id_reactor_id_emoji_key and the user
+      // sees a raw Postgres constraint error for a reaction that in fact
+      // succeeded. Landing on the row the echo created is the correct outcome,
+      // and it carries our platform_event_id onto it.
       const { data: reaction, error: reactionError } = await supabase
         .from('message_reactions')
-        .insert({
-          user_id: userId,
-          message_id: target.id,
-          platform_event_id: sent.platformEventId,
-          emoji,
-          from_me: true,
-          reactor_id: 'self',
-        })
+        .upsert(
+          {
+            user_id: userId,
+            message_id: target.id,
+            platform_event_id: sent.platformEventId,
+            emoji,
+            from_me: true,
+            reactor_id: 'self',
+          },
+          { onConflict: 'user_id,message_id,reactor_id,emoji' }
+        )
         .select('*')
         .single();
       if (reactionError) throw reactionError;

--- a/apps/server/src/utils/api-error.ts
+++ b/apps/server/src/utils/api-error.ts
@@ -1,0 +1,70 @@
+import { logger } from './logger';
+
+/**
+ * An error whose message is written for the person using the app.
+ *
+ * The default assumption for a thrown error is the opposite: `error.message`
+ * is written for whoever is reading the logs, and routinely carries database
+ * constraint names, table names, provider payloads and other internal detail.
+ * Returning that verbatim is both a poor experience and an information leak —
+ * a reaction that raced its own bridge echo once surfaced
+ * `duplicate key value violates unique constraint
+ * "message_reactions_user_id_message_id_reactor_id_emoji_key"` in the chat
+ * composer.
+ *
+ * So safety is opt-in, never inferred. Throw this when the text is genuinely
+ * meant for a person — a validation failure, a business rule, a provider
+ * result worth relaying — and let everything else fall back to a generic
+ * message.
+ */
+export class ClientFacingError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(message: string, options: { status?: number; code?: string } = {}) {
+    super(message);
+    this.name = 'ClientFacingError';
+    this.status = options.status ?? 400;
+    this.code = options.code;
+  }
+}
+
+export function isClientFacingError(error: unknown): error is ClientFacingError {
+  return error instanceof ClientFacingError;
+}
+
+interface ErrorResponseBody {
+  success: false;
+  error: string;
+  code?: string;
+}
+
+/**
+ * Log the real failure, return something safe.
+ *
+ * `fallback` is what an unexpected error becomes. Write it as advice to the
+ * person — what happened and whether retrying is worth it — not as a
+ * description of the internal fault.
+ */
+export function respondWithError(
+  res: { status: (code: number) => { json: (body: ErrorResponseBody) => unknown } },
+  error: unknown,
+  context: { fallback: string; logMessage: string; details?: Record<string, unknown> },
+): unknown {
+  // The full error only ever goes to the logs.
+  logger.error(context.logMessage, {
+    ...context.details,
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+
+  if (isClientFacingError(error)) {
+    return res.status(error.status).json({
+      success: false,
+      error: error.message,
+      ...(error.code ? { code: error.code } : {}),
+    });
+  }
+
+  return res.status(500).json({ success: false, error: context.fallback });
+}


### PR DESCRIPTION
> Stacked on #196 (both touch `platforms.ts`). Merge that first.

## Why

A reaction that raced its own bridge echo put this in the chat composer:

```
duplicate key value violates unique constraint
"message_reactions_user_id_message_id_reactor_id_emoji_key"
```

The path was unguarded end to end:

1. the route returned `error: (error as Error).message`
2. the axios interceptor took `data.error` verbatim into `new Error(message)`
3. the chat screen did `err.message` → `setSendError` → rendered it

Nothing along the way asked whether that text was meant for a person. It is both a poor experience and an information leak — constraint names, table names and provider payloads all reach the client the same way.

## What

Two independent layers, because one is a policy and the other is a backstop.

**Server — safety is opt-in.** `ClientFacingError` marks a message as written for a person; `respondWithError` logs the real failure and returns either that message or a generic fallback for anything unmarked. Applied to the three endpoints whose errors surface in the composer: send, voice, reactions.

Inferring safety was not an option. The Instagram login flow deliberately relays a *classified description* of the login page (`describeInstagramLoginPage`), so a blanket suppression would have regressed a working flow. Hence the explicit marker.

**Client — trust is decided by status, not by inspecting text.** A 4xx is the server deliberately telling the person something; a 5xx is written for whoever reads the logs and is never rendered, whatever it says. No heuristics to keep current. Extracted as a pure module (`services/api-errors.ts`) so it is testable without pulling axios into the jest environment.

## Tests

Five cases, including the exact string that reached the composer, asserting it is neither shown nor partially leaked; that a 4xx body is still relayed; and that a request which never reached the server explains itself.

## Deliberately not done

Twenty other routes still return raw `error.message`. They surface outside the chat and several relay provider text on purpose, so converting them needs the same case-by-case judgement rather than a sweep. The client-side status gate already covers all of them for 5xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)