### PR TITLE
fix(demo): keep group participants on their own platform

### DIFF
--- a/apps/server/src/demo/fixtures.test.ts
+++ b/apps/server/src/demo/fixtures.test.ts
@@ -113,6 +113,21 @@ describe('demo script integrity', () => {
     }
   });
 
+  it('never puts a persona in a room on another platform', () => {
+    // A persona's contact identity is minted from the *chat's* platform, so a
+    // participant from a different platform silently creates a second contact
+    // for the same person — a duplicate in the People screen with no avatar.
+    for (const chat of DEMO_CHATS) {
+      for (const key of chat.participants) {
+        const persona = DEMO_PERSONAS_BY_KEY[key];
+        expect(
+          persona.platform,
+          `${chat.key} is a ${chat.platform} chat but ${key} is on ${persona.platform}`
+        ).toBe(chat.platform);
+      }
+    }
+  });
+
   it('has a distinct platform identifier per persona', () => {
     const ids = DEMO_PERSONAS.map((persona) => `${persona.platform}:${persona.platformContactId}`);
     expect(new Set(ids).size).toBe(ids.length);

--- a/apps/server/src/demo/personas.ts
+++ b/apps/server/src/demo/personas.ts
@@ -324,6 +324,26 @@ export const DEMO_PERSONAS: DemoPersona[] = [
     },
   },
   {
+    key: 'tunde',
+    displayName: 'Tunde Bakare',
+    platform: Platform.WHATSAPP,
+    platformContactId: '15550194402',
+    phoneNumber: '+1 555 019 4402',
+    avatarUrl: avatar('tunde-bakare'),
+    sheet: {
+      relationship:
+        'Friend from the Saturday football group, and the one member who actually turns up every week.',
+      voice:
+        'Short and dry. Lowercase, no punctuation to speak of, one line at a time. Deadpan rather than jokey — he lands a comment and leaves it there. No emoji.',
+      topics: ['football', 'who is dropping out this week', 'the pitch'],
+      openThreads: [
+        'He has confirmed for Saturday 9am at Red Hook.',
+        'He finds the missing-bibs saga funnier than he lets on.',
+      ],
+      replyStyle: { words: [2, 12], emoji: 'none', splitChance: 0.2, replyChance: 0.85 },
+    },
+  },
+  {
     key: 'sofia',
     displayName: 'Sofia Almeida',
     platform: Platform.TELEGRAM,
@@ -584,19 +604,19 @@ export const DEMO_CHATS: DemoChat[] = [
     platformChatId: 'demo-group-redhook@g.us',
     name: 'Red Hook Saturday ⚽️',
     isGroup: true,
-    participants: ['rahim', 'amara', 'marcus'],
+    participants: ['rahim', 'amara', 'tunde'],
     groupContext:
-      'A Saturday 5-a-side group. Rahim books the pitch and chases people. Chaotic, affectionate, lots of dropouts. Amara is in the group from when she lived in New York and still comments occasionally.',
+      'A Saturday 5-a-side group. Rahim books the pitch and chases people. Chaotic, affectionate, lots of dropouts. Amara is in the group from when she lived in New York and still comments occasionally. Tunde is the reliable one.',
     script: [
       { from: 'rahim', text: 'pitch is booked. saturday 9am red hook, same as always', daysAgo: 5, at: '18:30' },
       { from: 'rahim', text: 'need a firm yes from everyone by thursday or i give the slot back', daysAgo: 5, at: '18:30' },
       { from: 'me', text: 'In', daysAgo: 5, at: '18:44' },
-      { from: 'marcus', text: 'I am in as well.', daysAgo: 5, at: '19:20' },
+      { from: 'tunde', text: 'in', daysAgo: 5, at: '19:20' },
       { from: 'rahim', text: 'that is 4. we need one more', daysAgo: 4, at: '11:02' },
       { from: 'amara', text: 'i will be in new york actually but i am not playing football at 9am, i will watch and judge', daysAgo: 4, at: '11:40' },
       { from: 'rahim', text: 'unhelpful but accepted 😂', daysAgo: 4, at: '11:44' },
       { from: 'rahim', text: 'also somebody needs to bring the bibs. mine are in the boot of a car i no longer own', daysAgo: 4, at: '11:45' },
-      { from: 'marcus', text: 'How does that happen', daysAgo: 4, at: '12:10' },
+      { from: 'tunde', text: 'how does that even happen', daysAgo: 4, at: '12:10' },
       { from: 'rahim', text: 'long story', daysAgo: 4, at: '12:11' },
       { from: 'rahim', text: 'BIBS. someone. anyone', daysAgo: 2, at: '20:15' },
       { from: 'me', text: 'I can grab bibs', daysAgo: 2, at: '21:30' },
@@ -699,6 +719,7 @@ export const DEMO_FALLBACK_REPLIES: Record<string, string[]> = {
   nina: ['omg one sec!! 💛', 'ahh ok let me check my calendar', 'yesss hold on'],
   marcus: ['Let me check and come back to you.', 'Understood, thanks.'],
   rahim: ['one sec', 'ok say no more', 'lol hold on'],
+  tunde: ['in', 'yeah alright', 'say less'],
   sofia: [
     'Thanks — let me try that and I will report back 🙂',
     'Noted, I will test it properly and follow up.',

--- a/apps/server/src/services/demo-responder.test.ts
+++ b/apps/server/src/services/demo-responder.test.ts
@@ -91,9 +91,9 @@ describe('chooseResponder', () => {
   it('otherwise answers as whoever spoke last', () => {
     const history: HistoryLine[] = [
       { fromMe: false, senderName: 'Rahim Osei', content: 'bibs?' },
-      { fromMe: false, senderName: 'Marcus Bell', content: 'I can bring them.' },
+      { fromMe: false, senderName: 'Tunde Bakare', content: 'i can bring them' },
     ];
-    expect(chooseResponder(footballChat, 'thanks', history)?.key).toBe('marcus');
+    expect(chooseResponder(footballChat, 'thanks', history)?.key).toBe('tunde');
   });
 
   it('ignores the account owner when looking for the last speaker', () => {


### PR DESCRIPTION
Follow-up to #221, found by seeding the demo account on production.

## The bug

Seeding produced **two contacts named Marcus Bell**: the correct Instagram one,
and a WhatsApp one carrying his Instagram id with no avatar.

A persona's contact identity is minted from the *chat's* platform, since that is
the ghost MXID ingestion reads. Marcus is an Instagram persona but I had put him
in the WhatsApp football group, so his messages there minted
`@whatsapp_17841338820917:…` and ingestion created a second person for him.

Chats rendered correctly, which is why it surfaced only as a duplicate in the
People screen — visible on camera, which is the whole point of this account.

## The fix

Replaces him in that group with **Tunde Bakare**, a WhatsApp persona, and adds a
fixture test asserting every group participant is on their chat's platform, so
the same class of mistake fails CI rather than showing up in a recording.

700 server tests pass, lint and typecheck clean.

Needs a `--reset` reseed after deploy to clear the stray contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)