### PR TITLE
fix(server): link outbound messages to their contact

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,6 +42,7 @@ import { voiceProfileService } from './services/voice-profile-service';
 import {
   displayNameFromBridge,
   incomingContactId,
+  messageContactId,
   phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
   resolveMentions,
@@ -515,7 +516,7 @@ async function initializePlatforms() {
           },
           { onConflict: 'user_id,platform,platform_chat_id' }
         )
-        .select('id, name, is_group, ai_enabled, member_count')
+        .select('id, name, is_group, ai_enabled, member_count, contact_id')
         .single();
 
       if (chatError || !chat) {
@@ -581,6 +582,24 @@ async function initializePlatforms() {
       if (contactId && message.chatType === 'individual') {
         await supabase.from('chats').update({ contact_id: contactId }).eq('id', chat.id);
       }
+
+      // An outbound message has no remote sender, so incomingContactId returns
+      // null for it and `contact_id` was left empty on every row the account
+      // owner sent. That silently broke the People "Contacted" filter, which
+      // counts exactly those rows: contacts.outbound_message_count is
+      // maintained from `from_me = TRUE AND contact_id IS NOT NULL`, so the
+      // counter never left zero and the filter could never return anyone.
+      //
+      // In a 1:1 the counterpart is unambiguous -- it is the chat's own linked
+      // contact. A group has no single counterpart, and "contacted" is defined
+      // as direct messages only (routes/contacts.ts filters is_group = false),
+      // so groups stay null on purpose.
+      const linkedContactId = messageContactId({
+        senderContactId: contactId,
+        isFromMe: message.isFromMe,
+        isGroup: message.chatType === 'group',
+        chatContactId: (chat as { contact_id?: string | null }).contact_id,
+      });
       if (message.chatType === 'individual' && !chatDisplayName) {
         // Outgoing messages do not have a remote sender to upsert above, and
         // some bridges only learn the profile name during contact sync. Reuse
@@ -643,7 +662,7 @@ async function initializePlatforms() {
             content_type: message.contentType,
             timestamp: message.timestamp,
             is_group: message.chatType === 'group',
-            contact_id: contactId,
+            contact_id: linkedContactId,
             contact_name: message.isFromMe
               ? null
               : displayNameFromBridge(message.senderName, message.platform, senderContactId),

--- a/apps/server/src/services/contact-identity.test.ts
+++ b/apps/server/src/services/contact-identity.test.ts
@@ -8,6 +8,7 @@ import {
   isRedactedPhoneFallback,
   phoneNumberFromBridgeIdentifiers,
   phoneNumberFromPlatformContactId,
+  messageContactId,
 } from './contact-identity';
 import { directoryInsertPayload, whatsappContactKeys } from './whatsapp-contact-backfill';
 
@@ -100,5 +101,34 @@ describe('WhatsApp directory identity matching', () => {
 
   test('does not persist a directory entry that has only an opaque LID', () => {
     expect(directoryInsertPayload('user-1', { id: 'lid-192204836479059' })).toBeNull();
+  });
+});
+
+describe('messageContactId', () => {
+  const base = { senderContactId: null, isFromMe: false, isGroup: false, chatContactId: 'chat-contact' };
+
+  test('links an outbound direct message to the chat contact', () => {
+    // The regression this guards: outbound rows used to store null, which kept
+    // contacts.outbound_message_count at zero and made the People "Contacted"
+    // filter permanently empty.
+    expect(messageContactId({ ...base, isFromMe: true })).toBe('chat-contact');
+  });
+
+  test('prefers the resolved sender for an incoming message', () => {
+    expect(messageContactId({ ...base, senderContactId: 'sender' })).toBe('sender');
+  });
+
+  test('leaves an outbound group message unlinked', () => {
+    // A group has no single counterpart, and "contacted" means direct only.
+    expect(messageContactId({ ...base, isFromMe: true, isGroup: true })).toBeNull();
+  });
+
+  test('leaves an incoming message with no resolvable sender unlinked', () => {
+    expect(messageContactId({ ...base, chatContactId: 'chat-contact' })).toBeNull();
+  });
+
+  test('handles a chat that has no contact linked yet', () => {
+    expect(messageContactId({ ...base, isFromMe: true, chatContactId: null })).toBeNull();
+    expect(messageContactId({ ...base, isFromMe: true, chatContactId: undefined })).toBeNull();
   });
 });

--- a/apps/server/src/services/contact-identity.ts
+++ b/apps/server/src/services/contact-identity.ts
@@ -108,6 +108,28 @@ export function incomingContactId(message: Pick<UnifiedMessage, 'platform' | 'is
 }
 
 /**
+ * Which contact a stored message belongs to.
+ *
+ * An incoming message resolves its own sender. An outbound one has no remote
+ * sender -- incomingContactId returns null for it -- so it takes the chat's
+ * linked contact instead. That linkage is what the People "Contacted" filter
+ * counts, and leaving it null meant the filter could never return anyone.
+ *
+ * A group has no single counterpart and "contacted" means direct messages
+ * only, so groups deliberately stay unlinked.
+ */
+export function messageContactId(input: {
+  senderContactId: string | null;
+  isFromMe: boolean;
+  isGroup: boolean;
+  chatContactId: string | null | undefined;
+}): string | null {
+  if (input.senderContactId) return input.senderContactId;
+  if (!input.isFromMe || input.isGroup) return null;
+  return input.chatContactId ?? null;
+}
+
+/**
  * Ghost MXID → platform contact id. Kept in one place so adding a bridge does
  * not require finding every copy of this regex.
  */

--- a/supabase/migrations/20260912000001_backfill_outbound_contact_links.sql
+++ b/supabase/migrations/20260912000001_backfill_outbound_contact_links.sql
@@ -1,0 +1,38 @@
+-- Repair the People "Contacted" filter.
+--
+-- `contacts.outbound_message_count` is maintained from messages where
+-- `from_me = TRUE AND contact_id IS NOT NULL` (20260820000004). But ingest only
+-- ever resolved a contact for the *incoming* sender, so every row the account
+-- owner sent carried contact_id = NULL. The counter therefore never left zero
+-- and the filter could not return anyone: measured on production, 3,780
+-- outbound messages, none of them linked.
+--
+-- Ingest now links an outbound 1:1 message to the chat's own contact. This
+-- repairs the rows already stored.
+
+-- In a 1:1 the counterpart is unambiguous: the chat's linked contact. Groups
+-- are excluded on purpose -- "contacted" is defined as direct messages only.
+UPDATE public.messages AS m
+SET contact_id = c.contact_id
+FROM public.chats AS c
+WHERE m.chat_id = c.id
+  AND m.user_id = c.user_id
+  AND m.from_me = TRUE
+  AND m.contact_id IS NULL
+  AND c.is_group = FALSE
+  AND c.contact_id IS NOT NULL;
+
+-- Recompute with the same aggregate the trigger keeps live, so the stored
+-- counter and the trigger's arithmetic agree from here on.
+UPDATE public.contacts AS contact
+SET outbound_message_count = source.count
+FROM (
+  SELECT contact_id, COUNT(*)::INTEGER AS count
+  FROM public.messages
+  WHERE from_me = TRUE AND contact_id IS NOT NULL
+  GROUP BY contact_id
+) AS source
+WHERE contact.id = source.contact_id
+  AND contact.outbound_message_count IS DISTINCT FROM source.count;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Problem

The People **Contacted** filter could never return anyone.

`contacts.outbound_message_count` is maintained from messages where `from_me = TRUE AND contact_id IS NOT NULL` (added in `20260820000004`). But `incomingContactId` returns `null` for an outbound message by design — it resolves the *remote sender*, and an outbound message has none. So every row the account owner sent stored `contact_id = NULL`, the trigger never fired, and the counter never left zero.

Measured against production:

```
outbound_msgs=3780  outbound_with_contact_id=0  inbound_with_contact_id=13871
contacts.max(outbound_message_count)=0  contacts_with_nonzero=0   (of 21,721 contacts)
```

This has been broken since the filter shipped. It is not a regression from the recent deploy — `20260820000004` had simply never been applied to production until 2026-09-12, which is how it surfaced.

## Fix

An outbound 1:1 message now links to the chat's own contact, which is the unambiguous counterpart. Groups stay unlinked deliberately: "contacted" means direct messages only, and `routes/contacts.ts` already filters `is_group = false`.

The resolution lives in a pure `messageContactId` helper in `contact-identity.ts` — beside the other identity helpers, where it is covered by tests rather than buried in the ingest handler.

A migration repairs the rows already stored and recomputes the counter with the same aggregate the trigger keeps live, so stored values and trigger arithmetic agree from here on.

## Verification

- `bunx tsc --noEmit` clean
- `bun test` — 630 pass / 0 fail (up from 625; five new cases in `contact-identity.test.ts`)
- Covers: outbound 1:1 links to the chat contact, incoming prefers its resolved sender, outbound group stays unlinked, incoming with no resolvable sender stays unlinked, and a chat with no contact linked yet

After the migration runs, `SELECT count(*) FROM contacts WHERE outbound_message_count > 0` should be non-zero and the Contacted chip should list people you have actually messaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)