### PR TITLE
feat: add profile-scoped workspaces

### DIFF
--- a/apps/client/app/(tabs)/contacts.tsx
+++ b/apps/client/app/(tabs)/contacts.tsx
@@ -5,6 +5,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { colors, mobileType, space, useIsDesktopLayout } from '@claire/design-system';
 import { useAuthStore } from '../../stores/authStore';
+import { useProfileStore } from '../../stores/profileStore';
 import { MobileAvatar, MobileChip, MobileHeader, MobileIconButton, MobileSearchField, MobileState } from '../../components/mobile/claire-mobile';
 import { BottomSheet } from '../../components/mobile/bottom-sheet';
 import { PlatformIcon, PlatformName } from '../../components/PlatformIcon';
@@ -101,6 +102,7 @@ export default function ContactsScreen() {
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
   const [showPlatformFilter, setShowPlatformFilter] = useState(false);
   const user = useAuthStore(state => state.user);
+  const profileId = useProfileStore(state => state.activeProfileId);
   const requestedIdentitySyncFor = useRef<string | null>(null);
   const peopleListRef = useRef<SectionList<PersonContact>>(null);
   const debouncedSearchQuery = useDebouncedValue(searchQuery);
@@ -110,8 +112,8 @@ export default function ContactsScreen() {
   }, [params.q, params.query]);
 
   const peopleQuery = useQuery({
-    queryKey: ['people', user?.id, debouncedSearchQuery, platform, filter],
-    enabled: !!user?.id,
+    queryKey: ['people', user?.id, profileId, debouncedSearchQuery, platform, filter],
+    enabled: !!user?.id && !!profileId,
     // The API and bridge sync share a 10k maximum. Loading that user-scoped
     // directory as one virtualized list is what makes an A–Z index truthful:
     // tapping J never jumps only within whichever page happened to be loaded.

--- a/apps/client/app/_layout.tsx
+++ b/apps/client/app/_layout.tsx
@@ -10,6 +10,7 @@ import { ClaireThemeProvider } from '@claire/design-system';
 import * as Sentry from '@sentry/react-native';
 import { useAuthStore } from '../stores/authStore';
 import { usePlatformStore } from '../stores/platformStore';
+import { useProfileStore } from '../stores/profileStore';
 import {
   addPushTokenRotationListener,
   getActiveNotificationChat,
@@ -86,6 +87,7 @@ export default function RootLayout() {
   const token = useAuthStore((state) => state.token);
   const initializePlatforms = usePlatformStore((state) => state.initialize);
   const fetchConnectedSessions = usePlatformStore((state) => state.fetchConnectedSessions);
+  const initializeProfiles = useProfileStore((state) => state.initialize);
 
   useEffect(() => {
     async function init() {
@@ -105,8 +107,12 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (!token) return;
-    void initializePlatforms();
     const userId = useAuthStore.getState().user?.id;
+    if (userId) {
+      void initializeProfiles(userId).then(() => initializePlatforms());
+    } else {
+      void initializePlatforms();
+    }
     if (userId) {
       // Native cache hydration happens before individual screens query. A
       // failed cache sync never blocks normal online Supabase behavior.
@@ -120,7 +126,7 @@ export default function RootLayout() {
       }
     });
     return () => subscription.remove();
-  }, [fetchConnectedSessions, initializePlatforms, token]);
+  }, [fetchConnectedSessions, initializePlatforms, initializeProfiles, token]);
 
   useEffect(() => {
     if (!token) return;
@@ -155,8 +161,10 @@ export default function RootLayout() {
   useEffect(() => {
     if (Platform.OS === 'web') return;
     const openNotification = (notification: Notifications.Notification) => {
-      const data = notification.request.content.data as { chatId?: unknown; messageId?: unknown };
+      const data = notification.request.content.data as { chatId?: unknown; messageId?: unknown; profileId?: unknown };
       if (typeof data.chatId !== 'string') return;
+      const userId = useAuthStore.getState().user?.id;
+      if (userId && typeof data.profileId === 'string') void useProfileStore.getState().setActiveProfile(userId, data.profileId);
       router.push({ pathname: '/chat/[chatId]', params: {
         chatId: data.chatId,
         ...(typeof data.messageId === 'string' ? { highlightMessageId: data.messageId } : {}),

--- a/apps/client/app/chat/[chatId].tsx
+++ b/apps/client/app/chat/[chatId].tsx
@@ -57,6 +57,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { MobileAvatar, MobileIconButton } from '../../components/mobile/claire-mobile';
 import { cacheTimeline, cachedTimeline, usesNativeMobileCache } from '../../services/mobile-cache';
 import { inboxQueryPrefix, patchInboxChat } from '../../hooks/useInboxMessages';
+import { useProfileStore } from '../../stores/profileStore';
 import {
   chatMessageFromSend,
   groupReactions,
@@ -432,6 +433,7 @@ export default function ChatRoute() {
 
 export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
   const queryClient = useQueryClient();
+  const profileId = useProfileStore((state) => state.activeProfileId);
   const { chatId, contact_name, chat_name, platform, is_group, highlightMessageId, draft } =
     useLocalSearchParams<{
       chatId: string;
@@ -632,17 +634,17 @@ export function ChatScreen({ embedded = false }: { embedded?: boolean }) {
       // it can arrive after someone has already navigated back. Patch every
       // cached inbox view now and refetch filter variants (especially Unread)
       // so neither the row nor the app badge retains a stale count.
-      patchInboxChat(queryClient, user?.id, {
+      patchInboxChat(queryClient, user?.id, profileId, {
         id: chatId,
         platform: platform as Platform,
         unread_count: 0,
       });
-      void queryClient.invalidateQueries({ queryKey: inboxQueryPrefix(user?.id) });
+      void queryClient.invalidateQueries({ queryKey: inboxQueryPrefix(user?.id, profileId) });
       await syncNotificationBadge().catch(() => undefined);
     } catch (error) {
       console.warn('Failed to mark conversation read:', error);
     }
-  }, [chatId, platform, connectedSessions, queryClient, user?.id]);
+  }, [chatId, platform, connectedSessions, profileId, queryClient, user?.id]);
 
   useEffect(() => {
     if (!chatId) return;

--- a/apps/client/app/connections/index.tsx
+++ b/apps/client/app/connections/index.tsx
@@ -13,6 +13,7 @@ import { PlatformAuthModal } from '../../components/PlatformAuthModal';
 import { MobileHeader, MobileIconButton, MobileState, SectionLabel } from '../../components/mobile/claire-mobile';
 import { ConnectionsSkeleton } from '../../components/claire/skeleton';
 import { useAuthStore } from '../../stores/authStore';
+import { useProfileStore } from '../../stores/profileStore';
 
 function ConnectionMark({ definition }: { definition: PlatformDefinition }) {
   const platform = resolvePlatform(definition.id);
@@ -34,6 +35,7 @@ export default function ConnectionsScreen() {
   const [error, setError] = useState<string | null>(null);
   const accessToken = useAuthStore(state => state.token);
   const user = useAuthStore(state => state.user);
+  const profileId = useProfileStore(state => state.activeProfileId);
 
   const load = async () => {
     setError(null);
@@ -66,7 +68,7 @@ export default function ConnectionsScreen() {
     }
     if (definition.id === Platform.INSTAGRAM && host.name === 'electron' && accessToken) {
       setError(null);
-      const result = await host.startInstagramLogin({ apiUrl: API_BASE_URL, accessToken });
+      const result = await host.startInstagramLogin({ apiUrl: API_BASE_URL, accessToken, ...(profileId ? { profileId } : {}) });
       if (!result.success) setError(result.error || 'Instagram sign-in did not finish.');
       else await load();
       return;

--- a/apps/client/app/settings/index.tsx
+++ b/apps/client/app/settings/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, type ComponentType, type ReactNode } from 'react';
 import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
-import { Bell, Bot, Check, ChevronRight, DatabaseZap, KeyRound, Link2, LogOut, MessageCircle, Smile, Sparkles } from 'lucide-react-native';
+import { Bell, Bot, Check, ChevronRight, DatabaseZap, KeyRound, Link2, LogOut, MessageCircle, Smile, Sparkles, UsersRound } from 'lucide-react-native';
 import { router } from 'expo-router';
 import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
 import { MobileAvatar, MobileHeader, SectionLabel } from '../../components/mobile/claire-mobile';
@@ -112,6 +112,7 @@ export default function SettingsScreen() {
   ];
 
   const appRows: SettingsRow[] = [
+    { title: 'Profiles', detail: 'Personal, Work, and custom workspaces', icon: UsersRound, href: '/settings/profiles', testID: 'settings-profiles', iconBackground: colors.mint },
     { title: 'Connected accounts', detail: `${connected} platform${connected === 1 ? '' : 's'} active`, icon: Link2, href: '/(tabs)/connections', testID: 'settings-connections', iconBackground: colors.lavender },
     { title: 'Notifications', detail: 'Priority people and quiet hours', icon: Bell, href: '/settings/notifications', testID: 'settings-notifications', iconBackground: colors.sky },
     { title: 'Chat', detail: 'Plus button and reply options', icon: MessageCircle, href: '/settings/chat', testID: 'settings-chat', iconBackground: colors.neutral[100] },

--- a/apps/client/app/settings/notifications.tsx
+++ b/apps/client/app/settings/notifications.tsx
@@ -14,6 +14,7 @@ import { MobileHeader, MobileIconButton } from '../../components/mobile/claire-m
 import { supabase } from '../../services/supabase';
 import { API_BASE_URL } from '../../services/platforms';
 import { getNativeNotificationPermission, registerNotificationDevice, requestWebNotificationPermission, supportsWebNotifications } from '../../services/notifications';
+import { useProfileStore } from '../../stores/profileStore';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -50,9 +51,9 @@ const QUIET_HOURS_OPTIONS = [
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function fetchNotificationPrefs(token: string): Promise<NotificationPrefs> {
+async function fetchNotificationPrefs(token: string, profileId?: string | null): Promise<NotificationPrefs> {
   const res = await fetch(`${API_BASE_URL}/preferences`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, ...(profileId ? { 'X-Claire-Profile-Id': profileId } : {}) },
   });
   if (!res.ok) throw new Error('Failed to fetch preferences');
   const { data } = await res.json();
@@ -71,12 +72,13 @@ async function fetchNotificationPrefs(token: string): Promise<NotificationPrefs>
   return { ...DEFAULTS, ...prefs };
 }
 
-async function saveNotificationPrefs(token: string, prefs: NotificationPrefs): Promise<void> {
+async function saveNotificationPrefs(token: string, prefs: NotificationPrefs, profileId?: string | null): Promise<void> {
   const res = await fetch(`${API_BASE_URL}/preferences`, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      ...(profileId ? { 'X-Claire-Profile-Id': profileId } : {}),
     },
     body: JSON.stringify({
       notification_enabled: prefs.notification_enabled,
@@ -185,6 +187,7 @@ function TimeSelector({
 }
 
 export default function NotificationsSettingsScreen() {
+  const profileId = useProfileStore((state) => state.activeProfileId);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULTS);
@@ -196,7 +199,7 @@ export default function NotificationsSettingsScreen() {
         const { data: { session } } = await supabase.auth.getSession();
         const token = session?.access_token;
         if (!token) return;
-        const loaded = await fetchNotificationPrefs(token);
+        const loaded = await fetchNotificationPrefs(token, profileId);
         setPrefs(loaded);
         setSystemPermission(await getNativeNotificationPermission());
       } catch {
@@ -205,7 +208,7 @@ export default function NotificationsSettingsScreen() {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [profileId]);
 
   const update = (patch: Partial<NotificationPrefs>) => setPrefs((p) => ({ ...p, ...patch }));
 
@@ -215,7 +218,7 @@ export default function NotificationsSettingsScreen() {
       const { data: { session } } = await supabase.auth.getSession();
       const token = session?.access_token;
       if (!token) throw new Error('Not authenticated');
-      await saveNotificationPrefs(token, prefs);
+      await saveNotificationPrefs(token, prefs, profileId);
       router.back();
     } catch {
       Alert.alert('Error', 'Failed to save notification preferences. Please try again.');

--- a/apps/client/app/settings/profiles.tsx
+++ b/apps/client/app/settings/profiles.tsx
@@ -1,0 +1,5 @@
+import { ProfileSettingsScreen } from '../../features/profiles/profile-settings-screen';
+
+export default function ProfilesRoute() {
+  return <ProfileSettingsScreen />;
+}

--- a/apps/client/components/profile-switcher.tsx
+++ b/apps/client/components/profile-switcher.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Modal, Pressable, Text, View } from 'react-native';
+import { Check, ChevronDown, Plus } from 'lucide-react-native';
+import { router } from 'expo-router';
+import { colors, mobileType, radius, space } from '@claire/design-system';
+import { useAuthStore } from '../stores/authStore';
+import { useProfileStore } from '../stores/profileStore';
+import { usePlatformStore } from '../stores/platformStore';
+
+export function ProfileSwitcher() {
+  const [open, setOpen] = useState(false);
+  const userId = useAuthStore((state) => state.user?.id);
+  const profiles = useProfileStore((state) => state.profiles);
+  const activeProfileId = useProfileStore((state) => state.activeProfileId);
+  const setActive = useProfileStore((state) => state.setActiveProfile);
+  const refreshSessions = usePlatformStore((state) => state.fetchConnectedSessions);
+  const active = profiles.find((profile) => profile.id === activeProfileId);
+  if (!active || !userId) return null;
+  return <>
+    <Pressable accessibilityRole="button" accessibilityLabel="Switch profile" onPress={() => setOpen(true)} style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, minHeight: 32, borderRadius: 99, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}>
+      <View style={{ width: 9, height: 9, borderRadius: 99, backgroundColor: active.color }} />
+      <Text numberOfLines={1} style={{ ...mobileType.label, maxWidth: 100, color: colors.ink }}>{active.name}</Text>
+      <ChevronDown size={14} color={colors.neutral[600]} />
+    </Pressable>
+    <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+      <Pressable onPress={() => setOpen(false)} style={{ flex: 1, justifyContent: 'center', padding: space[5], backgroundColor: 'rgba(16,18,15,0.28)' }}>
+        <Pressable onPress={(event) => event.stopPropagation()} style={{ borderRadius: radius.card, padding: space[4], gap: space[2], backgroundColor: colors.paper }}>
+          <Text style={{ ...mobileType.sectionTitle, color: colors.ink }}>Switch profile</Text>
+          {profiles.map((profile) => <Pressable key={profile.id} accessibilityRole="button" onPress={() => { void setActive(userId, profile.id).then(refreshSessions); setOpen(false); }} style={{ minHeight: 52, flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 10, borderRadius: 12, backgroundColor: profile.id === activeProfileId ? colors.sky : 'transparent' }}>
+            <View style={{ width: 12, height: 12, borderRadius: 99, backgroundColor: profile.color }} />
+            <View style={{ flex: 1 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{profile.name}</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{profile.unreadCount ? `${profile.unreadCount} unread` : 'All caught up'}</Text></View>
+            {profile.id === activeProfileId ? <Check size={17} color={colors.ink} /> : null}
+          </Pressable>)}
+          <Pressable accessibilityRole="button" onPress={() => { setOpen(false); router.push('/settings/profiles'); }} style={{ minHeight: 44, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, borderRadius: 12, borderWidth: 1, borderColor: colors.neutral[200] }}>
+            <Plus size={16} color={colors.ink} /><Text style={{ ...mobileType.label, color: colors.ink }}>Manage profiles in Settings</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  </>;
+}

--- a/apps/client/features/home/home-screen.tsx
+++ b/apps/client/features/home/home-screen.tsx
@@ -14,6 +14,7 @@ import { resolvePlatform, platformLabel } from '../../types/platform';
 import { formatInboxTimestamp } from '../../utils/messageTimestamp';
 import { computeUrgencyScore } from '../../utils/urgency';
 import { HomeSkeleton } from '../../components/claire/skeleton';
+import { ProfileSwitcher } from '../../components/profile-switcher';
 import { installationId, listHandoffs, type WorkspaceHandoff } from '../../services/handoffs';
 import { loopTitle, type LoopItem } from '../../services/loops';
 
@@ -164,11 +165,7 @@ export function HomeScreen() {
         title={`${greeting()},\n${firstName}.`}
         subtitle={actionCount === 0 ? "You're clear right now." : `${actionCount} item${actionCount === 1 ? '' : 's'} need${actionCount === 1 ? 's' : ''} your attention.`}
         safeArea
-        profile={
-          <Pressable accessibilityRole="button" accessibilityLabel="Open settings" onPress={() => router.push('/settings')}>
-            <MobileAvatar name={user?.name || user?.email || 'You'} uri={user?.avatar_url} size={44} badge={<View style={{ width: 16, height: 16, borderRadius: 8, backgroundColor: colors.lime, borderWidth: 2, borderColor: colors.cream }} />} />
-          </Pressable>
-        }
+        profile={<View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}><ProfileSwitcher /><Pressable accessibilityRole="button" accessibilityLabel="Open settings" onPress={() => router.push('/settings')}><MobileAvatar name={user?.name || user?.email || 'You'} uri={user?.avatar_url} size={44} badge={<View style={{ width: 16, height: 16, borderRadius: 8, backgroundColor: colors.lime, borderWidth: 2, borderColor: colors.cream }} />} /></Pressable></View>}
       />
 
       <View style={{ paddingHorizontal: space[4], gap: space[4] }}>

--- a/apps/client/features/inbox/compose-screen.tsx
+++ b/apps/client/features/inbox/compose-screen.tsx
@@ -5,6 +5,7 @@ import { Stack, router } from 'expo-router';
 import { colors, mobileType, space } from '@claire/design-system';
 import { supabase, type DbRow } from '../../services/supabase';
 import { useAuthStore } from '../../stores/authStore';
+import { useProfileStore } from '../../stores/profileStore';
 import { MobileAvatar, MobileIconButton, MobileState, SectionLabel } from '../../components/mobile/claire-mobile';
 import { PeopleSkeleton } from '../../components/claire/skeleton';
 import { platformLabel } from '../../types/platform';
@@ -59,18 +60,19 @@ function ComposeCloseButton() {
 
 export function ComposeScreen() {
   const user = useAuthStore(state => state.user);
+  const profileId = useProfileStore(state => state.activeProfileId);
   const [query, setQuery] = useState('');
   const [recipients, setRecipients] = useState<ComposeRecipient[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!user?.id) {
+    if (!user?.id || !profileId) {
       setLoading(false);
       return;
     }
     Promise.all([
-      supabase.from('contacts').select('id,name,phone_number,avatar_url,inferred_name').eq('user_id', user.id),
-      supabase.from('chats').select('id,contact_id,name,platform,is_group,last_message_at').eq('user_id', user.id).order('last_message_at', { ascending: false }),
+      supabase.from('contacts').select('id,name,phone_number,avatar_url,inferred_name').eq('user_id', user.id).eq('profile_id', profileId),
+      supabase.from('chats').select('id,contact_id,name,platform,is_group,last_message_at').eq('user_id', user.id).eq('profile_id', profileId).order('last_message_at', { ascending: false }),
     ]).then(([contactResult, chatResult]) => {
       if (contactResult.error) throw contactResult.error;
       if (chatResult.error) throw chatResult.error;
@@ -90,7 +92,7 @@ export function ComposeScreen() {
         } satisfies ComposeRecipient;
       }));
     }).catch(error => console.error('[Compose] Failed to load recipients', error)).finally(() => setLoading(false));
-  }, [user?.id]);
+  }, [profileId, user?.id]);
 
   const normalizedQuery = query.trim().toLowerCase();
   const visible = useMemo(() => recipients.filter(recipient => matchesQuery(recipient, normalizedQuery)), [normalizedQuery, recipients]);

--- a/apps/client/features/inbox/inbox-screen.tsx
+++ b/apps/client/features/inbox/inbox-screen.tsx
@@ -15,6 +15,7 @@ import { Platform } from '../../types/platform';
 import { PlatformBadge } from '../../components/PlatformIcon';
 import { formatInboxTimestamp } from '../../utils/messageTimestamp';
 import { InboxRowSkeleton, InboxSkeleton } from '../../components/claire/skeleton';
+import { ProfileSwitcher } from '../../components/profile-switcher';
 
 type InboxFilter = 'all' | 'unread' | 'needs_reply' | 'groups';
 type PlatformFilter = 'all' | Platform;
@@ -309,7 +310,7 @@ export function InboxScreen() {
       <MobileHeader
         title="Inbox"
         safeArea
-        actions={<View style={{ flexDirection: 'row', gap: space[2] }}>
+        actions={<View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}><ProfileSwitcher />
           <MobileIconButton label="Search everything" testID="inbox-open-search" onPress={() => router.push('/(tabs)/search' as never)}><Search size={20} color={colors.ink} /></MobileIconButton>
           <MobileIconButton label="New message" testID="inbox-compose" onPress={() => router.push('/compose' as never)}><PenSquare size={20} color={colors.ink} /></MobileIconButton>
         </View>}

--- a/apps/client/features/profiles/profile-settings-screen.tsx
+++ b/apps/client/features/profiles/profile-settings-screen.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Alert, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { Plus, Trash2 } from 'lucide-react-native';
+import { colors, mobileType, radius, space } from '@claire/design-system';
+import { MobileHeader } from '../../components/mobile/claire-mobile';
+import { useAuthStore } from '../../stores/authStore';
+import { useProfileStore } from '../../stores/profileStore';
+import { usePlatformStore } from '../../stores/platformStore';
+import { profilesApi } from '../../services/profiles';
+
+const PROFILE_COLORS = ['#7C6EF6', '#38A169', '#3182CE', '#D53F8C', '#D69E2E'];
+
+export function ProfileSettingsScreen() {
+  const userId = useAuthStore((state) => state.user?.id);
+  const profiles = useProfileStore((state) => state.profiles);
+  const activeProfileId = useProfileStore((state) => state.activeProfileId);
+  const createProfile = useProfileStore((state) => state.createProfile);
+  const refresh = useProfileStore((state) => state.refresh);
+  const sessions = usePlatformStore((state) => state.connectedSessions);
+  const refreshSessions = usePlatformStore((state) => state.fetchConnectedSessions);
+  const [name, setName] = useState('Work');
+  const [color, setColor] = useState(PROFILE_COLORS[1]);
+  const [saving, setSaving] = useState(false);
+  const add = async () => {
+    if (!userId || !name.trim()) return;
+    setSaving(true);
+    try { await createProfile(userId, name.trim(), color); setName(''); }
+    catch (error) { Alert.alert('Could not create profile', error instanceof Error ? error.message : 'Try again.'); }
+    finally { setSaving(false); }
+  };
+  const remove = (profileId: string, profileName: string) => Alert.alert(`Delete ${profileName}?`, 'Move or disconnect all connected accounts first. This cannot delete the Personal profile.', [
+    { text: 'Cancel', style: 'cancel' },
+    { text: 'Delete', style: 'destructive', onPress: () => void profilesApi.remove(profileId).then(refresh).catch((error) => Alert.alert('Could not delete profile', error instanceof Error ? error.message : 'Try again.')) },
+  ]);
+  const moveSession = (sessionId: string, platform: string) => {
+    const destinations = profiles.filter((profile) => profile.id !== activeProfileId);
+    if (!destinations.length) { Alert.alert('Create another profile first', 'Accounts can only move to another profile.'); return; }
+    Alert.alert(`Move ${platform}?`, 'Its conversations and history will move with this account.', [
+      { text: 'Cancel', style: 'cancel' },
+      ...destinations.map((destination) => ({ text: destination.name, onPress: () => void profilesApi.moveSession(destination.id, sessionId).then(async () => { await Promise.all([refresh(), refreshSessions()]); }).catch((error) => Alert.alert('Could not move account', error instanceof Error ? error.message : 'Try again.')) })),
+    ]);
+  };
+  return <ScrollView style={{ flex: 1, backgroundColor: colors.cream }} contentInsetAdjustmentBehavior="automatic" contentContainerStyle={{ paddingBottom: 72 }}>
+    <MobileHeader title="Profiles" subtitle="Keep your accounts, conversations, AI, and notifications in separate workspaces." />
+    <View style={{ paddingHorizontal: space[4], gap: space[4] }}>
+      <View style={{ padding: space[4], borderRadius: radius.card, backgroundColor: colors.sky, gap: space[3] }}>
+        <Text style={{ ...mobileType.sectionTitle, color: colors.ink }}>Add a profile</Text>
+        <TextInput value={name} onChangeText={setName} placeholder="Profile name" placeholderTextColor={colors.neutral[400]} style={{ minHeight: 46, paddingHorizontal: 12, borderRadius: 12, backgroundColor: colors.paper, color: colors.ink, borderWidth: 1, borderColor: colors.neutral[200] }} />
+        <View style={{ flexDirection: 'row', gap: 10 }}>{PROFILE_COLORS.map((value) => <Pressable key={value} accessibilityRole="button" accessibilityLabel={`Use ${value} color`} onPress={() => setColor(value)} style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: value, borderWidth: color === value ? 3 : 0, borderColor: colors.ink }} />)}</View>
+        <Pressable disabled={saving || !name.trim()} onPress={() => void add()} style={{ minHeight: 44, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, borderRadius: 12, backgroundColor: colors.ink, opacity: saving || !name.trim() ? 0.5 : 1 }}><Plus size={17} color={colors.paper} /><Text style={{ ...mobileType.label, color: colors.paper }}>{saving ? 'Adding…' : 'Add profile'}</Text></Pressable>
+      </View>
+      <View style={{ gap: space[2] }}>{profiles.map((profile) => <View key={profile.id} style={{ minHeight: 66, flexDirection: 'row', alignItems: 'center', gap: 12, padding: space[3], borderRadius: 15, backgroundColor: colors.paper, borderWidth: 1, borderColor: profile.id === activeProfileId ? colors.ink : colors.neutral[200] }}>
+        <View style={{ width: 16, height: 16, borderRadius: 99, backgroundColor: profile.color }} />
+        <View style={{ flex: 1 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{profile.name}{profile.is_personal ? ' · Default' : ''}</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{profile.unreadCount ? `${profile.unreadCount} unread` : 'No unread conversations'}</Text></View>
+        {!profile.is_personal ? <Pressable accessibilityRole="button" accessibilityLabel={`Delete ${profile.name}`} onPress={() => remove(profile.id, profile.name)} style={{ padding: 8 }}><Trash2 size={18} color={colors.danger} /></Pressable> : null}
+      </View>)}</View>
+      {sessions.length ? <View style={{ gap: space[2] }}><Text style={{ ...mobileType.sectionTitle, color: colors.ink }}>Connected accounts</Text>{sessions.map((session) => <View key={session.id} style={{ minHeight: 56, flexDirection: 'row', alignItems: 'center', gap: 10, padding: space[3], borderRadius: 14, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[200] }}><View style={{ flex: 1 }}><Text style={{ ...mobileType.body, fontWeight: '700', color: colors.ink }}>{session.platform[0].toUpperCase() + session.platform.slice(1)}</Text><Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>This profile</Text></View><Pressable accessibilityRole="button" onPress={() => moveSession(session.id, session.platform)} style={{ paddingHorizontal: 10, paddingVertical: 7, borderRadius: 99, borderWidth: 1, borderColor: colors.neutral[200] }}><Text style={{ ...mobileType.label, color: colors.ink }}>Move</Text></Pressable></View>)}</View> : null}
+      <Text style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>The active profile changes the entire workspace. Incoming notifications retain each profile’s own settings even when you are viewing another one.</Text>
+    </View>
+  </ScrollView>;
+}

--- a/apps/client/hooks/useInboxMessages.ts
+++ b/apps/client/hooks/useInboxMessages.ts
@@ -4,6 +4,7 @@ import { supabase, type DbRow } from '../services/supabase';
 import { Platform } from '../types/platform';
 import { cacheTimeline, hydrateMobileCache, usesNativeMobileCache, type CachedChat } from '../services/mobile-cache';
 import { displayContactName } from '../services/contact-display';
+import { useProfileStore } from '../stores/profileStore';
 
 export interface InboxMessage {
   id: string;
@@ -61,8 +62,8 @@ type InboxQueryData = InfiniteData<MessagePage, InboxCursor | null>;
 
 export type InboxServerFilter = 'all' | 'unread' | 'needs_reply' | 'groups';
 
-export function inboxQueryKey(userId?: string, search = '', filter: InboxServerFilter = 'all', platform = 'all') {
-  return ['messages-feed', userId, search, filter, platform] as const;
+export function inboxQueryKey(userId?: string, profileId?: string | null, search = '', filter: InboxServerFilter = 'all', platform = 'all') {
+  return ['messages-feed', userId, profileId, search, filter, platform] as const;
 }
 
 /**
@@ -71,8 +72,8 @@ export function inboxQueryKey(userId?: string, search = '', filter: InboxServerF
  * unfiltered, unsearched feed, so an exact match would leave an active search
  * or filter stale.
  */
-export function inboxQueryPrefix(userId?: string) {
-  return ['messages-feed', userId] as const;
+export function inboxQueryPrefix(userId?: string, profileId?: string | null) {
+  return ['messages-feed', userId, profileId] as const;
 }
 
 function inboxTrace(event: string, details: Record<string, unknown> = {}) {
@@ -177,11 +178,12 @@ export type InboxRealtimeRow = Partial<RawMessage> & { id: string; content?: str
 function updateInboxQueries(
   queryClient: QueryClient,
   userId: string | undefined,
+  profileId: string | null | undefined,
   updater: (old: InboxQueryData | undefined, canInsert: boolean) => InboxQueryData | undefined,
 ) {
-  const queries = queryClient.getQueryCache().findAll({ queryKey: inboxQueryPrefix(userId) });
+  const queries = queryClient.getQueryCache().findAll({ queryKey: inboxQueryPrefix(userId, profileId) });
   for (const query of queries) {
-    const [, , search, filter, platform] = query.queryKey as ReturnType<typeof inboxQueryKey>;
+    const [, , , search, filter, platform] = query.queryKey as ReturnType<typeof inboxQueryKey>;
     const canInsert = !search && filter === 'all' && platform === 'all';
     queryClient.setQueryData<InboxQueryData>(query.queryKey, (old) => updater(old, canInsert));
   }
@@ -190,6 +192,7 @@ function updateInboxQueries(
 export function patchInboxRealtimeMessage(
   queryClient: QueryClient,
   userId: string | undefined,
+  profileId: string | null | undefined,
   row: InboxRealtimeRow,
 ) {
   if (!row.chat_id && !row.id) return;
@@ -199,7 +202,7 @@ export function patchInboxRealtimeMessage(
   if (usesNativeMobileCache() && userId && row.chat_id && row.timestamp) {
     void cacheTimeline(userId, row.chat_id, [row as RawMessage & { id: string; chat_id: string; timestamp: string }]).catch(() => undefined);
   }
-  updateInboxQueries(queryClient, userId, (old, canInsert) => {
+  updateInboxQueries(queryClient, userId, profileId, (old, canInsert) => {
     if (!old) return old;
     let found = false;
     const pages = old.pages.map((page) => {
@@ -254,10 +257,11 @@ export function patchInboxRealtimeMessage(
 export function patchInboxChat(
   queryClient: QueryClient,
   userId: string | undefined,
+  profileId: string | null | undefined,
   chat: { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean },
 ) {
   const key = conversationKey(chat.id, chat.platform || Platform.WHATSAPP);
-  updateInboxQueries(queryClient, userId, (old) => {
+  updateInboxQueries(queryClient, userId, profileId, (old) => {
     if (!old) return old;
     let changed = false;
     const pages = old.pages.map((page) => ({
@@ -272,8 +276,8 @@ export function patchInboxChat(
   });
 }
 
-export function markInboxAiResponse(queryClient: QueryClient, userId: string | undefined, messageId: string) {
-  updateInboxQueries(queryClient, userId, (old) => {
+export function markInboxAiResponse(queryClient: QueryClient, userId: string | undefined, profileId: string | null | undefined, messageId: string) {
+  updateInboxQueries(queryClient, userId, profileId, (old) => {
     if (!old) return old;
     let changed = false;
     const pages = old.pages.map((page) => {
@@ -324,19 +328,27 @@ export function useInboxMessages(
   const search = options.search?.trim() ?? '';
   const filter = options.filter ?? 'all';
   const platformFilter = options.platform ?? 'all';
+  const profileId = useProfileStore((state) => state.activeProfileId);
   const queryClient = useQueryClient();
   // Search and filters are part of the identity of this feed: they are applied
   // in the database, so each combination is a different result set and must not
   // share a cache entry.
   const queryKey = useMemo(
-    () => inboxQueryKey(userId, search, filter, platformFilter),
-    [userId, search, filter, platformFilter],
+    () => inboxQueryKey(userId, profileId, search, filter, platformFilter),
+    [userId, profileId, search, filter, platformFilter],
   );
   const [cacheReady, setCacheReady] = useState(!usesNativeMobileCache());
 
   useEffect(() => {
     let active = true;
     setCacheReady(!usesNativeMobileCache());
+    // The existing offline snapshot predates workspace ownership. Never seed a
+    // profile-filtered inbox from it, or a fast profile switch could briefly
+    // reveal another workspace before the network response arrives.
+    if (profileId) {
+      setCacheReady(true);
+      return () => { active = false; };
+    }
     if (!userId || !usesNativeMobileCache()) return;
     void hydrateMobileCache(userId).then((snapshot) => {
       if (!active) return;
@@ -346,11 +358,11 @@ export function useInboxMessages(
       if (messages.length) queryClient.setQueryData<InboxQueryData>(queryKey, { pages: [{ messages, hasMore: false, nextCursor: null }], pageParams: [null] });
     }).catch(() => undefined).finally(() => { if (active) setCacheReady(true); });
     return () => { active = false; };
-  }, [queryClient, queryKey, userId]);
+  }, [profileId, queryClient, queryKey, userId]);
 
   const query = useInfiniteQuery<MessagePage, Error, InboxQueryData, typeof queryKey, InboxCursor | null>({
     queryKey,
-    enabled: !!userId && cacheReady,
+    enabled: !!userId && !!profileId && cacheReady,
     initialPageParam: null,
     staleTime: 60_000,
     gcTime: 30 * 60_000,
@@ -370,6 +382,7 @@ export function useInboxMessages(
         .from('conversation_feed')
         .select('*')
         .eq('user_id', userId)
+        .eq('profile_id', profileId)
         .eq('is_archived', false)
         // WhatsApp's status broadcast is a pseudo-chat, not a conversation.
         // Older rows carry no platform_chat_id, so match the name too.

--- a/apps/client/hooks/useInboxRealtime.ts
+++ b/apps/client/hooks/useInboxRealtime.ts
@@ -10,6 +10,7 @@ import {
   type InboxRealtimeRow,
 } from './useInboxMessages';
 import { Platform } from '../types/platform';
+import { useProfileStore } from '../stores/profileStore';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -43,9 +44,10 @@ function dropInboxChannels(userId: string) {
 
 export function useInboxRealtime(userId?: string) {
   const queryClient = useQueryClient();
+  const profileId = useProfileStore((state) => state.activeProfileId);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId || !profileId) return;
 
     let cancelled = false;
     let fallbackTimer: ReturnType<typeof setInterval> | undefined;
@@ -53,16 +55,16 @@ export function useInboxRealtime(userId?: string) {
       if (cancelled) return;
       if (fallbackTimer) clearInterval(fallbackTimer);
       fallbackTimer = setInterval(() => {
-        if (!cancelled) void queryClient.invalidateQueries({ queryKey: inboxQueryPrefix(userId) });
+        if (!cancelled) void queryClient.invalidateQueries({ queryKey: inboxQueryPrefix(userId, profileId) });
       }, intervalMs);
     };
 
     startFallback(60_000);
     dropInboxChannels(userId);
 
-    const topic = `inbox-feed:${userId}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+    const topic = `inbox-feed:${userId}:${profileId}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
     const channel = supabase.channel(topic);
-    channel.on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages', filter: `user_id=eq.${userId}` }, ({ new: row }) => {
+    channel.on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages', filter: `profile_id=eq.${profileId}` }, ({ new: row }) => {
       const message = row as InboxRealtimeRow;
       if (message.platform) void reportClientState('acknowledged', message.platform);
       if (!message.from_me) {
@@ -72,18 +74,18 @@ export function useInboxRealtime(userId?: string) {
           { type: 'new_message', chatId: message.chat_id, platform: message.platform },
         );
       }
-      patchInboxRealtimeMessage(queryClient, userId, message);
+      patchInboxRealtimeMessage(queryClient, userId, profileId, message);
     });
-    channel.on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'messages', filter: `user_id=eq.${userId}` }, ({ new: row }) => {
-      patchInboxRealtimeMessage(queryClient, userId, row as InboxRealtimeRow);
+    channel.on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'messages', filter: `profile_id=eq.${profileId}` }, ({ new: row }) => {
+      patchInboxRealtimeMessage(queryClient, userId, profileId, row as InboxRealtimeRow);
     });
-    channel.on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'chats', filter: `user_id=eq.${userId}` }, ({ new: row }) => {
+    channel.on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'chats', filter: `profile_id=eq.${profileId}` }, ({ new: row }) => {
       const chat = row as { id: string; platform?: Platform; unread_count?: number; is_pinned?: boolean };
-      patchInboxChat(queryClient, userId, chat);
+      patchInboxChat(queryClient, userId, profileId, chat);
     });
     channel.on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'ai_suggestions', filter: `user_id=eq.${userId}` }, ({ new: row }) => {
       const messageId = (row as { message_id?: string }).message_id;
-      if (messageId) markInboxAiResponse(queryClient, userId, messageId);
+      if (messageId) markInboxAiResponse(queryClient, userId, profileId, messageId);
     });
     channel.subscribe((status, error) => {
       if (cancelled) return;
@@ -104,5 +106,5 @@ export function useInboxRealtime(userId?: string) {
       void reportClientState('disconnected');
       void supabase.removeChannel(channel);
     };
-  }, [queryClient, userId]);
+  }, [profileId, queryClient, userId]);
 }

--- a/apps/client/services/contacts.ts
+++ b/apps/client/services/contacts.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
 import { API_BASE_URL } from './platforms';
 import type { Platform } from '../types/platform';
+import { useProfileStore } from '../stores/profileStore';
 
 export type PeopleFilter = 'all' | 'contacted' | 'needs_context' | 'groups';
 
@@ -32,7 +33,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const { data: { session } } = await supabase.auth.getSession();
   const response = await fetch(`${API_BASE_URL}${path}`, {
     ...init,
-    headers: session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : undefined,
+    headers: { ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}), ...(useProfileStore.getState().activeProfileId ? { 'X-Claire-Profile-Id': useProfileStore.getState().activeProfileId! } : {}) },
   });
   const body = await response.json().catch(() => ({})) as { data?: T; error?: string };
   if (!response.ok) throw new Error(body.error || `Request failed (${response.status})`);

--- a/apps/client/services/platforms.ts
+++ b/apps/client/services/platforms.ts
@@ -7,6 +7,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { supabase } from './supabase';
+import { useProfileStore } from '../stores/profileStore';
 import {
   Platform,
   PlatformStatus,
@@ -101,6 +102,8 @@ api.interceptors.request.use(async (config) => {
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }
+  const profileId = useProfileStore.getState().activeProfileId;
+  if (profileId) config.headers['X-Claire-Profile-Id'] = profileId;
   return config;
 });
 

--- a/apps/client/services/profiles.ts
+++ b/apps/client/services/profiles.ts
@@ -1,0 +1,32 @@
+import { supabase } from './supabase';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface WorkspaceProfile {
+  id: string;
+  name: string;
+  color: string;
+  is_personal: boolean;
+  sort_order: number;
+  created_at: string;
+  unreadCount: number;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { data: { session } } = await supabase.auth.getSession();
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: { Accept: 'application/json', ...(init.body ? { 'Content-Type': 'application/json' } : {}), ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}), ...init.headers },
+  });
+  const body = await response.json().catch(() => ({})) as { data?: T; error?: string };
+  if (!response.ok) throw new Error(body.error || 'Profile request failed');
+  return body.data as T;
+}
+
+export const profilesApi = {
+  list: () => request<WorkspaceProfile[]>('/profiles'),
+  create: (name: string, color: string) => request<WorkspaceProfile>('/profiles', { method: 'POST', body: JSON.stringify({ name, color }) }),
+  update: (profileId: string, values: Partial<Pick<WorkspaceProfile, 'name' | 'color'>> & { sortOrder?: number }) => request<WorkspaceProfile>(`/profiles/${profileId}`, { method: 'PATCH', body: JSON.stringify(values) }),
+  remove: (profileId: string) => request<void>(`/profiles/${profileId}`, { method: 'DELETE' }),
+  moveSession: (profileId: string, sessionId: string) => request<void>(`/profiles/${profileId}/move-session`, { method: 'POST', body: JSON.stringify({ sessionId }) }),
+};

--- a/apps/client/stores/profileStore.ts
+++ b/apps/client/stores/profileStore.ts
@@ -1,0 +1,50 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { profilesApi, type WorkspaceProfile } from '../services/profiles';
+
+const keyFor = (userId: string) => `claire:active-profile:${userId}`;
+
+interface ProfileState {
+  profiles: WorkspaceProfile[];
+  activeProfileId: string | null;
+  isLoading: boolean;
+  error: string | null;
+  initialize: (userId: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  setActiveProfile: (userId: string, profileId: string) => Promise<void>;
+  createProfile: (userId: string, name: string, color: string) => Promise<WorkspaceProfile>;
+  reset: () => void;
+}
+
+export const useProfileStore = create<ProfileState>((set, get) => ({
+  profiles: [], activeProfileId: null, isLoading: false, error: null,
+  initialize: async (userId) => {
+    set({ isLoading: true, error: null });
+    try {
+      const profiles = await profilesApi.list();
+      const saved = await AsyncStorage.getItem(keyFor(userId));
+      const active = profiles.find((profile) => profile.id === saved) || profiles.find((profile) => profile.is_personal) || profiles[0];
+      set({ profiles, activeProfileId: active?.id || null, isLoading: false });
+      if (active) await AsyncStorage.setItem(keyFor(userId), active.id);
+    } catch (error) {
+      set({ isLoading: false, error: error instanceof Error ? error.message : 'Could not load profiles' });
+    }
+  },
+  refresh: async () => {
+    const profiles = await profilesApi.list();
+    const active = get().activeProfileId;
+    set({ profiles, activeProfileId: profiles.some((profile) => profile.id === active) ? active : profiles[0]?.id || null });
+  },
+  setActiveProfile: async (userId, profileId) => {
+    if (!get().profiles.some((profile) => profile.id === profileId)) return;
+    set({ activeProfileId: profileId });
+    await AsyncStorage.setItem(keyFor(userId), profileId);
+  },
+  createProfile: async (userId, name, color) => {
+    const profile = await profilesApi.create(name, color);
+    set((state) => ({ profiles: [...state.profiles, profile] }));
+    await get().setActiveProfile(userId, profile.id);
+    return profile;
+  },
+  reset: () => set({ profiles: [], activeProfileId: null, isLoading: false, error: null }),
+}));

--- a/apps/client/types/platform.ts
+++ b/apps/client/types/platform.ts
@@ -55,6 +55,7 @@ export interface PlatformSession {
   id: string;
   platform: Platform;
   userId: string;
+  profileId?: string;
   status: PlatformStatus;
   authMethod: AuthMethod;
   platformUserId?: string;

--- a/apps/desktop/src/instagram-login.ts
+++ b/apps/desktop/src/instagram-login.ts
@@ -17,7 +17,7 @@ function validRequest(value: unknown): value is InstagramLoginRequest {
 export async function startInstagramLogin(value: unknown): Promise<InstagramLoginResult> {
   if (!validRequest(value)) return { success: false, error: 'Sign-in context is invalid. Please sign in again.' };
   const response = await fetch(new URL('/platforms/instagram/login/start', value.apiUrl), {
-    method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${value.accessToken}` }, body: JSON.stringify({ client: 'web' }),
+    method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${value.accessToken}`, ...(value.profileId ? { 'X-Claire-Profile-Id': value.profileId } : {}) }, body: JSON.stringify({ client: 'web' }),
   });
   if (!response.ok) return { success: false, error: 'Could not start Instagram sign-in.' };
   const start = await response.json() as { sessionId: string; loginId: string; stepId: string; loginUrl?: string };

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -76,7 +76,7 @@ export type CompanionStatus = {
   encryptedCache: EncryptedCacheInfo;
   pushHelper: 'unsupported' | 'not_configured' | 'ready';
 };
-export type InstagramLoginRequest = { apiUrl: string; accessToken: string };
+export type InstagramLoginRequest = { apiUrl: string; accessToken: string; profileId?: string };
 export type InstagramLoginResult = { success: boolean; error?: string };
 export type IMessageSendRequest = { recipient: string; text: string };
 export type IMessageSendResult = { success: true } | { success: false; error: string };

--- a/apps/server/src/adapters/matrix/index.ts
+++ b/apps/server/src/adapters/matrix/index.ts
@@ -74,6 +74,7 @@ const matrixSdkLogger: MatrixSdkLogger = {
 
 export interface MatrixSessionConfig {
   platform: Platform;
+  profileId?: string;
   bridgeConfig?: BridgeAuthConfig;
 }
 
@@ -882,6 +883,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
     const session = this.createDefaultSession(userId, sessionId);
     // Set the actual platform for this session
     (session as PlatformSession & { platform: Platform }).platform = platform;
+    session.profileId = config?.profileId;
 
     this.sessions.set(sessionId, session);
     this.sessionPlatforms.set(sessionId, platform);
@@ -1010,6 +1012,18 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
     }
 
     const userSessions = [...sessions.values()];
+    // Redis sessions created before profiles do not contain profileId. Restore
+    // the durable ownership marker before exposing or routing them.
+    const missingProfileIds = userSessions.filter((session) => !session.profileId).map((session) => session.id);
+    if (missingProfileIds.length) {
+      const { data } = await supabase
+        .from('platform_sessions')
+        .select('session_id,profile_id')
+        .eq('user_id', userId)
+        .in('session_id', missingProfileIds);
+      const profileBySession = new Map((data || []).map((row) => [row.session_id, row.profile_id]));
+      for (const session of userSessions) session.profileId ||= profileBySession.get(session.id) || undefined;
+    }
 
     // Old versions persisted a session before confirming Instagram
     // provisioning was reachable. Retire those stale attempts as well as
@@ -1103,6 +1117,15 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
     await this.saveSessionToRedis(session);
     this.bridgeAuthManager.markFailed(sessionId, error);
     this.emitPlatformEvent('auth_failure', sessionId, { error });
+  }
+
+  /** Keep Redis/durable bridge state aligned after a workspace account move. */
+  async assignSessionProfile(sessionId: string, profileId: string): Promise<void> {
+    const session = await this.getSession(sessionId);
+    if (!session) throw new Error('Session not found');
+    session.profileId = profileId;
+    this.sessions.set(sessionId, session);
+    await this.saveSessionToRedis(session);
   }
 
   async disconnectSession(sessionId: string): Promise<void> {
@@ -1621,7 +1644,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
         const { data, error } = await supabase
           .from('platform_sessions')
           .select(
-            'session_id,user_id,platform,status,platform_user_id,platform_username,phone_number,session_data,created_at,last_connected_at'
+            'session_id,user_id,profile_id,platform,status,platform_user_id,platform_username,phone_number,session_data,created_at,last_connected_at'
           )
           .eq('status', PlatformStatus.CONNECTED);
         if (error) {
@@ -1644,6 +1667,15 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
 
   private async restoreConnectedSession(session: PlatformSession): Promise<void> {
     const { id: sessionId, platform, selfGhostId } = session;
+    if (!session.profileId) {
+      const { data } = await supabase
+        .from('platform_sessions')
+        .select('profile_id')
+        .eq('session_id', sessionId)
+        .eq('user_id', session.userId)
+        .maybeSingle();
+      session.profileId = data?.profile_id || undefined;
+    }
     this.sessions.set(sessionId, session);
     this.sessionPlatforms.set(sessionId, platform);
     await this.resolveAndPersistSelfGhostIds(sessionId, session, platform);
@@ -1755,6 +1787,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
           phoneNumberFromPlatformContactId(contact.platform, contact.platformContactId);
         const payload: DbRow = {
           user_id: session.userId,
+          profile_id: session.profileId,
           platform: contact.platform,
           platform_contact_id: contact.platformContactId,
           whatsapp_id: contact.platformContactId,
@@ -1767,7 +1800,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
         };
         const { error } = await supabase
           .from('contacts')
-          .upsert(payload, { onConflict: 'user_id,platform,platform_contact_id' });
+          .upsert(payload, { onConflict: 'profile_id,platform,platform_contact_id' });
 
         if (!error) {
           synced++;
@@ -1780,6 +1813,7 @@ export class MatrixBridgeAdapter extends BasePlatformAdapter {
               .from('chats')
               .update({ name })
               .eq('user_id', session.userId)
+              .eq('profile_id', session.profileId)
               .eq('platform', contact.platform)
               .eq('platform_chat_id', contact.platformContactId)
               .eq('is_group', false);

--- a/apps/server/src/adapters/matrix/session-persistence.ts
+++ b/apps/server/src/adapters/matrix/session-persistence.ts
@@ -9,6 +9,7 @@ import {
 export interface PersistedMatrixSessionRow {
   session_id: string;
   user_id: string;
+  profile_id?: string | null;
   platform: string;
   status: string;
   platform_user_id?: string | null;
@@ -32,6 +33,7 @@ export function toPersistedMatrixSession(session: PlatformSession) {
   return {
     session_id: session.id,
     user_id: session.userId,
+    profile_id: session.profileId || null,
     platform: session.platform,
     status: session.status,
     platform_user_id: session.platformUserId || null,
@@ -68,6 +70,7 @@ export function fromPersistedMatrixSession(
   return {
     id: row.session_id,
     userId: row.user_id,
+    profileId: row.profile_id || undefined,
     platform: row.platform as Platform,
     status: row.status as PlatformStatus,
     authMethod,

--- a/apps/server/src/adapters/types.ts
+++ b/apps/server/src/adapters/types.ts
@@ -185,6 +185,8 @@ export interface PlatformSession {
   id: string;
   platform: Platform;
   userId: string;
+  /** Workspace that owns this connected account. */
+  profileId?: string;
   status: PlatformStatus;
   authMethod: AuthMethod;
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,6 +21,7 @@ import aiRoutes from './routes/ai';
 import platformRoutes from './routes/platforms';
 import conversationRoutes from './routes/conversations';
 import preferencesRoutes from './routes/preferences';
+import profileRoutes from './routes/profiles';
 import autoReplyRoutes from './routes/auto-reply';
 import { aiRateLimit, authRateLimit } from './middleware/rate-limit';
 import seedRoutes from './routes/seed';
@@ -73,6 +74,7 @@ app.set('trust proxy', 1);
 
 async function notifyIncomingMessage(message: {
   userId: string;
+  profileId: string;
   chatId: string;
   platform: string;
   senderName?: string;
@@ -130,6 +132,7 @@ app.use('/ai', aiRateLimit, aiRoutes);
 app.use('/platforms', platformRoutes);
 app.use('/conversations', conversationRoutes);
 app.use('/preferences', preferencesRoutes);
+app.use('/profiles', profileRoutes);
 // Seed/reset route — only functional when MOCK_BRIDGE=true (guarded inside route)
 app.use('/seed', seedRoutes);
 app.use('/loops', loopRoutes);
@@ -440,11 +443,22 @@ async function initializePlatforms() {
     });
 
     try {
+      // A message is always emitted from an explicit connection. Resolve its
+      // profile before any durable write so bridge traffic cannot leak into a
+      // similarly-named account on another workspace.
+      const sourceSession = await platformManager.getSession(message.sessionId);
+      const profileId = sourceSession?.profileId;
+      if (!profileId) {
+        logger.warn('Skipping message without a workspace profile', { platform: message.platform });
+        return;
+      }
       // Fast-path: skip duplicate messages (backfill replay) without touching the DB further
       const { data: existing } = await supabase
         .from('messages')
         .select('id,content,platform')
-        .eq('whatsapp_id', message.platformMessageId)
+        .eq('profile_id', profileId)
+        .eq('platform', message.platform)
+        .eq('platform_message_id', message.platformMessageId)
         .maybeSingle();
 
       if (existing) {
@@ -463,7 +477,7 @@ async function initializePlatforms() {
       }
 
       logger.info('New platform message accepted', { platform: message.platform });
-      const aiProcessingEnabled = await isAiProcessingEnabled(message.userId);
+      const aiProcessingEnabled = await isAiProcessingEnabled(message.userId, profileId);
 
       // A WhatsApp LID is an opaque bridge identifier, not a contact name or
       // number. Prefer the real bridge profile name and omit the field when
@@ -487,6 +501,8 @@ async function initializePlatforms() {
         .upsert(
           {
             user_id: message.userId,
+            profile_id: profileId,
+            platform_session_id: message.sessionId,
             whatsapp_chat_id: message.chatId,
             platform_chat_id: message.chatId,
             platform: message.platform,
@@ -494,7 +510,7 @@ async function initializePlatforms() {
             is_group: message.chatType === 'group',
             last_message_at: message.timestamp,
           },
-          { onConflict: 'user_id,platform,platform_chat_id' }
+          { onConflict: 'profile_id,platform_session_id,platform,platform_chat_id' }
         )
         .select('id')
         .single();
@@ -530,13 +546,14 @@ async function initializePlatforms() {
             .upsert(
               {
                 user_id: message.userId,
+                profile_id: profileId,
                 platform: message.platform,
                 platform_contact_id: platformContactId,
                 whatsapp_id: platformContactId,
                 ...(contactName ? { name: contactName } : {}),
                 ...(contactPhone ? { phone_number: contactPhone } : {}),
               },
-              { onConflict: 'user_id,platform,platform_contact_id' }
+              { onConflict: 'profile_id,platform,platform_contact_id' }
             )
             .select('id, name')
             .single();
@@ -607,6 +624,7 @@ async function initializePlatforms() {
         .upsert(
           {
             user_id: message.userId,
+            profile_id: profileId,
             chat_id: chat.id,
             whatsapp_id: message.platformMessageId,
             platform_message_id: message.platformMessageId,
@@ -649,7 +667,7 @@ async function initializePlatforms() {
               (message.platformMetadata?.mediaInfo as { mimetype?: string } | undefined)
                 ?.mimetype || null,
           },
-          { onConflict: 'whatsapp_id', ignoreDuplicates: true }
+          { onConflict: 'profile_id,platform,platform_message_id', ignoreDuplicates: true }
         )
         .select('id')
         .maybeSingle();
@@ -710,6 +728,7 @@ async function initializePlatforms() {
         if (!message.isFromMe && !isBackfill && savedMsg?.id) {
           void notifyIncomingMessage({
             userId: message.userId,
+            profileId,
             chatId: chat.id,
             platform: message.platform,
             senderName: message.senderName,

--- a/apps/server/src/routes/contacts.ts
+++ b/apps/server/src/routes/contacts.ts
@@ -5,12 +5,15 @@ import { logger } from '../utils/logger';
 import { queueWhatsAppContactIdentitySync } from '../services/whatsapp-contact-backfill';
 import { phoneNumberFromPlatformContactId } from '../services/contact-identity';
 import { Platform } from '../adapters/types';
+import { profileScopeError, resolveProfileId } from '../services/profile-context';
 
 const router = Router();
 
 router.get('/', requireAuth, async (req: Request, res: Response) => {
   const userId = req.user?.id;
   if (!userId) return res.status(401).json({ success: false, error: 'Unauthorized' });
+  const profileId = await resolveProfileId(req, userId);
+  if (!profileId) return res.status(403).json({ success: false, ...profileScopeError() });
 
   try {
     // People is an address book as well as a conversation workspace. The
@@ -27,6 +30,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
         .from('contacts')
         .select('id, name, phone_number, platform_contact_id, avatar_url, inferred_name, inferred_relationship, is_group, platform, username')
         .eq('user_id', userId)
+        .eq('profile_id', profileId)
         .order('name', { ascending: true, nullsFirst: false })
         .order('id', { ascending: true });
 
@@ -72,6 +76,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
         .from('chats')
         .select('id, contact_id, name, platform, is_group, last_message_at')
         .eq('user_id', userId)
+        .eq('profile_id', profileId)
         .in('contact_id', contactIds)
         .order('last_message_at', { ascending: false, nullsFirst: false });
       if (platform !== 'all') chatQuery = chatQuery.eq('platform', platform);

--- a/apps/server/src/routes/platforms.ts
+++ b/apps/server/src/routes/platforms.ts
@@ -21,6 +21,7 @@ import { platformCatalog, platformCatalogVersion } from '../platform-catalog';
 import { supabase, type DbRow } from '../services/supabase';
 import { operationsTelemetry } from '../services/operations-telemetry';
 import { queueWhatsAppContactIdentitySync } from '../services/whatsapp-contact-backfill';
+import { profileScopeError, resolveProfileId } from '../services/profile-context';
 
 // Railway services cannot reach each other through localhost. Railway does not
 // inject NODE_ENV by default, so its public-domain marker is also used to
@@ -240,6 +241,8 @@ router.get('/:platform/status', async (req: Request, res: Response) => {
         error: 'Unauthorized',
       });
     }
+    const profileId = await resolveProfileId(req, userId);
+    if (!profileId) return res.status(403).json({ success: false, ...profileScopeError() });
 
     if (!Object.values(Platform).includes(platform as Platform)) {
       return res.status(400).json({
@@ -260,7 +263,7 @@ router.get('/:platform/status', async (req: Request, res: Response) => {
     // /platforms/whatsapp/status can never make Telegram or Instagram appear
     // connected in the client cache.
     const sessions = (await adapter.getUserSessions(userId)).filter(
-      (session) => session.platform === platform,
+      (session) => session.platform === platform && session.profileId === profileId,
     );
 
     // Disable caching so polling always gets fresh session state / QR codes
@@ -271,6 +274,7 @@ router.get('/:platform/status', async (req: Request, res: Response) => {
       platform,
       sessions: sessions.map((s) => ({
         id: s.id,
+        profileId: s.profileId,
         platform: s.platform,
         status: s.status,
         authMethod: s.authMethod,
@@ -305,6 +309,8 @@ router.post('/instagram/login/start', async (req: Request, res: Response) => {
     if (!userId) {
       return res.status(401).json({ success: false, error: 'Unauthorized' });
     }
+    const profileId = await resolveProfileId(req, userId);
+    if (!profileId) return res.status(403).json({ success: false, ...profileScopeError() });
 
     const adapter = platformManager.getAdapter(Platform.INSTAGRAM);
     if (!adapter) {
@@ -316,7 +322,7 @@ router.post('/instagram/login/start', async (req: Request, res: Response) => {
     // explicitly retire it instead of accumulating duplicate sessions.
     const matrixAdapter = adapter as MatrixBridgeAdapter;
     const pendingSessions = (await adapter.getUserSessions(userId)).filter((session) => (
-      session.platform === Platform.INSTAGRAM
+      session.platform === Platform.INSTAGRAM && session.profileId === profileId
       && (session.status === PlatformStatus.INITIALIZING
         || session.status === PlatformStatus.AWAITING_AUTH
         || session.status === PlatformStatus.AUTHENTICATING
@@ -342,6 +348,7 @@ router.post('/instagram/login/start', async (req: Request, res: Response) => {
     sessionId = `instagram-${userId}-${Date.now()}`;
     await adapter.createSession(userId, sessionId, {
       platform: Platform.INSTAGRAM,
+      profileId,
       // Instagram uses the provisioning API below, not a Matrix bot command.
       skipBridgeAuth: true,
     } as never);
@@ -542,6 +549,8 @@ router.post('/:platform/connect', async (req: Request, res: Response) => {
         error: 'Unauthorized',
       });
     }
+    const profileId = await resolveProfileId(req, userId);
+    if (!profileId) return res.status(403).json({ success: false, ...profileScopeError() });
 
     if (!Object.values(Platform).includes(platform as Platform)) {
       return res.status(400).json({
@@ -558,11 +567,11 @@ router.post('/:platform/connect', async (req: Request, res: Response) => {
       });
     }
 
-    // Connection creation is idempotent per user and platform. This is the
+    // Connection creation is idempotent per profile and platform. This is the
     // server-side authority that protects against stale mobile caches, rapid
     // taps, and two clients opening the login screen at the same time.
     const existingSessions = (await adapter.getUserSessions(userId)).filter(
-      (existing) => existing.platform === platform,
+      (existing) => existing.platform === platform && existing.profileId === profileId,
     );
     const connectedSession = existingSessions.find(
       (existing) => existing.status === PlatformStatus.CONNECTED,
@@ -616,7 +625,7 @@ router.post('/:platform/connect', async (req: Request, res: Response) => {
       const session = await (adapter as MatrixBridgeAdapter).createSession(
         userId,
         newSessionId,
-        { platform: Platform.WHATSAPP, phoneNumber: config.phoneNumber, skipBridgeAuth: true } as never
+        { platform: Platform.WHATSAPP, profileId, phoneNumber: config.phoneNumber, skipBridgeAuth: true } as never
       );
       const pairingCode = codeStep.display_and_wait?.data;
       await (adapter as MatrixBridgeAdapter).setSessionAuthData(
@@ -677,7 +686,7 @@ router.post('/:platform/connect', async (req: Request, res: Response) => {
       });
     }
 
-    const session = await adapter.createSession(userId, newSessionId, config);
+    const session = await adapter.createSession(userId, newSessionId, { ...config, profileId });
 
     // For QR-based auth, return auth data
     const authData = await adapter.getAuthData(session.id);

--- a/apps/server/src/routes/preferences.ts
+++ b/apps/server/src/routes/preferences.ts
@@ -6,6 +6,7 @@ import { supabase } from '../services/supabase';
 import { logger } from '../utils/logger';
 import { voiceProfileService } from '../services/voice-profile-service';
 import { aiProcessingDisclosure, isAiProcessingEnabled } from '../services/ai-policy';
+import { profileScopeError, resolveProfileId } from '../services/profile-context';
 
 const router = Router();
 
@@ -50,11 +51,14 @@ const updatePreferencesSchema = z.object({
 router.get('/', requireAuth, async (req: Request, res: Response) => {
   const userId = req.user?.id;
   if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+  const profileId = await resolveProfileId(req, userId);
+  if (!profileId) return res.status(403).json(profileScopeError());
 
   const { data, error } = await supabase
     .from('user_preferences')
     .select('tone, response_style, language, notification_enabled, preferences')
     .eq('user_id', userId)
+    .eq('profile_id', profileId)
     .single();
 
   if (error && error.code !== 'PGRST116') {
@@ -85,10 +89,12 @@ router.put(
   async (req: Request, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+    const profileId = await resolveProfileId(req, userId);
+    if (!profileId) return res.status(403).json(profileScopeError());
 
     const { tone, response_style, language, notification_enabled, preferences } = req.body;
 
-    const updates: Record<string, unknown> = { user_id: userId };
+    const updates: Record<string, unknown> = { user_id: userId, profile_id: profileId };
     if (tone !== undefined) updates.tone = tone;
     if (response_style !== undefined) updates.response_style = response_style;
     if (language !== undefined) updates.language = language;
@@ -98,6 +104,7 @@ router.put(
         .from('user_preferences')
         .select('preferences')
         .eq('user_id', userId)
+        .eq('profile_id', profileId)
         .maybeSingle();
       // Preference updates are partial from different clients. Preserve keys the
       // current desktop/client does not know about rather than clobbering them.
@@ -106,7 +113,7 @@ router.put(
 
     const { data, error } = await supabase
       .from('user_preferences')
-      .upsert(updates, { onConflict: 'user_id' })
+      .upsert(updates, { onConflict: 'user_id,profile_id' })
       .select('tone, response_style, language, notification_enabled, preferences')
       .single();
 

--- a/apps/server/src/routes/profiles.ts
+++ b/apps/server/src/routes/profiles.ts
@@ -1,0 +1,97 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../middleware/auth';
+import { supabase } from '../services/supabase';
+import { logger } from '../utils/logger';
+import { platformManager, Platform } from '../adapters';
+import { MatrixBridgeAdapter } from '../adapters/matrix';
+
+const router = Router();
+const color = z.string().regex(/^#[0-9A-Fa-f]{6}$/);
+const createSchema = z.object({ name: z.string().trim().min(1).max(48), color: color.optional() });
+const updateSchema = z.object({ name: z.string().trim().min(1).max(48).optional(), color: color.optional(), sortOrder: z.number().int().min(0).optional() });
+
+router.use(requireAuth);
+
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+    await supabase.rpc('ensure_personal_profile', { target_user_id: userId });
+    const [{ data: profiles, error }, { data: unread }] = await Promise.all([
+      supabase.from('profiles').select('id,name,color,is_personal,sort_order,created_at').eq('user_id', userId).order('sort_order').order('created_at'),
+      supabase.from('chats').select('profile_id,unread_count').eq('user_id', userId).gt('unread_count', 0),
+    ]);
+    if (error) throw error;
+    const unreadByProfile = new Map<string, number>();
+    for (const row of unread || []) {
+      const profileId = typeof row.profile_id === 'string' ? row.profile_id : '';
+      unreadByProfile.set(profileId, (unreadByProfile.get(profileId) || 0) + (Number(row.unread_count) || 0));
+    }
+    return res.json({ success: true, data: (profiles || []).map((profile) => ({ ...profile, unreadCount: unreadByProfile.get(profile.id) || 0 })) });
+  } catch (error) {
+    logger.error('Unable to list profiles', error);
+    return res.status(500).json({ error: 'Failed to load profiles' });
+  }
+});
+
+router.post('/', async (req: Request, res: Response) => {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'A name and six-digit color are required' });
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+  const { data: last } = await supabase.from('profiles').select('sort_order').eq('user_id', userId).order('sort_order', { ascending: false }).limit(1).maybeSingle();
+  const { data, error } = await supabase.from('profiles')
+    .insert({ user_id: userId, name: parsed.data.name, color: parsed.data.color || '#38A169', sort_order: (last?.sort_order || 0) + 1 })
+    .select('id,name,color,is_personal,sort_order,created_at').single();
+  if (error) return res.status(error.code === '23505' ? 409 : 500).json({ error: error.code === '23505' ? 'A profile with that name already exists' : 'Failed to create profile' });
+  return res.status(201).json({ success: true, data: { ...data, unreadCount: 0 } });
+});
+
+router.patch('/:profileId', async (req: Request, res: Response) => {
+  const parsed = updateSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Invalid profile update' });
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+  const updates: Record<string, unknown> = {};
+  if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+  if (parsed.data.color !== undefined) updates.color = parsed.data.color;
+  if (parsed.data.sortOrder !== undefined) updates.sort_order = parsed.data.sortOrder;
+  const { data, error } = await supabase.from('profiles').update(updates).eq('id', req.params.profileId).eq('user_id', userId).select('id,name,color,is_personal,sort_order,created_at').maybeSingle();
+  if (error) return res.status(500).json({ error: 'Failed to update profile' });
+  if (!data) return res.status(404).json({ error: 'Profile not found' });
+  return res.json({ success: true, data });
+});
+
+router.delete('/:profileId', async (req: Request, res: Response) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+  const { data: profile } = await supabase.from('profiles').select('id,is_personal').eq('id', req.params.profileId).eq('user_id', userId).maybeSingle();
+  if (!profile) return res.status(404).json({ error: 'Profile not found' });
+  if (profile.is_personal) return res.status(400).json({ error: 'Personal cannot be deleted' });
+  const [{ count: sessions }, { count: chats }] = await Promise.all([
+    supabase.from('platform_sessions').select('id', { count: 'exact', head: true }).eq('profile_id', profile.id),
+    supabase.from('chats').select('id', { count: 'exact', head: true }).eq('profile_id', profile.id),
+  ]);
+  if ((sessions || 0) + (chats || 0) > 0) return res.status(409).json({ error: 'Move or disconnect this profile’s accounts before deleting it' });
+  const { error } = await supabase.from('profiles').delete().eq('id', profile.id).eq('user_id', userId);
+  if (error) return res.status(500).json({ error: 'Failed to delete profile' });
+  return res.json({ success: true });
+});
+
+router.post('/:profileId/move-session', async (req: Request, res: Response) => {
+  const userId = req.user?.id;
+  const sessionId = typeof req.body?.sessionId === 'string' ? req.body.sessionId : '';
+  if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+  if (!sessionId) return res.status(400).json({ error: 'sessionId is required' });
+  const { data: connection } = await supabase.from('platform_sessions').select('platform').eq('session_id', sessionId).eq('user_id', userId).maybeSingle();
+  const { error } = await supabase.rpc('move_platform_session_to_profile', {
+    target_user_id: userId, target_session_id: sessionId, target_profile_id: req.params.profileId,
+  });
+  if (error) return res.status(error.message.includes('not found') ? 404 : 500).json({ error: error.message });
+  const adapter = connection?.platform ? platformManager.getAdapter(connection.platform as Platform) : undefined;
+  if (adapter instanceof MatrixBridgeAdapter) await adapter.assignSessionProfile(sessionId, req.params.profileId);
+  return res.json({ success: true });
+});
+
+export default router;

--- a/apps/server/src/services/ai-policy.ts
+++ b/apps/server/src/services/ai-policy.ts
@@ -9,12 +9,13 @@ type StoredPreferences = { ai_enabled?: unknown };
  * existing product behaviour; a database read failure fails closed so an
  * explicit privacy choice is never bypassed during an outage.
  */
-export async function isAiProcessingEnabled(userId: string): Promise<boolean> {
-  const { data, error } = await supabase
+export async function isAiProcessingEnabled(userId: string, profileId?: string): Promise<boolean> {
+  let query = supabase
     .from('user_preferences')
     .select('preferences')
-    .eq('user_id', userId)
-    .maybeSingle();
+    .eq('user_id', userId);
+  if (profileId) query = query.eq('profile_id', profileId);
+  const { data, error } = await query.maybeSingle();
   if (error) {
     logger.warn('Could not verify AI processing preference', { errorCode: error.code || 'preference_read_failed' });
     return false;

--- a/apps/server/src/services/notification-delivery.ts
+++ b/apps/server/src/services/notification-delivery.ts
@@ -19,6 +19,7 @@ interface NotificationDevice {
 
 export interface IncomingNotificationEvent {
   userId: string;
+  profileId: string;
   chatId: string;
   platform: string;
   senderName?: string;
@@ -100,9 +101,9 @@ export class NotificationDeliveryService {
   async enqueueIncomingMessage(event: IncomingNotificationEvent): Promise<number> {
     this.start();
     const [{ data: preferences, error: preferenceError }, { data: devices, error: deviceError }, { data: chat, error: chatError }] = await Promise.all([
-      supabase.from('user_preferences').select('notification_enabled,preferences').eq('user_id', event.userId).maybeSingle(),
+      supabase.from('user_preferences').select('notification_enabled,preferences').eq('user_id', event.userId).eq('profile_id', event.profileId).maybeSingle(),
       supabase.from('notification_devices').select('id,user_id,device_id,platform,provider,token,enabled,timezone').eq('user_id', event.userId).eq('enabled', true),
-      supabase.from('chats').select('is_muted').eq('id', event.chatId).eq('user_id', event.userId).maybeSingle(),
+      supabase.from('chats').select('is_muted').eq('id', event.chatId).eq('user_id', event.userId).eq('profile_id', event.profileId).maybeSingle(),
     ]);
     if (preferenceError) throw preferenceError;
     if (deviceError) throw deviceError;
@@ -140,6 +141,7 @@ export class NotificationDeliveryService {
           type: 'new_message',
           messageId: event.messageId,
           chatId: event.chatId,
+          profileId: event.profileId,
           platform: event.platform,
           url: `claire://chat/${event.chatId}?messageId=${event.messageId}`,
         },

--- a/apps/server/src/services/profile-context.ts
+++ b/apps/server/src/services/profile-context.ts
@@ -1,0 +1,30 @@
+import type { Request } from 'express';
+import { supabase } from './supabase';
+
+export const PROFILE_HEADER = 'x-claire-profile-id';
+
+/**
+ * Resolve a user-owned workspace from an HTTP request.  Profile IDs are never
+ * trusted just because a client supplied one: every scoped route uses this
+ * helper before reading or mutating profile data.
+ */
+export async function resolveProfileId(req: Request, userId: string): Promise<string | null> {
+  const requested = req.get(PROFILE_HEADER)?.trim();
+  if (requested) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('id', requested)
+      .eq('user_id', userId)
+      .maybeSingle();
+    return data?.id ?? null;
+  }
+
+  const { data, error } = await supabase.rpc('ensure_personal_profile', { target_user_id: userId });
+  if (error || typeof data !== 'string') return null;
+  return data;
+}
+
+export function profileScopeError() {
+  return { error: 'Profile not found or not owned by this account' };
+}

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -44,6 +44,7 @@ export type ClaireInstagramLoginRequest = {
   /** Ephemeral, authenticated server context. Never persisted by the host. */
   apiUrl: string;
   accessToken: string;
+  profileId?: string;
 };
 
 export type ClaireInstagramLoginResult = { success: boolean; error?: string };

--- a/supabase/migrations/20260821120000_add_workspace_profiles.sql
+++ b/supabase/migrations/20260821120000_add_workspace_profiles.sql
@@ -1,0 +1,162 @@
+-- Profiles are an application-level workspace boundary.  They deliberately
+-- belong to a Claire user, not auth.users directly, so the existing user
+-- provisioning path remains the single source of account ownership.
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL CHECK (char_length(trim(name)) BETWEEN 1 AND 48),
+  color TEXT NOT NULL DEFAULT '#7C6EF6' CHECK (color ~ '^#[0-9A-Fa-f]{6}$'),
+  is_personal BOOLEAN NOT NULL DEFAULT false,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, name)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_one_personal
+  ON public.profiles(user_id) WHERE is_personal;
+CREATE INDEX IF NOT EXISTS idx_profiles_user_order
+  ON public.profiles(user_id, sort_order, created_at);
+
+CREATE TRIGGER update_profiles_updated_at BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own workspace profiles" ON public.profiles
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.ensure_personal_profile(target_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE profile_id UUID;
+BEGIN
+  SELECT id INTO profile_id FROM public.profiles
+    WHERE user_id = target_user_id AND is_personal = true LIMIT 1;
+  IF profile_id IS NULL THEN
+    INSERT INTO public.profiles (user_id, name, color, is_personal, sort_order)
+    VALUES (target_user_id, 'Personal', '#7C6EF6', true, 0)
+    ON CONFLICT (user_id, name) DO UPDATE SET is_personal = true
+    RETURNING id INTO profile_id;
+  END IF;
+  RETURN profile_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_personal_profile_for_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  PERFORM public.ensure_personal_profile(NEW.id);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS create_personal_profile_for_user ON public.users;
+CREATE TRIGGER create_personal_profile_for_user
+  AFTER INSERT ON public.users FOR EACH ROW EXECUTE FUNCTION public.create_personal_profile_for_user();
+
+-- Existing users retain their exact history; it is simply placed in Personal.
+INSERT INTO public.profiles (user_id, name, color, is_personal, sort_order)
+SELECT id, 'Personal', '#7C6EF6', true, 0 FROM public.users
+ON CONFLICT (user_id, name) DO UPDATE SET is_personal = true;
+
+ALTER TABLE public.platform_sessions ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE RESTRICT;
+ALTER TABLE public.contacts ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE RESTRICT;
+ALTER TABLE public.chats ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE RESTRICT;
+ALTER TABLE public.chats ADD COLUMN IF NOT EXISTS platform_session_id TEXT;
+ALTER TABLE public.messages ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE RESTRICT;
+ALTER TABLE public.user_preferences ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE;
+ALTER TABLE public.platform_settings ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE;
+ALTER TABLE public.auto_reply_rules ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE;
+ALTER TABLE public.user_voice_profiles ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+UPDATE public.platform_sessions s SET profile_id = public.ensure_personal_profile(s.user_id) WHERE profile_id IS NULL;
+UPDATE public.contacts c SET profile_id = public.ensure_personal_profile(c.user_id) WHERE profile_id IS NULL;
+UPDATE public.chats c SET profile_id = public.ensure_personal_profile(c.user_id), platform_session_id = COALESCE(c.platform_session_id, 'legacy:' || c.platform::text)
+  WHERE profile_id IS NULL OR platform_session_id IS NULL;
+UPDATE public.messages m SET profile_id = c.profile_id FROM public.chats c WHERE c.id = m.chat_id AND m.profile_id IS NULL;
+UPDATE public.user_preferences p SET profile_id = public.ensure_personal_profile(p.user_id) WHERE profile_id IS NULL;
+UPDATE public.platform_settings p SET profile_id = public.ensure_personal_profile(p.user_id) WHERE profile_id IS NULL;
+UPDATE public.auto_reply_rules r SET profile_id = public.ensure_personal_profile(r.user_id) WHERE profile_id IS NULL;
+UPDATE public.user_voice_profiles v SET profile_id = public.ensure_personal_profile(v.user_id) WHERE profile_id IS NULL;
+
+ALTER TABLE public.platform_sessions ALTER COLUMN profile_id SET NOT NULL;
+ALTER TABLE public.contacts ALTER COLUMN profile_id SET NOT NULL;
+ALTER TABLE public.chats ALTER COLUMN profile_id SET NOT NULL;
+ALTER TABLE public.messages ALTER COLUMN profile_id SET NOT NULL;
+ALTER TABLE public.user_preferences ALTER COLUMN profile_id SET NOT NULL;
+
+-- A remote chat ID is only meaningful within a particular connected account.
+ALTER TABLE public.chats DROP CONSTRAINT IF EXISTS chats_user_platform_chat_key;
+ALTER TABLE public.chats ADD CONSTRAINT chats_profile_session_platform_chat_key
+  UNIQUE (profile_id, platform_session_id, platform, platform_chat_id);
+CREATE INDEX IF NOT EXISTS idx_chats_profile_last_message ON public.chats(profile_id, last_message_at DESC NULLS LAST);
+ALTER TABLE public.contacts DROP CONSTRAINT IF EXISTS contacts_user_platform_contact_key;
+ALTER TABLE public.contacts ADD CONSTRAINT contacts_profile_platform_contact_key
+  UNIQUE (profile_id, platform, platform_contact_id);
+CREATE INDEX IF NOT EXISTS idx_contacts_profile_platform_identity ON public.contacts(profile_id, platform, platform_contact_id);
+CREATE INDEX IF NOT EXISTS idx_messages_profile_chat_timestamp ON public.messages(profile_id, chat_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_platform_sessions_profile ON public.platform_sessions(profile_id, platform, status);
+
+ALTER TABLE public.user_preferences DROP CONSTRAINT IF EXISTS user_preferences_user_id_key;
+ALTER TABLE public.user_preferences ADD CONSTRAINT user_preferences_user_profile_key UNIQUE (user_id, profile_id);
+ALTER TABLE public.platform_settings DROP CONSTRAINT IF EXISTS platform_settings_user_id_platform_key;
+ALTER TABLE public.platform_settings ADD CONSTRAINT platform_settings_user_profile_platform_key UNIQUE (user_id, profile_id, platform);
+ALTER TABLE public.user_voice_profiles DROP CONSTRAINT IF EXISTS user_voice_profiles_pkey;
+ALTER TABLE public.user_voice_profiles ADD PRIMARY KEY (user_id, profile_id, language);
+
+-- Platform IDs are issued by remote accounts, not by Claire users. Two
+-- accounts can legitimately use the same remote event identifier.
+ALTER TABLE public.messages DROP CONSTRAINT IF EXISTS messages_whatsapp_id_key;
+ALTER TABLE public.messages ADD CONSTRAINT messages_profile_platform_event_key
+  UNIQUE (profile_id, platform, platform_message_id);
+
+-- The view is the shared read primitive for mobile and desktop inboxes.
+CREATE OR REPLACE VIEW public.conversation_feed
+WITH (security_invoker = true) AS
+SELECT c.id AS chat_id, c.user_id, c.platform, c.platform_chat_id,
+  c.name AS chat_name, c.is_group, c.is_pinned, c.pinned_at, c.is_archived, c.is_muted,
+  c.unread_count, c.last_read_at, c.contact_id, ct.name AS contact_name,
+  ct.inferred_name AS contact_inferred_name, ct.avatar_url AS contact_avatar_url, ct.phone_number AS contact_phone,
+  m.id AS last_message_id, m.content AS last_message_content, m.content_type AS last_message_content_type,
+  m.from_me AS last_message_from_me, m.status AS last_message_status, m.snoozed_until AS last_message_snoozed_until,
+  m.contact_name AS last_message_sender_name, m.timestamp AS last_message_at,
+  EXISTS (SELECT 1 FROM public.ai_suggestions s WHERE s.message_id = m.id AND s.user_id = c.user_id) AS last_message_has_ai_response,
+  COALESCE(m.timestamp, c.last_message_at, c.updated_at, c.created_at) AS last_activity_at,
+  m.media_url AS last_message_media_url, m.media_mime_type AS last_message_media_mime_type,
+  -- New columns must be appended: CREATE OR REPLACE VIEW preserves existing
+  -- column positions for PostgREST clients.
+  c.profile_id, c.platform_session_id
+FROM public.chats c
+LEFT JOIN public.contacts ct ON ct.id = c.contact_id AND ct.profile_id = c.profile_id
+LEFT JOIN LATERAL (
+  SELECT msg.id, msg.content, msg.content_type, msg.media_url, msg.media_mime_type, msg.from_me, msg.status,
+    msg.snoozed_until, msg.contact_name, msg.timestamp
+  FROM public.messages msg WHERE msg.chat_id = c.id AND msg.user_id = c.user_id AND msg.profile_id = c.profile_id
+  ORDER BY msg.timestamp DESC LIMIT 1
+) m ON TRUE;
+
+-- Moving a connection moves its complete durable workspace footprint.  The
+-- caller must still verify ownership before invoking this function.
+CREATE OR REPLACE FUNCTION public.move_platform_session_to_profile(
+  target_user_id UUID, target_session_id TEXT, target_profile_id UUID
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = target_profile_id AND user_id = target_user_id) THEN
+    RAISE EXCEPTION 'Profile not found';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.platform_sessions WHERE session_id = target_session_id AND user_id = target_user_id) THEN
+    RAISE EXCEPTION 'Connection not found';
+  END IF;
+  UPDATE public.platform_sessions SET profile_id = target_profile_id WHERE session_id = target_session_id AND user_id = target_user_id;
+  UPDATE public.chats SET profile_id = target_profile_id WHERE platform_session_id = target_session_id AND user_id = target_user_id;
+  UPDATE public.contacts c SET profile_id = target_profile_id
+    WHERE c.user_id = target_user_id AND EXISTS (SELECT 1 FROM public.chats ch WHERE ch.contact_id = c.id AND ch.platform_session_id = target_session_id);
+  UPDATE public.messages m SET profile_id = target_profile_id
+    WHERE m.user_id = target_user_id AND EXISTS (SELECT 1 FROM public.chats ch WHERE ch.id = m.chat_id AND ch.platform_session_id = target_session_id);
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add Personal-first, color-coded workspace profiles with profile CRUD and an active-profile client store
- scope connections, chats, contacts, inbox/realtime, preferences, Matrix sessions, and notification payloads to the selected profile
- support separate same-platform accounts, assign new connections to the active profile, and move a connection with its history between profiles
- backfill legacy data to Personal via a migration and enforce profile ownership in profile-aware server routes

## Validation
- `git diff --check`
- full Bun typecheck/tests not run: Bun is not installed in this environment

## Follow-up scope
- Loops and the remaining AI retrieval/automation surfaces still need full profile scoping before this becomes the complete end-to-end feature described in the original design.