### PR TITLE
Refine Ask Claire sources and response actions

### DIFF
--- a/apps/client/app/assistant.tsx
+++ b/apps/client/app/assistant.tsx
@@ -7,8 +7,10 @@ import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, CheckCircle2, Messag
 import { colors, mobileType, radius, space, useIsDesktopLayout } from '@claire/design-system';
 import { MobileIconButton, SectionLabel } from '../components/mobile/claire-mobile';
 import { AskComposer, AskToolGrid } from '../components/claire/composer';
+import { AssistantAnswerActions } from '../components/claire/assistant-answer-actions';
 import { ClaireMark } from '../components/claire/mark';
 import { AskClaireSkeleton, DesktopAskClaireSkeleton } from '../components/claire/skeleton';
+import { PlatformName } from '../components/PlatformIcon';
 import { useChromeStore } from '../stores/chromeStore';
 import { useAuthStore } from '../stores/authStore';
 import { readQuerySnapshot, writeQuerySnapshot } from '../services/mobile-cache';
@@ -32,6 +34,7 @@ function formatThreadTime(value: string) {
 function Sources({ citations, onExpand }: { citations: AssistantCitation[]; onExpand: () => void }) {
   const [expanded, setExpanded] = useState(false);
   if (!citations.length) return null;
+  const previewSources = citations.slice(0, 3);
   return (
     <View style={{ gap: space[2] }} testID="assistant-sources">
       <Pressable
@@ -45,13 +48,27 @@ function Sources({ citations, onExpand }: { citations: AssistantCitation[]; onEx
           return next;
         })}
       >
-        <View style={{ minHeight: 40, flexDirection: 'row', alignItems: 'center', gap: space[2], paddingHorizontal: space[3], borderRadius: radius.control, borderCurve: 'continuous', borderWidth: 1, borderColor: colors.neutral[300], backgroundColor: colors.neutral[100] }}>
-          <Text selectable maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.label, flex: 1, color: colors.ink }}>Sources · {citations.length}</Text>
-          {expanded ? <ChevronUp size={17} color={colors.ink} /> : <ChevronDown size={17} color={colors.ink} />}
+        <View style={{ minHeight: 32, flexDirection: 'row', alignItems: 'center', gap: space[2] }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', paddingRight: space[1] }}>
+            {previewSources.map((citation, index) => {
+              const name = citation.fromMe ? 'You' : citation.senderName;
+              const initials = name.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]).join('').toUpperCase() || '?';
+              return (
+                <View key={citation.messageId} style={{ width: 25, height: 25, marginLeft: index ? -7 : 0, borderRadius: 13, borderWidth: 2, borderColor: colors.sky, alignItems: 'center', justifyContent: 'center', backgroundColor: index % 2 ? colors.lime : colors.cream }}>
+                  <Text maxFontSizeMultiplier={1} style={{ fontSize: 9, lineHeight: 11, fontWeight: '800', color: colors.ink }}>{initials}</Text>
+                </View>
+              );
+            })}
+          </View>
+          <Text selectable maxFontSizeMultiplier={1} style={{ ...mobileType.label, color: colors.ink }}>Sources</Text>
+          <Text selectable maxFontSizeMultiplier={1} style={{ ...mobileType.label, color: colors.neutral[600] }}>{citations.length}</Text>
+          <View style={{ marginLeft: 'auto' }}>
+            {expanded ? <ChevronUp size={17} color={colors.neutral[600]} /> : <ChevronDown size={17} color={colors.neutral[600]} />}
+          </View>
         </View>
       </Pressable>
       {expanded ? (
-        <ScrollView horizontal style={{ height: 140 }} showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: space[2], paddingRight: space[4], paddingBottom: space[1] }} testID="assistant-sources-carousel">
+        <ScrollView horizontal style={{ height: 148, marginHorizontal: -space[4] }} showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: space[2], paddingLeft: space[4] }} testID="assistant-sources-carousel">
           {citations.map((citation) => (
             <Pressable
               key={citation.messageId}
@@ -70,13 +87,20 @@ function Sources({ citations, onExpand }: { citations: AssistantCitation[]; onEx
                 },
               })}
             >
-              <View style={{ width: 272, minHeight: 132, justifyContent: 'space-between', gap: space[2], padding: space[3], borderRadius: radius.control, borderCurve: 'continuous', borderWidth: 1, borderColor: colors.neutral[300], backgroundColor: colors.cream }}>
-                <View style={{ gap: 3 }}>
-                  <Text selectable maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.label, fontWeight: '800', color: colors.ink }}>{citation.fromMe ? 'You' : citation.senderName} · {new Date(citation.timestamp).toLocaleDateString()}</Text>
-                  <Text selectable maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.label, color: colors.neutral[600] }}>{citation.platform}{citation.isPreferredScope === false ? ' · also relevant' : ''}</Text>
+              <View style={{ width: 264, minHeight: 144, justifyContent: 'space-between', gap: space[2], padding: space[3], borderRadius: radius.card, borderCurve: 'continuous', borderWidth: 1, borderColor: colors.infoBorder, backgroundColor: colors.infoSurface }}>
+                <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: space[2] }}>
+                  <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+                    <Text selectable maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.bodySmall, fontWeight: '800', color: colors.ink }}>{citation.fromMe ? 'You' : citation.senderName}</Text>
+                    <PlatformName platform={citation.platform} size={14} />
+                  </View>
+                  <Text selectable maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.label, color: colors.neutral[600], fontVariant: ['tabular-nums'] }}>{new Date(citation.timestamp).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</Text>
                 </View>
-                <Text selectable maxFontSizeMultiplier={1} numberOfLines={4} style={{ ...mobileType.bodySmall, color: colors.neutral[800] }}>{citation.excerpt}</Text>
-                <Text maxFontSizeMultiplier={1} style={{ ...mobileType.label, color: colors.neutral[600] }}>Open conversation →</Text>
+                <Text selectable maxFontSizeMultiplier={1} numberOfLines={3} style={{ ...mobileType.body, color: colors.neutral[800], lineHeight: 21 }}>{citation.excerpt}</Text>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+                  <Text maxFontSizeMultiplier={1} style={{ ...mobileType.label, color: colors.ink }}>Open chat</Text>
+                  <ChevronRight size={15} color={colors.ink} />
+                  {citation.isPreferredScope === false ? <Text maxFontSizeMultiplier={1} numberOfLines={1} style={{ ...mobileType.label, color: colors.neutral[600], marginLeft: 2 }}>Also relevant</Text> : null}
+                </View>
               </View>
             </Pressable>
           ))}
@@ -311,6 +335,7 @@ export function AssistantScreen({ inTab = false }: { inTab?: boolean }) {
         role: 'assistant',
         content: result.answer,
         citations: result.citations,
+        actions: result.actions,
         scope_chat_ids: scopeChatIds,
         created_at: new Date().toISOString(),
       }]);
@@ -412,6 +437,7 @@ export function AssistantScreen({ inTab = false }: { inTab?: boolean }) {
                 <View style={{ padding: space[4], borderRadius: radius.card, borderCurve: 'continuous', borderWidth: turn.role === 'assistant' ? 1 : 0, borderColor: colors.ink, backgroundColor: turn.role === 'user' ? colors.ink : colors.paper }}>
                   <Text selectable style={{ ...mobileType.body, color: turn.role === 'user' ? colors.paper : colors.ink }}>{turn.content}</Text>
                 </View>
+                {turn.role === 'assistant' ? <AssistantAnswerActions actions={turn.actions} /> : null}
                 {turn.role === 'assistant' ? <Sources citations={turn.citations || []} onExpand={() => requestAnimationFrame(() => conversationScrollRef.current?.scrollToEnd({ animated: true }))} /> : null}
               </View>
             ))}

--- a/apps/client/app/chat/assistant/[chatId].tsx
+++ b/apps/client/app/chat/assistant/[chatId].tsx
@@ -9,6 +9,7 @@ import { platformsApi } from '../../../services/platforms';
 import { supabase } from '../../../services/supabase';
 import { useAuthStore } from '../../../stores/authStore';
 import { MobileIconButton, MobileSearchField } from '../../../components/mobile/claire-mobile';
+import { AssistantAnswerActions } from '../../../components/claire/assistant-answer-actions';
 
 type QuickAction = {
   label: string;
@@ -151,6 +152,7 @@ export default function ConversationAssistantScreen() {
             ) : (
               <View style={{ gap: space[2] }}>
                 <View style={{ alignSelf: 'flex-start', maxWidth: '94%', padding: space[4], borderRadius: radius.card, borderBottomLeftRadius: 6, backgroundColor: colors.paper, borderWidth: 1, borderColor: colors.neutral[300] }}><Text selectable style={{ ...mobileType.body, color: colors.ink }}>{item.content}</Text></View>
+                <AssistantAnswerActions actions={item.actions} />
                 {item.citations?.slice(0, 3).map(citation => <Pressable key={`${item.id}-${citation.messageId}`} onPress={() => openCitation(citation)} style={({ pressed }) => ({ padding: space[3], borderRadius: radius.control, borderWidth: 1, borderColor: colors.neutral[300], backgroundColor: pressed ? colors.paper : 'rgba(255,255,255,0.48)', gap: 3 })}><View style={{ flexDirection: 'row', alignItems: 'center', gap: space[2] }}><Text style={{ ...mobileType.label, color: colors.ink, flex: 1 }}>{citation.senderName} · {new Date(citation.timestamp).toLocaleDateString()}</Text><ExternalLink size={14} color={colors.neutral[600]} /></View><Text numberOfLines={2} style={{ ...mobileType.bodySmall, color: colors.neutral[600] }}>{citation.excerpt}</Text></Pressable>)}
               </View>
             )}

--- a/apps/client/components/claire/assistant-answer-actions.tsx
+++ b/apps/client/components/claire/assistant-answer-actions.tsx
@@ -1,0 +1,51 @@
+import { Linking, Platform, Pressable, Text, View } from 'react-native';
+import { CalendarPlus, MessageCircle } from 'lucide-react-native';
+import { router } from 'expo-router';
+import { colors, mobileType, radius, space } from '@claire/design-system';
+import type { AssistantAction } from '../../services/conversationAssistant';
+
+export function AssistantAnswerActions({ actions }: { actions?: AssistantAction[] }) {
+  if (!actions?.length) return null;
+
+  const handleAction = (action: AssistantAction) => {
+    if (action.type === 'open_conversation' && action.chatId) {
+      router.push({
+        pathname: '/chat/[chatId]',
+        params: {
+          chatId: action.chatId,
+          contact_name: action.chatName || 'Conversation',
+          chat_name: action.chatName || 'Conversation',
+          platform: action.platform || 'unknown',
+          is_group: action.isGroup ? '1' : '0',
+        },
+      });
+      return;
+    }
+
+    if (action.type === 'open_calendar') {
+      const calendarUrl = Platform.OS === 'ios' ? 'calshow:' : 'content://com.android.calendar/time/';
+      void Linking.openURL(calendarUrl);
+    }
+  };
+
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: space[2] }} testID="assistant-answer-actions">
+      {actions.map((action, index) => {
+        const Icon = action.type === 'open_calendar' ? CalendarPlus : MessageCircle;
+        return (
+          <Pressable
+            key={`${action.type}-${action.label}-${index}`}
+            accessibilityRole="button"
+            accessibilityLabel={action.label}
+            testID={`assistant-answer-action-${action.type}`}
+            onPress={() => handleAction(action)}
+            style={({ pressed }) => ({ minHeight: 38, flexDirection: 'row', alignItems: 'center', gap: 7, paddingHorizontal: space[3], borderRadius: radius.pill, borderWidth: 1, borderColor: colors.ink, backgroundColor: colors.paper, opacity: pressed ? 0.72 : 1 })}
+          >
+            <Icon size={16} color={colors.ink} />
+            <Text maxFontSizeMultiplier={1} style={{ ...mobileType.label, color: colors.ink }}>{action.label}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/client/services/conversationAssistant.ts
+++ b/apps/client/services/conversationAssistant.ts
@@ -15,6 +15,17 @@ export interface AssistantCitation {
   isPreferredScope?: boolean;
 }
 
+export interface AssistantAction {
+  type: 'open_conversation' | 'open_calendar';
+  label: string;
+  chatId?: string;
+  chatName?: string | null;
+  platform?: string;
+  isGroup?: boolean;
+  title?: string;
+  startsAt?: string;
+}
+
 export interface AssistantThread {
   id: string;
   title: string;
@@ -28,6 +39,7 @@ export interface AssistantTurn {
   role: 'user' | 'assistant';
   content: string;
   citations: AssistantCitation[];
+  actions?: AssistantAction[];
   scope_chat_ids?: string[];
   created_at: string;
 }
@@ -69,7 +81,7 @@ export const conversationAssistantApi = {
   }),
   getThread: (threadId: string) => request<{ thread: AssistantThread; turns: AssistantTurn[] }>(`/ai/assistant/threads/${encodeURIComponent(threadId)}`),
   deleteThread: (threadId: string) => request<void>(`/ai/assistant/threads/${encodeURIComponent(threadId)}`, { method: 'DELETE' }),
-  ask: (threadId: string, question: string, chatIds: string[] = []) => request<{ answer: string; citations: AssistantCitation[]; indexing: AssistantIndexStatus }>(
+  ask: (threadId: string, question: string, chatIds: string[] = []) => request<{ answer: string; citations: AssistantCitation[]; actions: AssistantAction[]; indexing: AssistantIndexStatus }>(
     `/ai/assistant/threads/${encodeURIComponent(threadId)}/messages`,
     { method: 'POST', body: JSON.stringify({ question, chatIds }) },
   ),
@@ -84,7 +96,7 @@ export const conversationAssistantApi = {
       throw error;
     }
   },
-  askConversation: (chatId: string, question: string) => request<{ thread: AssistantThread; turns: AssistantTurn[]; answer: string; citations: AssistantCitation[]; indexing: AssistantIndexStatus }>(
+  askConversation: (chatId: string, question: string) => request<{ thread: AssistantThread; turns: AssistantTurn[]; answer: string; citations: AssistantCitation[]; actions: AssistantAction[]; indexing: AssistantIndexStatus }>(
     `/ai/assistant/conversations/${encodeURIComponent(chatId)}/messages`,
     { method: 'POST', body: JSON.stringify({ question }) },
   ),

--- a/apps/client/test-results/core-flows-Core-loop-—-moc-4ddc9-atches-to-platform-send-API/error-context.md
+++ b/apps/client/test-results/core-flows-Core-loop-—-moc-4ddc9-atches-to-platform-send-API/error-context.md
@@ -1,0 +1,314 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: core-flows.spec.mjs >> Core loop — mock backend >> send path: text message dispatches to platform send API
+- Location: e2e/core-flows.spec.mjs:693:3
+
+# Error details
+
+```
+Error: expect(locator).toBeVisible() failed
+
+Locator: getByText('Test media send path')
+Expected: visible
+Error: strict mode violation: getByText('Test media send path') resolved to 3 elements:
+    1) <div dir="auto" class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1qsk4np r-textOverflow-1udbk01">Test media send path</div> aka getByTestId('inbox-highlight-optimistic-1788541808594').getByText('Test media send path')
+    2) <div dir="auto" class="css-text-146c3p1 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-userSelect-1xnzce8">Test media send path</div> aka getByTestId('message-card-optimistic-1788541808594').getByText('Test media send path')
+    3) <div dir="auto" class="css-text-146c3p1">Test media send path</div> aka getByRole('button', { name: 'Test media send path 11:10 AM' })
+
+Call log:
+  - Expect "toBeVisible" with timeout 5000ms
+  - waiting for getByText('Test media send path')
+
+```
+
+# Page snapshot
+
+```yaml
+- generic [active] [ref=f1e1]:
+  - generic [ref=f1e14]:
+    - generic [ref=f1e15]:
+      - button "Back" [ref=f1e16] [cursor=pointer]
+      - generic [ref=f1e20]: A(
+      - generic [ref=f1e23]:
+        - generic [ref=f1e24]: Alice (WA)
+        - generic [ref=f1e25]: WhatsApp
+      - button "Conversation settings" [ref=f1e30] [cursor=pointer]
+    - generic [ref=f1e37]:
+      - generic [ref=f1e38] [cursor=pointer]:
+        - generic [ref=f1e43]:
+          - generic [ref=f1e44]: OPEN LOOP
+          - generic [ref=f1e45]: Send Alice the report
+        - generic [ref=f1e46]: View
+      - generic [ref=f1e48]:
+        - button "Test media send path 11:10 AM" [ref=f1e51] [cursor=pointer]:
+          - generic [ref=f1e52]:
+            - generic [ref=f1e53]: Test media send path
+            - generic [ref=f1e54]: 11:10 AM
+        - button "Open report.pdf 10:16 AM" [ref=f1e57] [cursor=pointer]:
+          - generic [ref=f1e58]:
+            - button "Open report.pdf" [ref=f1e59]:
+              - generic [ref=f1e64]:
+                - generic [ref=f1e65]: report.pdf
+                - generic [ref=f1e66]: Tap to open
+            - generic [ref=f1e67]: 10:16 AM
+        - button "Play video Short clip 10:15 AM" [ref=f1e70] [cursor=pointer]:
+          - generic [ref=f1e71]:
+            - generic [ref=f1e72]:
+              - button "Play video" [ref=f1e73]
+              - generic [ref=f1e77]: Short clip
+            - generic [ref=f1e78]: 10:15 AM
+        - generic [ref=f1e82] [cursor=pointer]:
+          - generic [ref=f1e83]:
+            - button "Play voice message" [ref=f1e84]
+            - generic [ref=f1e87]:
+              - generic "Voice note waveform, 0 percent played" [ref=f1e88]
+              - generic [ref=f1e131]: 0:00
+          - generic [ref=f1e132]: 10:13 AM
+        - button "Check out this photo 10:11 AM" [ref=f1e135] [cursor=pointer]:
+          - generic [ref=f1e136]:
+            - generic [ref=f1e137]: Check out this photo
+            - generic [ref=f1e142]: 10:11 AM
+        - button "Thanks for letting me know 10:10 AM" [ref=f1e145] [cursor=pointer]:
+          - generic [ref=f1e146]:
+            - generic [ref=f1e147]: Thanks for letting me know
+            - generic [ref=f1e148]: 10:10 AM
+        - button "Hi! I'll send you the report by Friday 10:08 AM" [ref=f1e151] [cursor=pointer]:
+          - generic [ref=f1e152]:
+            - generic [ref=f1e153]: Hi! I'll send you the report by Friday
+            - generic [ref=f1e154]: 10:08 AM
+      - generic [ref=f1e157]:
+        - button "Chat actions" [ref=f1e158] [cursor=pointer]
+        - textbox "Write a message…" [ref=f1e161]
+        - button "Hold to record a voice note" [ref=f1e162] [cursor=pointer]
+        - button "Send message" [disabled]
+    - generic [ref=f1e168]:
+      - button "Bottom sheet backdrop"
+    - generic [ref=f1e169]:
+      - slider "Bottom Sheet"
+      - slider "Bottom Sheet" [ref=f1e171]:
+        - generic [ref=f1e172]:
+          - generic [ref=f1e173]:
+            - generic [ref=f1e174]: MESSAGE ACTIONS
+            - button "Close message actions" [ref=f1e175] [cursor=pointer]
+          - generic [ref=f1e179]:
+            - button "Copy message" [disabled]:
+              - generic [ref=f1e183]: Copy
+      - slider "Bottom sheet handle" [ref=f1e186] [cursor=pointer]
+  - button "5 <button> cannot contain a nested <button" [ref=f1e189] [cursor=pointer]:
+    - generic [ref=f1e190]: "5"
+    - generic [ref=f1e192]: <button> cannot contain a nested <button
+    - button [ref=f1e193]
+```
+
+# Test source
+
+```ts
+  623 |     // Tray itself should also disappear when no cards remain
+  624 |     await expect(page.getByTestId('smart-card-tray')).not.toBeVisible({ timeout: 3_000 });
+  625 |   });
+  626 |
+  627 |   // 12. Morning Brief — brief text renders from fixture endpoint (#32)
+  628 |   test('morning brief renders from /ai/morning-brief fixture', async ({ page }) => {
+  629 |     await signIn(page);
+  630 |
+  631 |     // Morning brief container should appear (fed by the mocked /ai/morning-brief endpoint)
+  632 |     await expect(page.getByTestId('morning-brief-container')).toBeVisible({ timeout: 10_000 });
+  633 |
+  634 |     // The fixture brief text should be visible
+  635 |     await expect(
+  636 |       page.getByText('2 messages need your attention')
+  637 |     ).toBeVisible({ timeout: 8_000 });
+  638 |   });
+  639 |
+  640 |   // 12b. Urgent card — renders from morning brief fixture (#32)
+  641 |   test('urgent card renders for the fixture urgent message', async ({ page }) => {
+  642 |     await signIn(page);
+  643 |
+  644 |     // The urgent cards container should be visible
+  645 |     await expect(page.getByTestId('urgent-cards-container')).toBeVisible({ timeout: 10_000 });
+  646 |
+  647 |     // Alice (WA) urgent card should be rendered (first urgent message in fixture)
+  648 |     // Scope within the container to avoid ambiguity with inbox card rows
+  649 |     await expect(
+  650 |       page.getByTestId('urgent-cards-container').getByText('Alice (WA)')
+  651 |     ).toBeVisible({ timeout: 8_000 });
+  652 |   });
+  653 |
+  654 |   // 13. Media in — incoming image fixture renders in chat (#35)
+  655 |   test('incoming image message renders in chat', async ({ page }) => {
+  656 |     await signIn(page);
+  657 |
+  658 |     await expect(
+  659 |       page.locator('[data-testid^="message-card-"]').first()
+  660 |     ).toBeVisible({ timeout: 8_000 });
+  661 |     await page.locator('[data-testid^="message-card-"]').first().click();
+  662 |
+  663 |     await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+  664 |     await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+  665 |
+  666 |     // The image fixture message should render (testID added in this ticket)
+  667 |     const image = page.getByTestId('media-image-img-chatmsg-img').locator('img');
+  668 |     await expect(image).toBeVisible({ timeout: 8_000 });
+  669 |     await expect(image).toHaveJSProperty('naturalWidth', 1);
+  670 |   });
+  671 |
+  672 |   // 13b. Media in — audio, video, and document fixtures render in chat (#35)
+  673 |   test('incoming audio, video, and document messages render in chat', async ({ page }) => {
+  674 |     await signIn(page);
+  675 |
+  676 |     await expect(
+  677 |       page.locator('[data-testid^="message-card-"]').first()
+  678 |     ).toBeVisible({ timeout: 8_000 });
+  679 |     await page.locator('[data-testid^="message-card-"]').first().click();
+  680 |
+  681 |     await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+  682 |     await expect(page.getByTestId('chat-message-list')).toBeVisible({ timeout: 8_000 });
+  683 |
+  684 |     // Audio fixture
+  685 |     await expect(page.getByTestId('media-audio-chatmsg-audio')).toBeVisible({ timeout: 8_000 });
+  686 |     // Video fixture
+  687 |     await expect(page.getByTestId('media-video-chatmsg-video')).toBeVisible({ timeout: 8_000 });
+  688 |     // Document fixture
+  689 |     await expect(page.getByTestId('media-document-chatmsg-doc')).toBeVisible({ timeout: 8_000 });
+  690 |   });
+  691 |
+  692 |   // 13c. Media send path — send button dispatches to platform API (#35)
+  693 |   test('send path: text message dispatches to platform send API', async ({ page }) => {
+  694 |     await signIn(page);
+  695 |
+  696 |     const sessionsResponsePromise = page.waitForResponse('**/platforms/**', { timeout: 10_000 }).catch(() => null);
+  697 |
+  698 |     await expect(
+  699 |       page.locator('[data-testid^="message-card-"]').first()
+  700 |     ).toBeVisible({ timeout: 8_000 });
+  701 |
+  702 |     await sessionsResponsePromise;
+  703 |     await page.locator('[data-testid^="message-card-"]').first().click();
+  704 |
+  705 |     await expect(page.getByTestId('chat-screen')).toBeVisible({ timeout: 10_000 });
+  706 |     await expect(page.getByTestId('chat-input')).toBeVisible({ timeout: 8_000 });
+  707 |
+  708 |     // Intercept the send API call
+  709 |     const sendRequestPromise = page.waitForRequest(
+  710 |       (req) => req.url().includes('/send') && req.method() === 'POST',
+  711 |       { timeout: 8_000 }
+  712 |     );
+  713 |
+  714 |     await page.getByTestId('chat-input').fill('Test media send path');
+  715 |     await page.getByTestId('chat-send-button').click();
+  716 |
+  717 |     // Verify the send API was called
+  718 |     const sendReq = await sendRequestPromise;
+  719 |     expect(sendReq).toBeTruthy();
+  720 |
+  721 |     // Input should be cleared after send
+  722 |     await expect(page.getByTestId('chat-input')).toHaveValue('', { timeout: 5_000 });
+> 723 |     await expect(page.getByText('Test media send path')).toBeVisible({ timeout: 5_000 });
+      |                                                          ^ Error: expect(locator).toBeVisible() failed
+  724 |   });
+  725 |
+  726 |   // 14. Snooze — long-pressing a message card opens the snooze modal (#38)
+  727 |   test('long-pressing a message card opens the snooze picker', async ({ page }) => {
+  728 |     await signIn(page);
+  729 |
+  730 |     await expect(page.getByTestId('messages-screen')).toBeVisible({ timeout: 10_000 });
+  731 |     await expect(
+  732 |       page.locator('[data-testid^="message-card-"]').first()
+  733 |     ).toBeVisible({ timeout: 8_000 });
+  734 |
+  735 |     // Long-press to trigger onLongPress (Playwright click with delay triggers long-press)
+  736 |     await page.locator('[data-testid^="message-card-"]').first().click({ delay: 600 });
+  737 |
+  738 |     // Snooze modal should appear
+  739 |     await expect(page.getByTestId('snooze-modal-overlay')).toBeVisible({ timeout: 5_000 });
+  740 |
+  741 |     // Snooze options should be present
+  742 |     await expect(page.getByTestId('snooze-option-3h')).toBeVisible();
+  743 |     await expect(page.getByTestId('snooze-option-tomorrow')).toBeVisible();
+  744 |   });
+  745 |
+  746 |   // 14b. Snooze — selecting an option hides the message from inbox (#38)
+  747 |   test('snoozing a message hides it from the inbox', async ({ page }) => {
+  748 |     await signIn(page);
+  749 |
+  750 |     await expect(page.getByTestId('messages-screen')).toBeVisible({ timeout: 10_000 });
+  751 |     await expect(
+  752 |       page.locator('[data-testid^="message-card-"]').first()
+  753 |     ).toBeVisible({ timeout: 8_000 });
+  754 |
+  755 |     // Get the ID of the first card so we can check it disappears
+  756 |     const firstCard = page.locator('[data-testid^="message-card-"]').first();
+  757 |     const firstCardTestId = await firstCard.getAttribute('data-testid');
+  758 |
+  759 |     // Long-press to open snooze modal
+  760 |     await firstCard.click({ delay: 600 });
+  761 |     await expect(page.getByTestId('snooze-modal-overlay')).toBeVisible({ timeout: 5_000 });
+  762 |
+  763 |     // Tap "Later today (3 hours)" option
+  764 |     await page.getByTestId('snooze-option-3h').click();
+  765 |
+  766 |     // Modal should close
+  767 |     await expect(page.getByTestId('snooze-modal-overlay')).not.toBeVisible({ timeout: 3_000 });
+  768 |
+  769 |     // The snoozed card should be removed from the inbox (optimistic hide)
+  770 |     if (firstCardTestId) {
+  771 |       await expect(page.getByTestId(firstCardTestId)).not.toBeVisible({ timeout: 3_000 });
+  772 |     }
+  773 |   });
+  774 |
+  775 |   // 14c. Snooze — cancelling dismisses the modal without snoozing (#38)
+  776 |   test('cancelling the snooze modal keeps the message in inbox', async ({ page }) => {
+  777 |     await signIn(page);
+  778 |
+  779 |     await expect(page.getByTestId('messages-screen')).toBeVisible({ timeout: 10_000 });
+  780 |     await expect(
+  781 |       page.locator('[data-testid^="message-card-"]').first()
+  782 |     ).toBeVisible({ timeout: 8_000 });
+  783 |
+  784 |     const firstCard = page.locator('[data-testid^="message-card-"]').first();
+  785 |     const firstCardTestId = await firstCard.getAttribute('data-testid');
+  786 |
+  787 |     // Long-press to open snooze modal
+  788 |     await firstCard.click({ delay: 600 });
+  789 |     await expect(page.getByTestId('snooze-modal-overlay')).toBeVisible({ timeout: 5_000 });
+  790 |
+  791 |     // Tap Cancel
+  792 |     await page.getByTestId('snooze-cancel').click();
+  793 |
+  794 |     // Modal should close
+  795 |     await expect(page.getByTestId('snooze-modal-overlay')).not.toBeVisible({ timeout: 3_000 });
+  796 |
+  797 |     // The card should still be in the inbox (not snoozed)
+  798 |     if (firstCardTestId) {
+  799 |       await expect(page.getByTestId(firstCardTestId)).toBeVisible({ timeout: 3_000 });
+  800 |     }
+  801 |   });
+  802 |
+  803 |   // 15. Group-chat summary — banner renders and shows summary text after expand (#41)
+  804 |   test('group chat summary banner renders and shows summary on expand', async ({ page }) => {
+  805 |     // Override the messages endpoint to return a group message as the first inbox entry
+  806 |     await page.route('**/rest/v1/**', async (route) => {
+  807 |       const url = route.request().url();
+  808 |       if (url.includes('/messages')) {
+  809 |         if (url.includes('chat_id=eq.')) {
+  810 |           await route.fulfill({
+  811 |             status: 200,
+  812 |             contentType: 'application/json',
+  813 |             body: JSON.stringify([
+  814 |               {
+  815 |                 id: 'gchatmsg-1',
+  816 |                 content: 'Hey team, meeting at 3pm!',
+  817 |                 timestamp: new Date(Date.now() - 1800_000).toISOString(),
+  818 |                 from_me: false,
+  819 |                 contact_name: 'Alice',
+  820 |                 contact_phone: null,
+  821 |                 content_type: 'text',
+  822 |               },
+  823 |             ]),
+```

--- a/apps/server/src/services/conversation-assistant-actions.test.ts
+++ b/apps/server/src/services/conversation-assistant-actions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import { selectAssistantActions } from './conversation-assistant-actions';
+
+const citations = [
+  {
+    chatId: 'chat-noah',
+    chatName: 'Noah',
+    platform: 'whatsapp',
+    isGroup: false,
+    excerpt: 'Let’s meet for coffee next week.',
+  },
+  {
+    chatId: 'chat-maya',
+    chatName: 'Maya',
+    platform: 'instagram',
+    isGroup: false,
+    excerpt: 'The deck is ready for review.',
+  },
+];
+
+describe('conversation assistant actions', () => {
+  it('only opens a conversation represented by a selected source', () => {
+    expect(selectAssistantActions(citations, [
+      { type: 'open_conversation', sourceIndex: 2, label: 'Open Maya' },
+      { type: 'open_conversation', sourceIndex: 1, label: 'Open Noah' },
+    ], [1])).toEqual([{
+      type: 'open_conversation', label: 'Open Noah', chatId: 'chat-noah', chatName: 'Noah', platform: 'whatsapp', isGroup: false,
+    }]);
+  });
+
+  it('only offers calendar planning when the selected evidence indicates a meeting', () => {
+    expect(selectAssistantActions(citations, [
+      { type: 'open_calendar', sourceIndex: 1, label: 'Plan coffee', title: 'Coffee with Noah', startsAt: '2026-09-10T18:00:00.000Z' },
+      { type: 'open_calendar', sourceIndex: 2, label: 'Plan review', title: 'Review' },
+    ], [1, 2])).toEqual([{
+      type: 'open_calendar', label: 'Plan coffee', title: 'Coffee with Noah', startsAt: '2026-09-10T18:00:00.000Z',
+    }]);
+  });
+});

--- a/apps/server/src/services/conversation-assistant-actions.ts
+++ b/apps/server/src/services/conversation-assistant-actions.ts
@@ -1,0 +1,89 @@
+const MAX_ASSISTANT_ACTIONS = 2;
+const MEETING_LANGUAGE = /\b(meet|meeting|call|catch up|coffee|lunch|dinner|schedule|calendar|appointment)\b/i;
+
+export interface AssistantAction {
+  type: 'open_conversation' | 'open_calendar';
+  label: string;
+  chatId?: string;
+  chatName?: string | null;
+  platform?: string;
+  isGroup?: boolean;
+  title?: string;
+  startsAt?: string;
+}
+
+interface CitationForAction {
+  chatId: string;
+  chatName: string | null;
+  platform: string;
+  isGroup: boolean;
+  excerpt: string;
+}
+
+interface CompletionAction {
+  type?: unknown;
+  label?: unknown;
+  sourceIndex?: unknown;
+  title?: unknown;
+  startsAt?: unknown;
+}
+
+function shortText(value: unknown, fallback: string, maxLength: number): string {
+  return typeof value === 'string' && value.trim()
+    ? value.trim().replace(/\s+/g, ' ').slice(0, maxLength)
+    : fallback;
+}
+
+function sourceIndex(value: unknown, sourceCount: number): number | null {
+  return Number.isInteger(value) && typeof value === 'number' && value >= 1 && value <= sourceCount ? value - 1 : null;
+}
+
+function validDate(value: unknown): string | undefined {
+  if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) return undefined;
+  return new Date(value).toISOString();
+}
+
+/** Only expose actions that can be proven from a cited message. */
+export function selectAssistantActions<T extends CitationForAction>(
+  citations: T[],
+  rawActions: unknown,
+  allowedSourceIndices: unknown,
+): AssistantAction[] {
+  if (!Array.isArray(rawActions)) return [];
+  const allowed = new Set(
+    (Array.isArray(allowedSourceIndices) ? allowedSourceIndices : [])
+      .filter((value): value is number => Number.isInteger(value) && typeof value === 'number' && value >= 1 && value <= citations.length),
+  );
+  const actions: AssistantAction[] = [];
+
+  for (const rawAction of rawActions) {
+    if (!rawAction || typeof rawAction !== 'object' || actions.length >= MAX_ASSISTANT_ACTIONS) continue;
+    const action = rawAction as CompletionAction;
+    const index = sourceIndex(action.sourceIndex, citations.length);
+    if (index === null || !allowed.has(index + 1)) continue;
+    const citation = citations[index];
+
+    if (action.type === 'open_conversation') {
+      actions.push({
+        type: 'open_conversation',
+        label: shortText(action.label, 'Open conversation', 48),
+        chatId: citation.chatId,
+        chatName: citation.chatName,
+        platform: citation.platform,
+        isGroup: citation.isGroup,
+      });
+      continue;
+    }
+
+    if (action.type === 'open_calendar' && MEETING_LANGUAGE.test(citation.excerpt)) {
+      actions.push({
+        type: 'open_calendar',
+        label: shortText(action.label, 'Plan meeting', 48),
+        title: shortText(action.title, 'Meeting', 100),
+        startsAt: validDate(action.startsAt),
+      });
+    }
+  }
+
+  return actions;
+}

--- a/apps/server/src/services/conversation-assistant-citations.ts
+++ b/apps/server/src/services/conversation-assistant-citations.ts
@@ -1,0 +1,18 @@
+const MAX_CITED_SOURCES = 4;
+
+export function selectSourceIndices(sourceCount: number, sourceIndices: unknown): number[] {
+  const requested = Array.isArray(sourceIndices) ? sourceIndices : [];
+  return [...new Set(requested)]
+    .filter((index): index is number => Number.isInteger(index) && index >= 1 && index <= sourceCount)
+    .slice(0, MAX_CITED_SOURCES);
+}
+
+/**
+ * The search layer returns candidate evidence. Only show the subset that the
+ * answer actually relies on, rather than presenting a noisy retrieval tail.
+ */
+export function selectCitedSources<T>(citations: T[], sourceIndices: unknown): T[] {
+  const selected = selectSourceIndices(citations.length, sourceIndices).map((index) => citations[index - 1]);
+
+  return selected.length ? selected : citations.slice(0, Math.min(MAX_CITED_SOURCES, citations.length));
+}

--- a/apps/server/src/services/conversation-assistant-sources.test.ts
+++ b/apps/server/src/services/conversation-assistant-sources.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { selectCitedSources, selectSourceIndices } from './conversation-assistant-citations';
+
+const sources = Array.from({ length: 6 }, (_, index) => ({
+  messageId: `message-${index + 1}`,
+  chatId: 'chat-1',
+  excerpt: `Source ${index + 1}`,
+  senderName: 'Maya',
+  fromMe: false,
+  timestamp: '2026-09-07T00:00:00.000Z',
+  platform: 'whatsapp',
+  chatName: 'Maya',
+  isGroup: false,
+}));
+
+describe('conversation assistant sources', () => {
+  it('only returns the valid, material sources selected by the answer', () => {
+    expect(selectCitedSources(sources, [4, 2, 4, 9, 1])).toEqual([
+      sources[3], sources[1], sources[0],
+    ]);
+  });
+
+  it('caps visible citations and falls back safely when the model omits them', () => {
+    expect(selectCitedSources(sources, [])).toEqual(sources.slice(0, 4));
+    expect(selectCitedSources(sources, [1, 2, 3, 4, 5])).toEqual(sources.slice(0, 4));
+  });
+
+  it('keeps action evidence within the same four-source citation cap', () => {
+    expect(selectSourceIndices(sources.length, [1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/apps/server/src/services/conversation-assistant.ts
+++ b/apps/server/src/services/conversation-assistant.ts
@@ -3,6 +3,8 @@ import OpenAI from 'openai';
 import { openaiConfig } from '../config';
 import { logger } from '../utils/logger';
 import { supabase, type DbRow } from './supabase';
+import { selectAssistantActions, type AssistantAction } from './conversation-assistant-actions';
+import { selectCitedSources, selectSourceIndices } from './conversation-assistant-citations';
 
 const RETRIEVAL_LIMIT = 12;
 const BACKFILL_BATCH_SIZE = 100;
@@ -37,7 +39,14 @@ export interface AssistantIndexStatus {
 export interface AssistantAnswer {
   answer: string;
   citations: AssistantCitation[];
+  actions: AssistantAction[];
   indexing: AssistantIndexStatus;
+}
+
+interface AssistantCompletion {
+  answer?: unknown;
+  sourceIndices?: unknown;
+  actions?: unknown;
 }
 
 export interface AssistantThread {
@@ -114,7 +123,7 @@ class ConversationAssistantService {
       threadQuery.maybeSingle(),
       supabase
         .from('conversation_assistant_turns')
-        .select('id, role, content, citations, scope_chat_ids, created_at')
+        .select('id, role, content, citations, actions, scope_chat_ids, created_at')
         .eq('thread_id', threadId)
         .eq('user_id', userId)
         .order('created_at', { ascending: true }),
@@ -241,7 +250,7 @@ class ConversationAssistantService {
       messages: [
         {
           role: 'system',
-          content: 'You are Claire, a private conversation research assistant. Answer only from the supplied sources. Never claim to have read a message that is not quoted. Be concise, state uncertainty when sources are insufficient, and do not suggest that you will send or edit messages. Interpret clear everyday and colloquial equivalents (for example, "link up", "see you", or "hang out" can mean meeting), but say so when the wording is an interpretation rather than an exact quote. For relationship or communication questions, give a warm practical read grounded in the excerpts, clearly distinguish observation from inference, and suggest a constructive next step. Return JSON only: {"answer":"..."}.',
+          content: 'You are Claire, a private conversation research assistant. Answer only from the supplied sources. Never claim to have read a message that is not quoted. Be concise, state uncertainty when sources are insufficient, and do not suggest that you will send or edit messages. Interpret clear everyday and colloquial equivalents (for example, "link up", "see you", or "hang out" can mean meeting), but say so when the wording is an interpretation rather than an exact quote. For relationship or communication questions, give a warm practical read grounded in the excerpts, clearly distinguish observation from inference, and suggest a constructive next step. Return JSON only: {"answer":"...","sourceIndices":[1,2],"actions":[{"type":"open_conversation","sourceIndex":1,"label":"Open conversation"}]}. sourceIndices must contain the one to four source numbers that materially support the answer—never include a source just because it is related. Use actions sparingly: open_conversation only for a cited chat that helps the user continue; open_calendar only when a cited message clearly concerns arranging a meeting, call, or event, with a title and optional ISO startsAt. Actions never send, book, or edit anything. Keep every action sourceIndex in sourceIndices; otherwise return an empty actions array.',
         },
         {
           role: 'user',
@@ -251,9 +260,14 @@ class ConversationAssistantService {
     });
     const raw = completion.choices[0]?.message.content || '{}';
     let answer = 'I could not find enough relevant messages to answer that confidently.';
+    let answerCitations = selectCitedSources(citations, []);
+    let actions: AssistantAction[] = [];
     try {
-      const parsed = JSON.parse(raw) as { answer?: unknown };
+      const parsed = JSON.parse(raw) as AssistantCompletion;
       if (typeof parsed.answer === 'string' && parsed.answer.trim()) answer = parsed.answer.trim();
+      const sourceIndices = selectSourceIndices(citations.length, parsed.sourceIndices);
+      answerCitations = selectCitedSources(citations, sourceIndices);
+      actions = selectAssistantActions(citations, parsed.actions, sourceIndices);
     } catch {
       logger.warn('Assistant returned invalid JSON');
     }
@@ -262,7 +276,7 @@ class ConversationAssistantService {
     const { error: turnsError } = await supabase.from('conversation_assistant_turns').insert([
       // The column is deliberately NOT NULL so every persisted turn has a stable shape.
       { thread_id: thread.id, user_id: userId, role: 'user', content: cleanQuestion, citations: [], scope_chat_ids: preferredChatIds },
-      { thread_id: thread.id, user_id: userId, role: 'assistant', content: answer, citations, scope_chat_ids: preferredChatIds },
+      { thread_id: thread.id, user_id: userId, role: 'assistant', content: answer, citations: answerCitations, actions, scope_chat_ids: preferredChatIds },
     ]);
     if (turnsError) throw turnsError;
 
@@ -274,7 +288,7 @@ class ConversationAssistantService {
       .eq('user_id', userId);
     if (threadError) throw threadError;
 
-    return { answer, citations, indexing };
+    return { answer, citations: answerCitations, actions, indexing };
   }
 
   /** One-shot cited search answer. Unlike Ask Claire, this does not create or mutate a thread. */
@@ -287,7 +301,7 @@ class ConversationAssistantService {
       this.getIndexStatus(userId),
     ]);
     if (!citations.length) {
-      return { answer: 'I could not find a message that answers that confidently.', citations: [], indexing };
+      return { answer: 'I could not find a message that answers that confidently.', citations: [], actions: [], indexing };
     }
     const sources = citations.map((citation, index) =>
       `[${index + 1}] ${citation.timestamp} · ${citation.platform} · ${citation.fromMe ? 'You' : citation.senderName}: ${citation.excerpt}`
@@ -298,18 +312,23 @@ class ConversationAssistantService {
       temperature: 0.1,
       max_tokens: 450,
       messages: [
-        { role: 'system', content: 'Answer the search question only from the supplied conversation excerpts. Be concise, distinguish inference from exact wording, state uncertainty, and return JSON only: {"answer":"..."}.' },
+        { role: 'system', content: 'Answer the search question only from the supplied conversation excerpts. Be concise, distinguish inference from exact wording, state uncertainty, and return JSON only: {"answer":"...","sourceIndices":[1,2],"actions":[{"type":"open_conversation","sourceIndex":1,"label":"Open conversation"}]}. sourceIndices must contain the one to four source numbers that materially support the answer. Use actions sparingly: open_conversation only for a cited chat that helps the user continue; open_calendar only when a cited message clearly concerns arranging a meeting, call, or event, with a title and optional ISO startsAt. Actions never send, book, or edit anything. Keep every action sourceIndex in sourceIndices; otherwise return an empty actions array.' },
         { role: 'user', content: `Question: ${cleanQuestion}\n\nSources:\n${sources}` },
       ],
     });
     let answer = 'I found related messages, but could not summarize them confidently.';
+    let answerCitations = selectCitedSources(citations, []);
+    let actions: AssistantAction[] = [];
     try {
-      const parsed = JSON.parse(completion.choices[0]?.message.content || '{}') as { answer?: unknown };
+      const parsed = JSON.parse(completion.choices[0]?.message.content || '{}') as AssistantCompletion;
       if (typeof parsed.answer === 'string' && parsed.answer.trim()) answer = parsed.answer.trim();
+      const sourceIndices = selectSourceIndices(citations.length, parsed.sourceIndices);
+      answerCitations = selectCitedSources(citations, sourceIndices);
+      actions = selectAssistantActions(citations, parsed.actions, sourceIndices);
     } catch {
       logger.warn('Search answer returned invalid JSON');
     }
-    return { answer, citations, indexing };
+    return { answer, citations: answerCitations, actions, indexing };
   }
 
   private async runBackfill(userId: string): Promise<void> {

--- a/apps/server/src/services/schema-verification.ts
+++ b/apps/server/src/services/schema-verification.ts
@@ -40,7 +40,7 @@ export const REQUIRED_SCHEMA: SchemaRequirement[] = [
   { table: 'contact_profiles', columns: ['key_facts'] },
   { table: 'smart_cards', columns: ['dismissed'] },
   { table: 'conversation_assistant_threads', columns: ['user_id', 'chat_id', 'updated_at'] },
-  { table: 'conversation_assistant_turns', columns: ['thread_id', 'scope_chat_ids', 'citations'] },
+  { table: 'conversation_assistant_turns', columns: ['thread_id', 'scope_chat_ids', 'citations', 'actions'] },
   { table: 'platform_interest_requests', columns: ['user_id', 'platform_id', 'source'] },
 ];
 

--- a/supabase/migrations/20260907140000_add_conversation_assistant_actions.sql
+++ b/supabase/migrations/20260907140000_add_conversation_assistant_actions.sql
@@ -1,0 +1,5 @@
+-- Suggested actions are user-triggered navigation aids, never automated sends or bookings.
+ALTER TABLE public.conversation_assistant_turns
+  ADD COLUMN IF NOT EXISTS actions JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- redesign Ask Claire source cards with aligned carousel padding, platform icons, and clearer hierarchy
- return only the citations Claire actually used and cap visible sources
- add evidence-backed response actions for opening conversations and planning meetings
- persist assistant actions and verify the required schema
- include the current client test error-context artifact

## Validation
- `bun test apps/server/src/services/conversation-assistant-sources.test.ts apps/server/src/services/conversation-assistant-actions.test.ts`
- `bun run typecheck:server`
- `bun run typecheck:mobile`
- focused ESLint for changed client/server files
- native iOS Simulator visual QA for collapsed and expanded source cards