### PR TITLE
Make the renamed push-tokens migration safe to re-run

### DIFF
--- a/supabase/migrations/20260630000002_add_push_tokens.sql
+++ b/supabase/migrations/20260630000002_add_push_tokens.sql
@@ -1,5 +1,12 @@
 -- Push tokens: store Expo push notification tokens per user/device
-CREATE TABLE push_tokens (
+--
+-- Idempotent because this migration's version changed after it had already run.
+-- It previously shared 20260630000001 with add_message_snooze, so only one of
+-- the two was ever recorded; renaming it to ...0002 fixed the collision but
+-- left a file that a database has applied under a version it no longer claims.
+-- The next `supabase db push` will therefore try to run it again, and a plain
+-- CREATE TABLE would fail against any environment where push_tokens exists.
+CREATE TABLE IF NOT EXISTS push_tokens (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   token TEXT NOT NULL,
@@ -11,6 +18,7 @@ CREATE TABLE push_tokens (
 );
 
 ALTER TABLE push_tokens ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users manage own push_tokens" ON push_tokens;
 CREATE POLICY "Users manage own push_tokens" ON push_tokens FOR ALL USING (auth.uid() = user_id);
 
 -- Reload PostgREST schema cache


### PR DESCRIPTION
Follow-up to #162.

That PR was correct: `add_push_tokens.sql` shared version `20260630000001` with `add_message_snooze.sql`, so only one of the two was ever recorded as applied. Giving it a unique version fixes a real collision.

But renaming a migration that has **already run** leaves a file no database claims. The next `supabase db push` sees `20260630000002` as unapplied and runs it — and

```sql
CREATE TABLE push_tokens (...)
```

fails against every environment where `push_tokens` already exists, which is all of them.

This makes the second run a no-op instead of a failed deploy: `CREATE TABLE IF NOT EXISTS`, and the RLS policy dropped before it is recreated.

Worth knowing: Railway's start command is `bun run dist/index.js` with no migration step, so nothing ran automatically when #162 merged. The hazard is latent until someone next pushes migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)