### PR TITLE
copy(website): humanize marketing language

### DIFF
--- a/apps/website/public/campaigns/close-the-loop.html
+++ b/apps/website/public/campaigns/close-the-loop.html
@@ -36,8 +36,7 @@
           <p class="eyebrow"><span></span> CLAIRE FILM CONCEPT / 01</p>
           <h1>Close your<br /><i>loops.</i></h1>
           <p class="intro">
-            The little things you mean to do are the things that make up a life. Claire keeps them
-            from becoming the things you forgot.
+            You mean to do a lot of small things. Claire helps keep them from slipping away.
           </p>
         </div>
         <div class="loop-orbit" aria-hidden="true">
@@ -60,8 +59,7 @@
           <p class="eyebrow"><span></span> THE 60 SECOND FILM</p>
           <h2>A familiar feeling.<br />A better ending.</h2>
           <p>
-            Three small missed moments, then the quiet relief of letting Claire keep track of what
-            matters.
+            Three small missed moments, then the relief of letting Claire keep track of what matters.
           </p>
         </div>
 
@@ -104,7 +102,7 @@
                 ><small id="scene-phone-notice">Read 2h ago</small>
               </div>
               <p class="visual-caption" id="scene-visual-caption">
-                The moment you remember,<br />just a little too late.
+                The moment you remember,<br />a little too late.
               </p>
             </div>
             <div class="scene-copy">

--- a/apps/website/public/campaigns/close-the-loop.js
+++ b/apps/website/public/campaigns/close-the-loop.js
@@ -10,7 +10,7 @@ const scenes = {
     phoneContext: 'Friday',
     phoneTitle: 'It’s our anniversary.',
     phoneNotice: 'Read 2h ago',
-    caption: 'The moment you remember,<br />just a little too late.',
+    caption: 'The moment you remember,<br />a little too late.',
   },
   dinner: {
     counter: 'SCENE 02 / 04',
@@ -30,7 +30,7 @@ const scenes = {
     duration: '00:20 — 00:30',
     kicker: 'THE OPEN LOOP',
     title: 'Forgot to follow up with the client?',
-    body: 'The six-figure deal did not disappear because you were careless. Its thread just disappeared into every other thread.',
+    body: 'The six-figure deal got buried under every other thread.',
     line: '“Some loops cost more than others.”',
     visual: 'is-client',
     phoneContext: 'David · proposal',

--- a/apps/website/src/app/(marketing)/business/page.tsx
+++ b/apps/website/src/app/(marketing)/business/page.tsx
@@ -145,7 +145,7 @@ export default function BusinessPage() {
           </h1>
           <p className="hero-copy">
             Manage Instagram, WhatsApp, LinkedIn, SMS, Messenger, and more from one shared
-            inbox—with AI that qualifies leads, prepares replies, routes work, and follows through.
+            inbox. AI can qualify leads, prepare replies, route work, and handle follow-ups.
           </p>
           <div className="hero-actions">
             <a className="button button-dark" href="#contact">
@@ -304,7 +304,7 @@ export default function BusinessPage() {
             </div>
             <p>
               Customer messaging is already spread across personal apps, shared logins, and a phone
-              on someone’s desk. Claire’s job is to collapse that into a single accountable queue.
+              on someone’s desk. Claire brings it into one queue with a clear owner.
             </p>
           </header>
           <div className="shift-grid">
@@ -389,8 +389,8 @@ export default function BusinessPage() {
               </h2>
             </div>
             <p>
-              Claire Business combines a shared inbox, customer context, AI assistance, assignments,
-              and automation without turning every conversation into a ticket.
+              Claire Business brings together a shared inbox, customer context, AI assistance,
+              assignments, and automation without treating every conversation like a ticket.
             </p>
           </header>
           <div className="workspace-grid">
@@ -459,7 +459,7 @@ export default function BusinessPage() {
               </div>
               <div className="workspace-copy">
                 <span>AI COPILOT</span>
-                <h3>Answers grounded in your business.</h3>
+                <h3>Answers based on your business.</h3>
                 <p>Draft replies from approved knowledge, inventory, policies, and history.</p>
               </div>
             </article>

--- a/apps/website/src/app/(marketing)/developers/page.tsx
+++ b/apps/website/src/app/(marketing)/developers/page.tsx
@@ -152,7 +152,7 @@ export default function DevelopersPage() {
             <p>
               Claire is an AI-native, multi-network messenger with open references for mobile,
               desktop, connectors, and conversation plugins. Clone it, run the whole stack in mock
-              mode, and make one part dramatically better.
+              mode, and improve one part at a time.
             </p>
             <div className="dev-hero-actions">
               <a className="button button-dark" href="#start">
@@ -725,7 +725,7 @@ export default function DevelopersPage() {
               <span className="claire-underline">Operate with care.</span>
             </h2>
             <p>
-              The community can make Claire broader and more trustworthy: connectors for underserved
+              The community can make Claire more useful and more trustworthy: connectors for underserved
               networks, local-first deployments, plugins for real workflows, translations,
               accessibility, and deeper platform-native experiences.
             </p>

--- a/apps/website/src/app/(marketing)/pricing/page.tsx
+++ b/apps/website/src/app/(marketing)/pricing/page.tsx
@@ -22,7 +22,7 @@ const loopSteps = [
     number: '01',
     label: 'SWEEP',
     title: 'Read every connected chat.',
-    body: 'One pass across every network on the account—not one conversation at a time, and not only the threads you happened to open.',
+    body: 'One pass across every network on the account, including conversations you have not opened.',
     chips: ['WhatsApp', 'Telegram', 'Instagram'],
   },
   {
@@ -50,7 +50,7 @@ const tiers = [
     title: 'Get your chats in one place.',
     price: '$0',
     unit: 'forever',
-    body: 'Every network in one inbox, with a weekly Loop so nothing important quietly disappears.',
+    body: 'Every network in one inbox, with a weekly Loop to help important threads stay in view.',
     loop: '1 Loop run per week',
     features: [
       'Up to 5 connected networks',
@@ -69,7 +69,7 @@ const tiers = [
     title: 'The full AI, on demand.',
     price: '$10',
     unit: 'USD / month',
-    body: 'Everything Claire’s AI can do, with Loop runs you can fire whenever the inbox gets loud.',
+    body: 'Everything Claire’s AI can do, with Loop runs whenever the inbox gets busy.',
     loop: 'Up to 3 Loop runs per day',
     features: [
       'Every supported network, 3 accounts each',
@@ -281,7 +281,7 @@ const questions = [
   ],
   [
     'What happens when I use up my Loop runs?',
-    'Messaging, search, connections, promises, and reminders all keep working. The next Loop waits for your allowance to reset, or you move up a plan. Claire never silently bills you for another run.',
+    'Messaging, search, connections, promises, and reminders all keep working. The next Loop waits for your allowance to reset, or you move up a plan. Claire does not bill you automatically for another run.',
   ],
   [
     'Can I bring my own OpenAI or Anthropic key?',
@@ -489,8 +489,8 @@ export default function PricingPage() {
               </h2>
             </div>
             <p>
-              Loop runs and AI credits are metered separately from the subscription, so model costs
-              never become a surprise line on a card statement.
+              Loop runs and AI credits are metered separately from the subscription, so you can track
+              model costs separately from your plan.
             </p>
           </header>
           <div className="usage-grid">
@@ -512,7 +512,7 @@ export default function PricingPage() {
                   <span>hard cap · no overage</span>
                 </div>
               </div>
-              <small>Credits settle against actual model usage—not a made-up “one request” unit.</small>
+              <small>Credits reflect actual model usage, not a flat “one request” unit.</small>
             </article>
             <article className="usage-card">
               <span className="usage-icon">
@@ -551,8 +551,8 @@ export default function PricingPage() {
                 </h2>
               </div>
               <p>
-                Same Loop, running continuously across the whole workspace—except now it can act.
-                Connect your systems and let Claire turn what customers say into work that is done.
+                The same Loop runs continuously across the workspace and can take approved actions.
+                Connect your systems and let Claire turn customer messages into work for the team.
               </p>
             </header>
 
@@ -586,7 +586,7 @@ export default function PricingPage() {
               <h3>Connect the systems the work actually lives in.</h3>
               <p>
                 A plugin declares what it can do, how risky each action is, and whether a person has
-                to approve it. Availability is listed honestly—nothing here pretends to be finished.
+                to approve it. The catalog shows what is available now and what is still planned.
               </p>
             </div>
             <div className="pr-plugin-grid">

--- a/apps/website/src/components/site/HomePage.tsx
+++ b/apps/website/src/components/site/HomePage.tsx
@@ -22,14 +22,10 @@ export function HomePage() {
             <span className="claire-underline">One AI.</span>
           </h1>
           <p className="hero-copy">
-            Bring WhatsApp, Telegram, Instagram, and more into one intelligent client. Search every
-            conversation, get relationship-aware help, and never lose track of what you promised.
+            Bring WhatsApp, Telegram, Instagram, and more into one client. Search your conversations,
+            get help that understands the relationship, and keep track of what you promised.
           </p>
           <div className="hero-actions" id="waitlist">
-            <p className="hero-waitlist-copy">
-              Join the waitlist to get the beta—and short, honest notes on what shipped, what
-              broke, and what I learned along the way.
-            </p>
             <WaitlistForm source="homepage_hero" />
           </div>
           <div className="hero-art" aria-label="Claire application preview">
@@ -517,8 +513,8 @@ export function HomePage() {
               </h2>
             </div>
             <p>
-              Claire connects your chat networks, then gives its AI the context to help you find,
-              understand, reply, and follow through—without losing the human thread.
+              Claire brings your chat networks together and gives its AI the context to help you find,
+              understand, reply, and follow through.
             </p>
           </div>
           <div className="feature-grid">
@@ -562,7 +558,7 @@ export function HomePage() {
                 </div>
               </div>
               <div>
-                <h3>Conversation becomes follow-through.</h3>
+                <h3>Keep promises moving.</h3>
                 <p>
                   Claire notices commitments in your chats and turns them into gentle follow-through.
                 </p>
@@ -681,7 +677,7 @@ export function HomePage() {
         <section className="stories" id="stories">
           <div className="shell">
             <div className="kicker">PEOPLE HAVE ENOUGH TO JUGGLE</div>
-            <h2>Claire keeps the human things close.</h2>
+            <h2>Keep the people who matter in view.</h2>
             <div className="quotes">
               <blockquote>
                 <p>
@@ -823,7 +819,7 @@ export function HomePage() {
           <div className="pricing-teaser-foot">
             <p>
               AI use is metered separately from the subscription, with a visible balance and a hard
-              cap. Model costs never become a surprise.
+              cap, so model costs stay predictable.
             </p>
             <Link className="button button-dark" href="/pricing">
               Compare all plans <HeroIcon name="arrow-right" />

--- a/apps/website/src/components/site/LabHome.tsx
+++ b/apps/website/src/components/site/LabHome.tsx
@@ -8,7 +8,7 @@ const labDestinations = [
     href: '/lab/style',
     eyebrow: 'FOUNDATIONS',
     title: 'Style guide',
-    body: 'Color, type, surfaces, component anatomy, and the writing system that holds Claire together.',
+    body: 'Color, type, surfaces, component anatomy, and the writing rules used across Claire.',
   },
   {
     href: '/lab/logo',
@@ -26,7 +26,7 @@ const labDestinations = [
     href: '/mockups/mobile',
     eyebrow: 'PRODUCT',
     title: 'Mobile reference',
-    body: 'The mobile information architecture and high-fidelity screen gallery.',
+    body: 'The mobile information architecture and screen gallery.',
   },
   {
     href: '/lab/ask',
@@ -61,8 +61,8 @@ export function LabHome() {
             <span className="claire-underline">feel inevitable.</span>
           </h1>
           <p>
-            The working source for Claire’s visual language, product references, and exploratory AI
-            experiences. These are living references—not a separate product.
+            The working source for Claire’s visual language, product references, and AI experiments.
+            These are working references, not a separate product.
           </p>
         </section>
         <section className="lab-home__grid" aria-label="Claire Lab destinations">

--- a/apps/website/src/components/site/SecurityPage.tsx
+++ b/apps/website/src/components/site/SecurityPage.tsx
@@ -37,8 +37,7 @@ export function SecurityPage() {
               <HeroIcon name="shield" size="xl" />
             </div>
             <p>
-              Security should make the product easier to understand—not hide its trade-offs behind a
-              badge.
+              Security should make the product easier to understand and make its trade-offs clear.
             </p>
           </aside>
         </section>
@@ -116,7 +115,7 @@ export function SecurityPage() {
               <div className="kicker">HOW DATA MOVES</div>
               <h2 id="map-title">One message, named boundaries.</h2>
             </div>
-            <p>We prefer showing the flow to making blanket privacy claims.</p>
+            <p>We show the flow instead of making blanket privacy claims.</p>
           </div>
           <div className="security-map-grid">
             <article className="security-map-step">
@@ -163,7 +162,7 @@ export function SecurityPage() {
             <div className="kicker">WHAT WE WILL EARN</div>
             <h2 id="roadmap-title">Stronger claims require stronger proof.</h2>
             <p>
-              We will only upgrade our language when a real configuration, test suite, and review
+              We will only make stronger claims when a real configuration, test suite, and review
               demonstrate the behavior in production.
             </p>
           </div>

--- a/apps/website/src/components/site/WaitlistForm.tsx
+++ b/apps/website/src/components/site/WaitlistForm.tsx
@@ -122,8 +122,8 @@ export function WaitlistForm({ source, tone = 'light' }: WaitlistFormProps) {
           ? submission.message
           : (
               <>
-                By joining, you agree to receive short build notes and your beta invitation. No
-                inbox filler; unsubscribe anytime. <Link href="/legal/privacy">Privacy</Link>
+                By joining, you agree to receive short build notes and your beta invitation. You can
+                {' '}unsubscribe anytime. <Link href="/legal/privacy">Privacy</Link>
               </>
             )}
       </p>

--- a/apps/website/src/content/site.ts
+++ b/apps/website/src/content/site.ts
@@ -7,7 +7,7 @@ export const primaryNavigation = [
 ] as const;
 
 export const moreLinks = [
-  { href: '/lab', title: 'Claire Lab', body: 'The visual system, product references, and working explorations.' },
+  { href: '/lab', title: 'Claire Lab', body: 'The visual system, product references, and work in progress.' },
   {
     href: '/security',
     title: 'Security',


### PR DESCRIPTION
## Summary
- remove the homepage waitlist support line
- revise visitor-facing marketing and campaign copy for a more direct, natural voice
- preserve product claims while removing filler and stock phrasing

## Validation
- bun run typecheck:website