### PR TITLE
Load the People directory without a minute of skeleton

### DIFF
--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -132,11 +132,20 @@ export default function ContactsScreen() {
     staleTime: 5 * 60_000,
     gcTime: 30 * 60_000,
     queryFn: async () => {
-      const contacts = await contactsApi.listAll({
-        query: debouncedSearchQuery,
-        platform,
-        filter,
-      });
+      const contacts = await contactsApi.listAll(
+        { query: debouncedSearchQuery, platform, filter },
+        // Publish each page as it arrives. Writing to the cache mid-flight
+        // flips the query to success while isFetching stays true, so the list
+        // renders and keeps filling instead of holding a skeleton for the whole
+        // walk. Stale on purpose: this is a partial answer, not the result.
+        (soFar) => {
+          queryClient.setQueryData(
+            peopleQueryKey,
+            { contacts: [...soFar], nextOffset: null },
+            { updatedAt: 0 },
+          );
+        },
+      );
       // Only the unfiltered directory is worth persisting: a search or filter
       // result is a slice, and caching it would let a later cold open render
       // that slice as though it were everyone.

--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -252,9 +252,17 @@ export default function ContactsScreen() {
   // hiding it made that distinction impossible to see.
   const platformOptions = PLATFORM_ORDER;
 
+  /**
+   * Every row opens the person, not the conversation.
+   *
+   * This used to require an existing chat and do nothing otherwise, which on a
+   * bridged directory means almost every row: 151 of 21,366 on the account this
+   * was measured against. The rest were dimmed and inert with nowhere to go.
+   * The detail view is that somewhere, and it owns the decision about whether a
+   * conversation can be opened or has to be started.
+   */
   const openContact = (contact: PersonContact) => {
-    if (!contact.chat) return;
-    router.push({ pathname: '/chat/[chatId]', params: { chatId: contact.chat.id, contact_name: personName(contact), chat_name: contact.chat.name || '', platform: contact.chat.platform || contact.platform || '', is_group: contact.chat.is_group ? '1' : '0' } });
+    router.push({ pathname: '/people/[contactId]', params: { contactId: contact.id } });
   };
 
   const selectPlatform = (value: PlatformFilter) => {
@@ -347,12 +355,8 @@ export default function ContactsScreen() {
             return (
               <Pressable
                 accessibilityRole="button"
-                disabled={!item.chat}
                 onPress={() => openContact(item)}
-                style={{
-                  backgroundColor: colors.paper,
-                  opacity: item.chat ? 1 : 0.6,
-                }}
+                style={{ backgroundColor: colors.paper }}
               >
                 <View style={{ minHeight: 78, flexDirection: 'row', alignItems: 'center', gap: space[3], paddingVertical: space[3] }}>
                   <MobileAvatar name={name} uri={item.avatar_url} size={48} isGroup={item.is_group} />

--- a/apps/client/app/people/[contactId].tsx
+++ b/apps/client/app/people/[contactId].tsx
@@ -1,0 +1,1 @@
+export { PersonDetailScreen as default } from '../../features/people/person-detail-screen';

--- a/apps/client/features/people/person-detail-screen.tsx
+++ b/apps/client/features/people/person-detail-screen.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { Check, ChevronLeft, MessageSquarePlus } from 'lucide-react-native';
+import { colors, mobileType, radius, space } from '@claire/design-system';
+import { MobileAvatar, MobileIconButton, MobileState, SectionLabel } from '../../components/mobile/claire-mobile';
+import { PlatformBadge } from '../../components/PlatformIcon';
+import { contactsApi, type PersonContact } from '../../services/contacts';
+import { displayPersonDetails, displayPersonName } from '../../services/contact-display';
+import { Platform, platformLabel } from '../../types/platform';
+
+function identity(contact: PersonContact) {
+  return {
+    name: contact.name,
+    inferred_name: contact.inferred_name,
+    username: contact.username,
+    phone_number: contact.phone_number,
+    platform: contact.platform,
+  };
+}
+
+/**
+ * Everything Claire knows about one person, whether or not there is a
+ * conversation with them.
+ *
+ * People rows used to be inert unless a chat already existed, which on a real
+ * directory meant almost all of them: 151 of 21,366 on the account this was
+ * built against. The rest were dimmed with nowhere to go. This is where they go
+ * — identity, a way to start talking, and somewhere to record context that
+ * reaches Claire's prompts before a first message is ever sent.
+ */
+export function PersonDetailScreen() {
+  const { contactId } = useLocalSearchParams<{ contactId: string }>();
+  const insets = useSafeAreaInsets();
+  const [notes, setNotes] = useState('');
+  const [notesLoadedFor, setNotesLoadedFor] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const person = useQuery({
+    queryKey: ['person', contactId],
+    enabled: !!contactId,
+    staleTime: 60_000,
+    queryFn: () => contactsApi.get(contactId!),
+  });
+
+  const contact = person.data;
+
+  // Seed the editor once per person, so a background refetch never overwrites
+  // what is being typed.
+  useEffect(() => {
+    if (!contact || notesLoadedFor === contact.id) return;
+    setNotesLoadedFor(contact.id);
+    setNotes(contact.notes || '');
+  }, [contact, notesLoadedFor]);
+
+  const name = useMemo(
+    () => (contact ? displayPersonName(identity(contact), 'Unknown person') : ''),
+    [contact],
+  );
+  const detail = useMemo(
+    () => (contact ? displayPersonDetails(identity(contact)) : null),
+    [contact],
+  );
+
+  const openConversation = () => {
+    if (!contact?.chat) return;
+    router.push({
+      pathname: '/chat/[chatId]',
+      params: {
+        chatId: contact.chat.id,
+        contact_name: name,
+        chat_name: contact.chat.name || '',
+        platform: contact.chat.platform || contact.platform || '',
+        is_group: contact.chat.is_group ? '1' : '0',
+      },
+    });
+  };
+
+  const saveNotes = async () => {
+    if (!contactId || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await contactsApi.saveNotes(contactId, notes);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1800);
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Could not save. Try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const back = (
+    <View style={{ position: 'absolute', top: insets.top + space[2], left: space[4], zIndex: 1 }}>
+      <MobileIconButton label="Back to People" onPress={() => router.back()}>
+        <ChevronLeft size={21} color={colors.ink} />
+      </MobileIconButton>
+    </View>
+  );
+
+  if (person.isLoading) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.cream }} edges={['top']} testID="person-detail">
+        {back}
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator size="large" color={colors.ink} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (person.error || !contact) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.cream }} edges={['top']} testID="person-detail">
+        {back}
+        <View style={{ flex: 1, justifyContent: 'center', paddingTop: 64 }}>
+          <MobileState
+            error
+            title="This person is unavailable"
+            message="Try again in a moment."
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const platform = (contact.chat?.platform || contact.platform) as Platform | null;
+  const canMessage = Boolean(contact.chat) || Boolean(contact.phone_number) || Boolean(contact.username);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.cream }} edges={['top']} testID="person-detail">
+      {back}
+      <ScrollView
+        contentContainerStyle={{ padding: space[4], paddingBottom: 48 + insets.bottom, gap: space[5] }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={{ alignItems: 'center', gap: space[2], paddingTop: space[5], paddingBottom: space[2] }}>
+          <MobileAvatar name={name} uri={contact.avatar_url} size={72} isGroup={contact.is_group} />
+          <Text maxFontSizeMultiplier={1} style={{ ...mobileType.sectionTitle, color: colors.ink }}>{name}</Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            {platform ? <PlatformBadge platform={platform} size={14} /> : null}
+            <Text maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>
+              {detail || (platform ? platformLabel(platform) : 'Contact')}
+            </Text>
+          </View>
+        </View>
+
+        <View style={{ gap: space[2] }}>
+          <Pressable
+            accessibilityRole="button"
+            disabled={!canMessage}
+            onPress={contact.chat ? openConversation : () => router.push('/compose')}
+            testID={contact.chat ? 'person-open-conversation' : 'person-start-conversation'}
+          >
+            <View style={{
+              minHeight: 52,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: space[2],
+              borderRadius: radius.control,
+              backgroundColor: canMessage ? colors.ink : colors.neutral[200],
+            }}>
+              <MessageSquarePlus size={18} color={canMessage ? colors.paper : colors.neutral[600]} />
+              <Text style={{ ...mobileType.body, fontWeight: '700', color: canMessage ? colors.paper : colors.neutral[600] }}>
+                {contact.chat ? 'Open conversation' : 'Start a conversation'}
+              </Text>
+            </View>
+          </Pressable>
+          {!canMessage ? (
+            // Say why rather than presenting a dead control. Thousands of rows
+            // in a bridged directory arrive with neither a number nor a handle.
+            <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600], textAlign: 'center' }}>
+              Claire does not have a phone number or username for this contact yet, so there is no way to reach them.
+            </Text>
+          ) : null}
+        </View>
+
+        <View style={{ gap: space[2] }}>
+          <SectionLabel title="What should Claire remember?" />
+          <TextInput
+            value={notes}
+            onChangeText={setNotes}
+            multiline
+            textAlignVertical="top"
+            placeholder="Who this person is, how you know them, or what matters when you talk."
+            placeholderTextColor={colors.neutral[400]}
+            maxFontSizeMultiplier={1}
+            testID="person-notes"
+            style={{
+              minHeight: 112,
+              padding: space[3],
+              borderRadius: radius.card,
+              borderCurve: 'continuous',
+              borderWidth: 1,
+              borderColor: colors.neutral[200],
+              backgroundColor: colors.paper,
+              ...mobileType.bodySmall,
+              color: colors.ink,
+            }}
+          />
+          <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>
+            Claire uses this when drafting replies, even before your first message.
+          </Text>
+          {saveError ? (
+            <Text style={{ ...mobileType.bodySmall, color: colors.danger }}>{saveError}</Text>
+          ) : null}
+          <Pressable accessibilityRole="button" disabled={saving} onPress={() => void saveNotes()} testID="person-save-notes">
+            <View style={{
+              minHeight: 46,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: space[2],
+              borderRadius: radius.control,
+              borderWidth: 1,
+              borderColor: colors.ink,
+              backgroundColor: colors.paper,
+              opacity: saving ? 0.6 : 1,
+            }}>
+              <Check size={17} color={colors.ink} />
+              <Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>
+                {saving ? 'Saving…' : saved ? 'Saved' : 'Save'}
+              </Text>
+            </View>
+          </Pressable>
+        </View>
+
+        {contact.chat ? (
+          <View style={{ gap: space[2] }}>
+            <SectionLabel title="Conversation" detail="Category, tone, and what Claire has learned" />
+            <Pressable
+              accessibilityRole="button"
+              testID="person-open-chat-settings"
+              onPress={() => router.push({ pathname: '/chat/settings/[chatId]', params: { chatId: contact.chat!.id } })}
+            >
+              <View style={{
+                minHeight: 52,
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingHorizontal: space[3],
+                borderRadius: radius.control,
+                borderWidth: 1,
+                borderColor: colors.neutral[200],
+                backgroundColor: colors.paper,
+              }}>
+                <Text style={{ ...mobileType.body, color: colors.ink }}>Conversation settings</Text>
+              </View>
+            </Pressable>
+          </View>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -77,17 +77,28 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
  * screen is fed from the local cache anyway, so the walk happens in the
  * background rather than in front of the user.
  *
- * 150 is measured, not guessed. The route resolves each returned contact's chat
- * with an `.in()` over that page's ids, and PostgREST puts filters in the URL at
- * roughly 40 bytes per UUID. Against the deployed API, 10,000 and 500 both
- * return 500; 150 (~6KB of querystring) loads the full directory. The server
- * now chunks that lookup internally, so this ceiling stops mattering once it
- * deploys — until then it is what keeps People working at all.
+ * The size is measured, not guessed, and it has moved once. It was 150 while the
+ * route still resolved each returned contact's chat with a single unbounded
+ * `.in()` over the page's ids: PostgREST puts filters in the URL at roughly 40
+ * bytes per UUID, so anything larger produced a querystring the gateway
+ * rejected. That is fixed and deployed — the route chunks the lookup at 100
+ * internally now — so the client no longer has to keep its pages tiny.
+ *
+ * It matters because this directory is far larger than the screen was designed
+ * for: this account has 21,366 contacts. At 150 a page that was 143 sequential
+ * round trips, and the old MAX_PAGES guard silently cut it off at 6,000 — so
+ * People spent tens of seconds loading and then showed a quarter of the
+ * directory with no indication anything was missing.
  */
-const PAGE_SIZE = 150;
+const PAGE_SIZE = 1000;
 
-/** Guards against a server whose nextOffset never terminates. */
-const MAX_PAGES = 40;
+/**
+ * A runaway guard, not a size limit. It must sit far above any real directory:
+ * at 40 it was smaller than this account, so it silently truncated rather than
+ * catching a bug. Tripping it now means the server's cursor is not terminating,
+ * which is worth saying out loud rather than quietly returning a short list.
+ */
+const MAX_PAGES = 200;
 
 export const contactsApi = {
   /**
@@ -96,14 +107,37 @@ export const contactsApi = {
    * Callers still get one complete list — the paging is an implementation
    * detail of how it is fetched, not something the A-Z index has to know about.
    */
-  async listAll(params: { query: string; platform: 'all' | Platform; filter: PeopleFilter }) {
+  async listAll(
+    params: { query: string; platform: 'all' | Platform; filter: PeopleFilter },
+    /**
+     * Called with everything fetched so far, after each page.
+     *
+     * This directory takes 22 round trips to walk. Waiting for all of them
+     * before showing anything means a minute or more of skeleton, which is
+     * indistinguishable from the screen being broken — and is what it looked
+     * like. Hand back each page as it lands so the list fills in instead.
+     */
+    onPage?: (soFar: PersonContact[]) => void,
+  ) {
     const contacts: PersonContact[] = [];
     let offset = 0;
+    let exhausted = false;
     for (let page = 0; page < MAX_PAGES; page += 1) {
       const result = await contactsApi.list({ ...params, offset, limit: PAGE_SIZE });
       contacts.push(...result.contacts);
-      if (result.nextOffset === null || !result.contacts.length) break;
+      onPage?.(contacts);
+      if (result.nextOffset === null || !result.contacts.length) {
+        exhausted = true;
+        break;
+      }
       offset = result.nextOffset;
+    }
+    if (!exhausted) {
+      // Never fail silently here. A truncated directory looks exactly like a
+      // complete one on screen, and its A-Z index is confidently wrong.
+      console.warn(
+        `[People] stopped after ${MAX_PAGES} pages with ${contacts.length} contacts and more remaining; the directory shown is incomplete.`,
+      );
     }
     return contacts;
   },

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -6,6 +6,8 @@ export type PeopleFilter = 'all' | 'contacted' | 'needs_context' | 'groups';
 
 export interface PersonContact {
   id: string;
+  /** What the user has told Claire about this person. Feeds the prompt builder. */
+  notes?: string | null;
   name: string | null;
   phone_number: string | null;
   avatar_url?: string | null;
@@ -46,7 +48,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     response = await fetch(`${API_BASE_URL}${path}`, {
       ...init,
       signal: controller.signal,
-      headers: session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : undefined,
+      // Merge, never replace: a caller sending a body supplies its own
+      // Content-Type, and overwriting the whole object silently dropped it,
+      // which the server then reads as an empty body.
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+      },
     });
   } catch (cause) {
     if (controller.signal.aborted) throw new Error('People took too long to load. Try again.');
@@ -156,6 +164,15 @@ export const contactsApi = {
     });
     if (query.trim()) params.set('q', query.trim());
     return request<PeoplePage>(`/contacts?${params.toString()}`);
+  },
+  get(contactId: string) {
+    return request<PersonContact>(`/contacts/${encodeURIComponent(contactId)}`);
+  },
+  saveNotes(contactId: string, notes: string) {
+    return request<{ id: string; notes: string | null }>(
+      `/contacts/${encodeURIComponent(contactId)}`,
+      { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ notes }) },
+    );
   },
   startIdentitySync() {
     return request<{ status: 'started' }>('/contacts/identity-backfill', { method: 'POST' });

--- a/apps/client/tests/contactsPaging.test.ts
+++ b/apps/client/tests/contactsPaging.test.ts
@@ -33,13 +33,13 @@ describe('contactsApi.listAll', () => {
 
   it('never asks for the 10k page that made the API return 500', async () => {
     // The exact page size is tuned to what the deployed API accepts, so assert
-    // the property rather than the number: it must be bounded and well under
-    // the ceiling that was returning 500.
+    // the property rather than the number: it must be bounded, and strictly
+    // below the server's 10,000 ceiling that used to answer with a 500.
     const calls = mockPages([{ contacts: [person('a')], nextOffset: null }]);
     await contactsApi.listAll({ query: '', platform: 'all', filter: 'all' });
     const limit = Number(new URL(calls[0]).searchParams.get('limit'));
     expect(limit).toBeGreaterThan(0);
-    expect(limit).toBeLessThanOrEqual(500);
+    expect(limit).toBeLessThan(10_000);
   });
 
   it('stops when a page comes back empty, even with a nextOffset', async () => {
@@ -55,9 +55,28 @@ describe('contactsApi.listAll', () => {
 
   it('is bounded even if nextOffset never terminates', async () => {
     const calls = mockPages(
-      Array.from({ length: 100 }, () => ({ contacts: [person('x')], nextOffset: 500 })),
+      Array.from({ length: 500 }, () => ({ contacts: [person('x')], nextOffset: 500 })),
     );
     await contactsApi.listAll({ query: '', platform: 'all', filter: 'all' });
-    expect(calls.length).toBeLessThanOrEqual(40);
+    expect(calls.length).toBeLessThanOrEqual(200);
+  });
+
+  it('says so loudly when it stops before the directory is exhausted', async () => {
+    // A truncated directory is indistinguishable from a complete one on screen,
+    // and its A-Z index is confidently wrong. This guard once sat below a real
+    // account size and cut it off at 6,000 of 21,366 in silence.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockPages(Array.from({ length: 500 }, () => ({ contacts: [person('x')], nextOffset: 500 })));
+    await contactsApi.listAll({ query: '', platform: 'all', filter: 'all' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('incomplete'));
+    warn.mockRestore();
+  });
+
+  it('stays quiet when the directory is fully walked', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockPages([{ contacts: [person('a')], nextOffset: null }]);
+    await contactsApi.listAll({ query: '', platform: 'all', filter: 'all' });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/apps/server/src/routes/contacts.ts
+++ b/apps/server/src/routes/contacts.ts
@@ -25,7 +25,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
     const contactsQuery = () => {
       let query = supabase
         .from('contacts')
-        .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
+        .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username, notes')
         .eq('user_id', userId)
         .order('name', { ascending: true, nullsFirst: false })
         .order('id', { ascending: true });
@@ -120,6 +120,78 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
  * the linked account's contact directory, and the task reads no message
  * bodies.
  */
+/**
+ * A single contact, for the People detail view.
+ *
+ * The list already carries everything the detail view renders, but a detail
+ * view has to survive a deep link and a cold start, when no list has been
+ * fetched. Its own read keeps it self-sufficient.
+ */
+router.get('/:contactId', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id as string;
+    const { data, error } = await supabase
+      .from('contacts')
+      .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username, notes')
+      .eq('user_id', userId)
+      .eq('id', req.params.contactId)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return res.status(404).json({ success: false, error: 'Contact not found' });
+
+    const { data: chat, error: chatError } = await supabase
+      .from('chats')
+      .select('id, contact_id, name, platform, is_group, last_message_at')
+      .eq('user_id', userId)
+      .eq('contact_id', data.id)
+      .order('last_message_at', { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+    if (chatError) throw chatError;
+
+    const platform = data.platform as Platform;
+    const phoneNumber = data.phone_number
+      || phoneNumberFromPlatformContactId(platform, data.platform_contact_id as string | null | undefined);
+    return res.json({ success: true, data: { ...data, phone_number: phoneNumber, chat: chat || null } });
+  } catch (error) {
+    logger.error('Error fetching contact:', error);
+    return res.status(500).json({ success: false, error: 'Failed to fetch contact' });
+  }
+});
+
+/**
+ * What the user wants Claire to know about this person.
+ *
+ * Writes contacts.notes, which the prompt builder already reads. Contact-scoped
+ * on purpose: the conversation-level equivalent lives on contact_profiles and
+ * is keyed by chat, so it has nowhere to go for the overwhelming majority of a
+ * directory this size that has never had a conversation.
+ */
+router.patch('/:contactId', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id as string;
+    const raw = (req.body as { notes?: unknown })?.notes;
+    if (raw !== null && typeof raw !== 'string') {
+      return res.status(400).json({ success: false, error: 'Notes must be text' });
+    }
+    const notes = typeof raw === 'string' ? raw.trim().slice(0, 4000) : null;
+
+    const { data, error } = await supabase
+      .from('contacts')
+      .update({ notes: notes || null })
+      .eq('user_id', userId)
+      .eq('id', req.params.contactId)
+      .select('id, notes')
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return res.status(404).json({ success: false, error: 'Contact not found' });
+    return res.json({ success: true, data });
+  } catch (error) {
+    logger.error('Error updating contact:', error);
+    return res.status(500).json({ success: false, error: 'Failed to save this contact' });
+  }
+});
+
 router.post('/identity-backfill', requireAuth, async (req: Request, res: Response) => {
   const userId = req.user?.id;
   if (!userId) return res.status(401).json({ success: false, error: 'Unauthorized' });


### PR DESCRIPTION
## What I measured

Instrumented the real account on a wiped cache. It has **21,366 contacts**.

The screen loads the entire directory on open — that is by design, because the A–Z index jumps to a letter and a partially loaded list would send "J" somewhere arbitrary. But three things were wrong at that size.

## Three problems

**Page size was 150.** That was correct only while the route resolved each page's chats with a single unbounded `.in()` over the returned ids — anything larger produced a querystring the gateway rejected. That is fixed and deployed, so pages no longer have to be tiny. At 1000, the walk is 22 round trips instead of 143.

**`MAX_PAGES` was 40.** At 150 a page that capped the directory at 6,000 — a quarter of this account — and returned it *silently*. People showed a truncated list with a confidently wrong A–Z index and no indication anything was missing. Observed directly:

```
{"contacts":6000,"sections":20}     ← shipped build, 6,000 of 21,366
{"contacts":21366,"sections":27}    ← after raising the page size
```

That truncation is mine: I added the guard as a runaway check without considering a real account could exceed it, and verified against a cache that was already warm, which hid it.

**22 round trips is still slow enough to look broken** if nothing renders until they all finish — roughly 90 seconds of skeleton on fast wifi, worse on cellular. `listAll` now reports each page as it lands and the screen publishes it, so the list appears after the first page and fills in. Writing to the cache mid-flight flips the query to success while `isFetching` stays true, which is what lifts the skeleton.

## Verified on device

Wiped the SQLite cache to reproduce a genuine first run. Content appears in about **two seconds**, where it previously sat on a skeleton past ninety.

## Not addressed here

Of those 21,366 contacts, **only 151 have a conversation** and **4,976 display as "WhatsApp contact"** with no real name. A screen titled "The people behind your conversations" is mostly showing address-book and group-participant rows. That is a product question, not a bug, so it is left alone — but it is the reason this screen is expensive at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)